### PR TITLE
config: use relative repoPath instead of absolute

### DIFF
--- a/cadre.config.json
+++ b/cadre.config.json
@@ -2,7 +2,7 @@
   "projectName": "cadre",
   "platform": "github",
   "repository": "jafreck/CADRE",
-  "repoPath": "/Users/jacobfreck/Source/cadre",
+  "repoPath": ".",
   "baseBranch": "main",
   "issues": {
     "query": {


### PR DESCRIPTION
Replace the machine-specific absolute path `"/Users/jacobfreck/Source/cadre"` with `"."` so the config is portable across checkout locations.

The loader already supports this — `src/config/loader.ts` lines 62–64 resolve relative paths against `process.cwd()`:
```ts
const resolvedRepoPath = isAbsolute(config.repoPath)
  ? config.repoPath
  : resolve(process.cwd(), config.repoPath);
```