### PR TITLE
config: increase parallelism and disable draft PRs

### DIFF
--- a/cadre.config.json
+++ b/cadre.config.json
@@ -19,14 +19,14 @@
   },
   "pullRequest": {
     "autoCreate": true,
-    "draft": true,
+    "draft": false,
     "labels": ["cadre-generated"],
     "reviewers": [],
     "linkIssue": true
   },
   "options": {
-    "maxParallelIssues": 3,
-    "maxParallelAgents": 2,
+    "maxParallelIssues": 8,
+    "maxParallelAgents": 4,
     "maxRetriesPerTask": 3,
     "tokenBudget": 500000,
     "perIssueTokenBudget": 100000,


### PR DESCRIPTION
- `maxParallelIssues`: 3 → 8
- `maxParallelAgents`: 2 → 4
- `pullRequest.draft`: true → false