### PR TITLE
refactor: group PhaseContext into services/io/callbacks sub-objects

### DIFF
--- a/src/agents/context-builder.ts
+++ b/src/agents/context-builder.ts
@@ -223,11 +223,12 @@ export class ContextBuilder {
   async buildForFixSurgeon(
     issueNumber: number,
     worktreePath: string,
-    task: ImplementationTask,
+    taskId: string,
     feedbackPath: string,
     changedFiles: string[],
     progressDir: string,
     issueType: 'review' | 'test-failure' | 'build',
+    phase: 3 | 4,
   ): Promise<string> {
     return this.writeContext(progressDir, 'fix-surgeon', issueNumber, {
       agent: 'fix-surgeon',
@@ -235,13 +236,13 @@ export class ContextBuilder {
       projectName: this.config.projectName,
       repository: this.config.repository,
       worktreePath,
-      phase: 3,
-      taskId: task.id,
+      phase,
+      taskId,
       config: { commands: this.config.commands },
       inputFiles: [feedbackPath, ...changedFiles],
       outputPath: join(worktreePath, '.cadre', 'tasks'), // scratch artifacts stay in .cadre/
       payload: {
-        taskId: task.id,
+        taskId,
         issueType,
       },
     });

--- a/src/core/fleet-orchestrator.ts
+++ b/src/core/fleet-orchestrator.ts
@@ -202,6 +202,7 @@ export class FleetOrchestrator {
         this.launcher,
         this.platform,
         this.logger.child(issue.number, join(this.cadreDir, 'logs')),
+        this.notifications,
       );
 
       // 6. Run the 5-phase pipeline
@@ -353,11 +354,13 @@ export class FleetOrchestrator {
       };
     });
 
-    const prRefs: PullRequestRef[] = result.prsCreated.map((pr) => ({
-      issueNumber: 0, // We'd need to track this mapping
-      prNumber: pr.number,
-      url: pr.url,
-    }));
+    const prRefs: PullRequestRef[] = result.issues
+      .filter((ir) => ir.pr != null)
+      .map((ir) => ({
+        issueNumber: ir.issueNumber,
+        prNumber: ir.pr!.number,
+        url: ir.pr!.url,
+      }));
 
     await this.fleetProgress.write(issueInfos, prRefs, {
       current: this.tokenTracker.getTotal(),

--- a/src/core/issue-orchestrator.ts
+++ b/src/core/issue-orchestrator.ts
@@ -1,11 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { CadreConfig } from '../config/schema.js';
-import type {
-  AgentInvocation,
-  AgentResult,
-  PhaseResult,
-} from '../agents/types.js';
+import type { PhaseResult } from '../agents/types.js';
 import type { IssueDetail, PullRequestInfo, PlatformProvider } from '../platform/provider.js';
 import type { WorktreeInfo } from '../git/worktree.js';
 import { CheckpointManager } from './checkpoint.js';
@@ -55,6 +51,14 @@ export interface IssueResult {
   budgetExceeded?: boolean;
 }
 
+/** Stateless gates — constructed once and reused across all runGate() calls. */
+const GATE_MAP: Record<number, PhaseGate> = {
+  1: new AnalysisToPlanningGate(),
+  2: new PlanningToImplementationGate(),
+  3: new ImplementationToIntegrationGate(),
+  4: new IntegrationToPRGate(),
+};
+
 /**
  * Runs the 5-phase pipeline for a single issue within its worktree.
  */
@@ -66,8 +70,9 @@ export class IssueOrchestrator {
   private readonly retryExecutor: RetryExecutor;
   private readonly progressWriter: IssueProgressWriter;
   private readonly tokenTracker: TokenTracker;
-  private readonly notifier: IssueNotifier;
+  private readonly notificationManager: NotificationManager;
   private readonly registry: PhaseRegistry;
+  private ctx!: PhaseContext;
   private readonly phases: PhaseResult[] = [];
   private budgetExceeded = false;
   private budgetWarningSent = false;
@@ -81,7 +86,7 @@ export class IssueOrchestrator {
     private readonly launcher: AgentLauncher,
     private readonly platform: PlatformProvider,
     private readonly logger: Logger,
-    private readonly notificationManager?: NotificationManager,
+    notificationManager?: NotificationManager,
   ) {
     this.progressDir = join(
       worktree.path,
@@ -104,7 +109,15 @@ export class IssueOrchestrator {
       logger,
     );
     this.tokenTracker = new TokenTracker();
-    this.notifier = new IssueNotifier(config, platform, logger);
+
+    // Ensure we always have a NotificationManager so dispatch calls are unconditional.
+    this.notificationManager = notificationManager ?? new NotificationManager();
+
+    // Register IssueNotifier as a provider so issue comments go through the
+    // unified dispatch channel alongside webhooks / Slack / log providers.
+    const notifier = new IssueNotifier(config, platform, logger);
+    this.notificationManager.addProvider(notifier);
+
     this.registry = new PhaseRegistry();
     this.registry.register(new AnalysisPhaseExecutor());
     this.registry.register(new PlanningPhaseExecutor());
@@ -120,15 +133,40 @@ export class IssueOrchestrator {
     const startTime = Date.now();
     const resumePoint = this.checkpoint.getResumePoint();
 
+    this.ctx = {
+      issue: this.issue,
+      worktree: this.worktree,
+      config: this.config,
+      platform: this.platform,
+      services: {
+        launcher: this.launcher,
+        retryExecutor: this.retryExecutor,
+        tokenTracker: this.tokenTracker,
+        contextBuilder: this.contextBuilder,
+        resultParser: this.resultParser,
+        logger: this.logger,
+      },
+      io: {
+        progressDir: this.progressDir,
+        progressWriter: this.progressWriter,
+        checkpoint: this.checkpoint,
+        commitManager: this.commitManager,
+      },
+      callbacks: {
+        recordTokens: (agent, tokens) => this.recordTokens(agent, tokens),
+        checkBudget: () => this.checkBudget(),
+        updateProgress: () => this.updateProgress(),
+      },
+    };
+
     this.logger.info(`Starting pipeline for issue #${this.issue.number}: ${this.issue.title}`, {
       issueNumber: this.issue.number,
       data: { resumeFrom: resumePoint },
     });
 
     await this.progressWriter.appendEvent(`Pipeline started (resume from phase ${resumePoint.phase})`);
-    void this.notifier.notifyStart(this.issue.number, this.issue.title);
 
-    await this.notificationManager?.dispatch({
+    await this.notificationManager.dispatch({
       type: 'issue-started',
       issueNumber: this.issue.number,
       issueTitle: this.issue.title,
@@ -176,7 +214,13 @@ export class IssueOrchestrator {
             { issueNumber: this.issue.number },
           );
           await this.progressWriter.appendEvent('Pipeline aborted: token budget exceeded');
-          void this.notifier.notifyFailed(this.issue.number, this.issue.title, undefined, undefined, 'Per-issue token budget exceeded');
+          await this.notificationManager.dispatch({
+            type: 'issue-failed',
+            issueNumber: this.issue.number,
+            issueTitle: this.issue.title,
+            error: 'Per-issue token budget exceeded',
+            phase: cpState.currentPhase,
+          });
           return this.buildResult(false, 'Per-issue token budget exceeded', startTime, true);
         }
         throw err;
@@ -193,7 +237,11 @@ export class IssueOrchestrator {
             this.logger.warn(`Ambiguity in issue #${this.issue.number}: ${a}`, { issueNumber: this.issue.number });
           }
           if (ambiguities.length > 0) {
-            void this.notifier.notifyAmbiguities(this.issue.number, ambiguities);
+            await this.notificationManager.dispatch({
+              type: 'ambiguity-detected',
+              issueNumber: this.issue.number,
+              ambiguities,
+            });
           }
           if (
             this.config.options.haltOnAmbiguity &&
@@ -248,19 +296,26 @@ export class IssueOrchestrator {
         }
 
         await this.updateProgress();
-        void this.notifier.notifyPhaseComplete(this.issue.number, executor.phaseId, executor.name, phaseResult.duration);
+        await this.notificationManager.dispatch({
+          type: 'phase-completed',
+          issueNumber: this.issue.number,
+          phase: executor.phaseId,
+          phaseName: executor.name,
+          duration: phaseResult.duration,
+        });
       } else if (phaseDef.critical) {
         this.logger.error(`Critical phase ${executor.phaseId} failed, aborting pipeline`, {
           issueNumber: this.issue.number,
           phase: executor.phaseId,
         });
         await this.progressWriter.appendEvent(`Pipeline aborted: phase ${executor.phaseId} failed`);
-        void this.notifier.notifyFailed(this.issue.number, this.issue.title, { id: executor.phaseId, name: executor.name }, undefined, phaseResult.error);
-        await this.notificationManager?.dispatch({
+        await this.notificationManager.dispatch({
           type: 'issue-failed',
           issueNumber: this.issue.number,
+          issueTitle: this.issue.title,
           error: phaseResult.error ?? `Phase ${executor.phaseId} failed`,
           phase: executor.phaseId,
+          phaseName: executor.name,
         });
         return this.buildResult(false, phaseResult.error, startTime);
       }
@@ -268,10 +323,10 @@ export class IssueOrchestrator {
 
     await this.progressWriter.appendEvent('Pipeline completed successfully');
     const successResult = this.buildResult(true, undefined, startTime);
-    void this.notifier.notifyComplete(this.issue.number, this.issue.title, undefined, successResult.tokenUsage ?? 0);
-    await this.notificationManager?.dispatch({
+    await this.notificationManager.dispatch({
       type: 'issue-completed',
       issueNumber: successResult.issueNumber,
+      issueTitle: successResult.issueTitle,
       success: successResult.success,
       duration: successResult.totalDuration,
       tokenUsage: successResult.tokenUsage ?? 0,
@@ -293,26 +348,7 @@ export class IssueOrchestrator {
     });
 
     try {
-      const ctx: PhaseContext = {
-        issue: this.issue,
-        worktree: this.worktree,
-        config: this.config,
-        progressDir: this.progressDir,
-        contextBuilder: this.contextBuilder,
-        launcher: this.launcher,
-        resultParser: this.resultParser,
-        checkpoint: this.checkpoint,
-        commitManager: this.commitManager,
-        retryExecutor: this.retryExecutor,
-        tokenTracker: this.tokenTracker,
-        progressWriter: this.progressWriter,
-        platform: this.platform,
-        recordTokens: (agent, tokens) => this.recordTokens(agent, tokens),
-        checkBudget: () => this.checkBudget(),
-        logger: this.logger,
-      };
-
-      const outputPath = await executor.execute(ctx);
+      const outputPath = await executor.execute(this.ctx);
 
       const duration = Date.now() - phaseStart;
       await this.progressWriter.appendEvent(`Phase ${executor.phaseId} completed in ${duration}ms`);
@@ -345,49 +381,6 @@ export class IssueOrchestrator {
 
   // ── Helper Methods ──
 
-  private async launchWithRetry(
-    agentName: string,
-    invocation: Omit<AgentInvocation, 'timeout'>,
-  ): Promise<AgentResult> {
-    const result = await this.retryExecutor.execute<AgentResult>({
-      fn: async () => {
-        this.checkBudget();
-        const agentResult = await this.launcher.launchAgent(
-          invocation as AgentInvocation,
-          this.worktree.path,
-        );
-        this.recordTokens(agentName, agentResult.tokenUsage);
-        this.checkBudget();
-        if (!agentResult.success) {
-          throw new Error(agentResult.error ?? `Agent ${agentName} failed`);
-        }
-        return agentResult;
-      },
-      maxAttempts: this.config.options.maxRetriesPerTask,
-      description: agentName,
-    });
-
-    this.checkBudget();
-
-    if (!result.success || !result.result) {
-      return {
-        agent: invocation.agent,
-        success: false,
-        exitCode: 1,
-        timedOut: false,
-        duration: 0,
-        stdout: '',
-        stderr: result.error ?? 'Unknown failure',
-        tokenUsage: null,
-        outputPath: invocation.outputPath,
-        outputExists: false,
-        error: result.error,
-      };
-    }
-
-    return result.result;
-  }
-
   private recordTokens(agent: string, tokens: number | null): void {
     if (tokens != null && tokens > 0) {
       this.tokenTracker.record(
@@ -414,11 +407,16 @@ export class IssueOrchestrator {
       this.tokenTracker.checkIssueBudget(this.issue.number, this.config.options.tokenBudget) === 'warning'
     ) {
       this.budgetWarningSent = true;
-      void this.notifier.notifyBudgetWarning(
-        this.issue.number,
-        this.tokenTracker.getTotal() ?? 0,
-        this.config.options.tokenBudget ?? 0,
-      );
+      const currentUsage = this.tokenTracker.getTotal() ?? 0;
+      const budget = this.config.options.tokenBudget ?? 0;
+      void this.notificationManager.dispatch({
+        type: 'budget-warning',
+        scope: 'issue',
+        issueNumber: this.issue.number,
+        currentUsage,
+        budget,
+        percentUsed: budget > 0 ? Math.round((currentUsage / budget) * 100) : 0,
+      });
     }
   }
 
@@ -430,15 +428,9 @@ export class IssueOrchestrator {
     try {
       const isClean = await this.commitManager.isClean();
       if (!isClean) {
-        const type = phase.id <= 2 ? 'chore' : phase.id === 3 ? 'feat' : 'fix';
-        const message =
-          phase.id === 1
-            ? `analyze issue #${this.issue.number}`
-            : phase.id === 2
-              ? `plan implementation for #${this.issue.number}`
-              : phase.id === 4
-                ? `address integration issues`
-                : `phase ${phase.id} complete`;
+        const type = phase.commitType ?? 'chore';
+        const message = (phase.commitMessage ?? `phase ${phase.id} complete`)
+          .replace('{issueNumber}', String(this.issue.number));
 
         await this.commitManager.commit(message, this.issue.number, type);
       }
@@ -471,14 +463,7 @@ export class IssueOrchestrator {
   }
 
   private async runGate(phaseId: number): Promise<'pass' | 'warn' | 'fail'> {
-    const gateMap: Record<number, PhaseGate> = {
-      1: new AnalysisToPlanningGate(),
-      2: new PlanningToImplementationGate(),
-      3: new ImplementationToIntegrationGate(),
-      4: new IntegrationToPRGate(),
-    };
-
-    const gate = gateMap[phaseId];
+    const gate = GATE_MAP[phaseId];
     if (!gate) return 'pass';
 
     const context: GateContext = {

--- a/src/core/phase-executor.ts
+++ b/src/core/phase-executor.ts
@@ -11,6 +11,31 @@ import type { RetryExecutor } from '../execution/retry.js';
 import type { TokenTracker } from '../budget/token-tracker.js';
 import type { Logger } from '../logging/logger.js';
 
+/** Cross-cutting services used by every phase. */
+export type PhaseServices = {
+  launcher: AgentLauncher;
+  retryExecutor: RetryExecutor;
+  tokenTracker: TokenTracker;
+  contextBuilder: ContextBuilder;
+  resultParser: ResultParser;
+  logger: Logger;
+};
+
+/** I/O and persistence dependencies. */
+export type PhaseIO = {
+  progressDir: string;
+  progressWriter: IssueProgressWriter;
+  checkpoint: CheckpointManager;
+  commitManager: CommitManager;
+};
+
+/** Callbacks injected by the orchestrator. */
+export type PhaseCallbacks = {
+  recordTokens: (agent: string, tokens: number | null) => void;
+  checkBudget: () => void;
+  updateProgress: () => Promise<void>;
+};
+
 /**
  * All dependencies and shared state needed by a phase during execution.
  */
@@ -18,19 +43,10 @@ export type PhaseContext = {
   issue: IssueDetail;
   worktree: WorktreeInfo;
   config: CadreConfig;
-  progressDir: string;
-  contextBuilder: ContextBuilder;
-  launcher: AgentLauncher;
-  resultParser: ResultParser;
-  checkpoint: CheckpointManager;
-  commitManager: CommitManager;
-  retryExecutor: RetryExecutor;
-  tokenTracker: TokenTracker;
-  progressWriter: IssueProgressWriter;
   platform: PlatformProvider;
-  recordTokens: (agent: string, tokens: number | null) => void;
-  checkBudget: () => void;
-  logger: Logger;
+  services: PhaseServices;
+  io: PhaseIO;
+  callbacks: PhaseCallbacks;
 };
 
 /**

--- a/src/core/phase-registry.ts
+++ b/src/core/phase-registry.ts
@@ -11,14 +11,18 @@ export interface PhaseDefinition {
   name: string;
   /** Whether failure in this phase should abort the issue pipeline. */
   critical: boolean;
+  /** Commit type for per-phase commits (e.g. 'chore', 'feat', 'fix'). */
+  commitType?: string;
+  /** Commit message template. Use `{issueNumber}` as a placeholder. */
+  commitMessage?: string;
 }
 
 export const ISSUE_PHASES: PhaseDefinition[] = [
-  { id: 1, name: 'Analysis & Scouting', critical: true },
-  { id: 2, name: 'Planning', critical: true },
-  { id: 3, name: 'Implementation', critical: true },
-  { id: 4, name: 'Integration Verification', critical: false },
-  { id: 5, name: 'PR Composition', critical: false },
+  { id: 1, name: 'Analysis & Scouting', critical: true, commitType: 'chore', commitMessage: 'analyze issue #{issueNumber}' },
+  { id: 2, name: 'Planning', critical: true, commitType: 'chore', commitMessage: 'plan implementation for #{issueNumber}' },
+  { id: 3, name: 'Implementation', critical: true, commitType: 'feat', commitMessage: 'implement changes for #{issueNumber}' },
+  { id: 4, name: 'Integration Verification', critical: false, commitType: 'fix', commitMessage: 'address integration issues' },
+  { id: 5, name: 'PR Composition', critical: false, commitType: 'chore', commitMessage: 'compose PR for #{issueNumber}' },
 ];
 
 /**

--- a/src/executors/analysis-phase-executor.ts
+++ b/src/executors/analysis-phase-executor.ts
@@ -1,42 +1,43 @@
 import { join } from 'node:path';
 import { writeFile } from 'node:fs/promises';
 import type { PhaseExecutor, PhaseContext } from '../core/phase-executor.js';
-import type { AgentInvocation, AgentResult } from '../agents/types.js';
+import { launchWithRetry } from './helpers.js';
 import { atomicWriteJSON, ensureDir, listFilesRecursive } from '../util/fs.js';
 import { execShell } from '../util/process.js';
+import { extractFailures } from '../util/failure-parser.js';
 
 export class AnalysisPhaseExecutor implements PhaseExecutor {
   readonly phaseId = 1;
   readonly name = 'Analysis & Scouting';
 
   async execute(ctx: PhaseContext): Promise<string> {
-    await ensureDir(ctx.progressDir);
+    await ensureDir(ctx.io.progressDir);
 
     // Write issue JSON
-    const issueJsonPath = join(ctx.progressDir, 'issue.json');
+    const issueJsonPath = join(ctx.io.progressDir, 'issue.json');
     await atomicWriteJSON(issueJsonPath, ctx.issue);
 
     // Generate file tree
-    const fileTreePath = join(ctx.progressDir, 'repo-file-tree.txt');
+    const fileTreePath = join(ctx.io.progressDir, 'repo-file-tree.txt');
     const files = await listFilesRecursive(ctx.worktree.path);
     const fileTree = files.filter((f) => !f.startsWith('.cadre/')).join('\n');
     await writeFile(fileTreePath, fileTree, 'utf-8');
 
     // Build context for issue-analyst
-    const analystContextPath = await ctx.contextBuilder.buildForIssueAnalyst(
+    const analystContextPath = await ctx.services.contextBuilder.buildForIssueAnalyst(
       ctx.issue.number,
       ctx.worktree.path,
       issueJsonPath,
-      ctx.progressDir,
+      ctx.io.progressDir,
     );
 
     // Launch issue-analyst
-    const analystResult = await this.launchWithRetry(ctx, 'issue-analyst', {
+    const analystResult = await launchWithRetry(ctx, 'issue-analyst', {
       agent: 'issue-analyst',
       issueNumber: ctx.issue.number,
       phase: 1,
       contextPath: analystContextPath,
-      outputPath: join(ctx.progressDir, 'analysis.md'),
+      outputPath: join(ctx.io.progressDir, 'analysis.md'),
     });
 
     if (!analystResult.success) {
@@ -44,21 +45,21 @@ export class AnalysisPhaseExecutor implements PhaseExecutor {
     }
 
     // Build context for codebase-scout (needs analysis.md)
-    const scoutContextPath = await ctx.contextBuilder.buildForCodebaseScout(
+    const scoutContextPath = await ctx.services.contextBuilder.buildForCodebaseScout(
       ctx.issue.number,
       ctx.worktree.path,
-      join(ctx.progressDir, 'analysis.md'),
+      join(ctx.io.progressDir, 'analysis.md'),
       fileTreePath,
-      ctx.progressDir,
+      ctx.io.progressDir,
     );
 
     // Launch codebase-scout
-    const scoutResult = await this.launchWithRetry(ctx, 'codebase-scout', {
+    const scoutResult = await launchWithRetry(ctx, 'codebase-scout', {
       agent: 'codebase-scout',
       issueNumber: ctx.issue.number,
       phase: 1,
       contextPath: scoutContextPath,
-      outputPath: join(ctx.progressDir, 'scout-report.md'),
+      outputPath: join(ctx.io.progressDir, 'scout-report.md'),
     });
 
     if (!scoutResult.success) {
@@ -68,7 +69,7 @@ export class AnalysisPhaseExecutor implements PhaseExecutor {
     // Capture baseline build/test results
     await this.captureBaseline(ctx);
 
-    return join(ctx.progressDir, 'scout-report.md');
+    return join(ctx.io.progressDir, 'scout-report.md');
   }
 
   private async captureBaseline(ctx: PhaseContext): Promise<void> {
@@ -87,7 +88,7 @@ export class AnalysisPhaseExecutor implements PhaseExecutor {
         });
         buildExitCode = result.exitCode ?? 1;
         if (buildExitCode !== 0) {
-          buildFailures = this.extractFailures(result.stdout + '\n' + result.stderr);
+          buildFailures = extractFailures(result.stdout + '\n' + result.stderr);
         }
       }
 
@@ -98,11 +99,11 @@ export class AnalysisPhaseExecutor implements PhaseExecutor {
         });
         testExitCode = result.exitCode ?? 1;
         if (testExitCode !== 0) {
-          testFailures = this.extractFailures(result.stdout + '\n' + result.stderr);
+          testFailures = extractFailures(result.stdout + '\n' + result.stderr);
         }
       }
     } catch (err) {
-      ctx.logger.warn(`Baseline capture encountered an error: ${String(err)}`);
+      ctx.services.logger.warn(`Baseline capture encountered an error: ${String(err)}`);
     }
 
     await atomicWriteJSON(baselinePath, {
@@ -111,67 +112,5 @@ export class AnalysisPhaseExecutor implements PhaseExecutor {
       buildFailures,
       testFailures,
     });
-  }
-
-  /**
-   * Extract failing test/build identifiers from command output using line-based heuristics.
-   */
-  private extractFailures(output: string): string[] {
-    const failures = new Set<string>();
-    for (const line of output.split('\n')) {
-      const trimmed = line.trim();
-      // Common failure patterns: lines containing FAIL, ✗, ×, error:, Error:
-      if (/^(FAIL|FAILED|✗|×)\s+/.test(trimmed)) {
-        const match = trimmed.match(/^(?:FAIL|FAILED|✗|×)\s+(.+)/);
-        if (match) failures.add(match[1].trim());
-      } else if (/^\s*(error|Error)\s*:/i.test(trimmed) && trimmed.length < 200) {
-        failures.add(trimmed);
-      }
-    }
-    return Array.from(failures);
-  }
-
-  private async launchWithRetry(
-    ctx: PhaseContext,
-    agentName: string,
-    invocation: Omit<AgentInvocation, 'timeout'>,
-  ): Promise<AgentResult> {
-    const result = await ctx.retryExecutor.execute<AgentResult>({
-      fn: async () => {
-        ctx.checkBudget();
-        const agentResult = await ctx.launcher.launchAgent(
-          invocation as AgentInvocation,
-          ctx.worktree.path,
-        );
-        ctx.recordTokens(agentName, agentResult.tokenUsage);
-        ctx.checkBudget();
-        if (!agentResult.success) {
-          throw new Error(agentResult.error ?? `Agent ${agentName} failed`);
-        }
-        return agentResult;
-      },
-      maxAttempts: ctx.config.options.maxRetriesPerTask,
-      description: agentName,
-    });
-
-    ctx.checkBudget();
-
-    if (!result.success || !result.result) {
-      return {
-        agent: invocation.agent,
-        success: false,
-        exitCode: 1,
-        timedOut: false,
-        duration: 0,
-        stdout: '',
-        stderr: result.error ?? 'Unknown failure',
-        tokenUsage: null,
-        outputPath: invocation.outputPath,
-        outputExists: false,
-        error: result.error,
-      };
-    }
-
-    return result.result;
   }
 }

--- a/src/executors/helpers.ts
+++ b/src/executors/helpers.ts
@@ -1,0 +1,50 @@
+import type { PhaseContext } from '../core/phase-executor.js';
+import type { AgentInvocation, AgentResult } from '../agents/types.js';
+
+/**
+ * Launch an agent with retry logic, budget checks, and token recording.
+ * Shared by all phase executors.
+ */
+export async function launchWithRetry(
+  ctx: PhaseContext,
+  agentName: string,
+  invocation: Omit<AgentInvocation, 'timeout'>,
+): Promise<AgentResult> {
+  const result = await ctx.services.retryExecutor.execute<AgentResult>({
+    fn: async () => {
+      ctx.callbacks.checkBudget();
+      const agentResult = await ctx.services.launcher.launchAgent(
+        invocation as AgentInvocation,
+        ctx.worktree.path,
+      );
+      ctx.callbacks.recordTokens(agentName, agentResult.tokenUsage);
+      ctx.callbacks.checkBudget();
+      if (!agentResult.success) {
+        throw new Error(agentResult.error ?? `Agent ${agentName} failed`);
+      }
+      return agentResult;
+    },
+    maxAttempts: ctx.config.options.maxRetriesPerTask,
+    description: agentName,
+  });
+
+  ctx.callbacks.checkBudget();
+
+  if (!result.success || !result.result) {
+    return {
+      agent: invocation.agent,
+      success: false,
+      exitCode: 1,
+      timedOut: false,
+      duration: 0,
+      stdout: '',
+      stderr: result.error ?? 'Unknown failure',
+      tokenUsage: null,
+      outputPath: invocation.outputPath,
+      outputExists: false,
+      error: result.error,
+    };
+  }
+
+  return result.result;
+}

--- a/src/logging/events.ts
+++ b/src/logging/events.ts
@@ -50,8 +50,10 @@ export interface IssueStartedEvent {
 export interface IssueCompletedEvent {
   type: 'issue-completed';
   issueNumber: number;
+  issueTitle: string;
   success: boolean;
   prNumber?: number;
+  prUrl?: string;
   duration: number;
   tokenUsage: number;
 }
@@ -59,8 +61,11 @@ export interface IssueCompletedEvent {
 export interface IssueFailedEvent {
   type: 'issue-failed';
   issueNumber: number;
+  issueTitle: string;
   error: string;
   phase: number;
+  phaseName?: string;
+  failedTask?: string;
 }
 
 // ── Phase-level events ──
@@ -173,6 +178,12 @@ export interface PRCreatedEvent {
 
 // ── Budget events ──
 
+export interface AmbiguityDetectedEvent {
+  type: 'ambiguity-detected';
+  issueNumber: number;
+  ambiguities: string[];
+}
+
 export interface BudgetWarningEvent {
   type: 'budget-warning';
   scope: 'fleet' | 'issue';
@@ -210,5 +221,6 @@ export type CadreEvent =
   | GitCommitEvent
   | GitPushEvent
   | PRCreatedEvent
+  | AmbiguityDetectedEvent
   | BudgetWarningEvent
   | BudgetExceededEvent;

--- a/src/notifications/manager.ts
+++ b/src/notifications/manager.ts
@@ -7,7 +7,7 @@ import { LogProvider } from './log-provider.js';
 
 export class NotificationManager {
   private readonly providers: NotificationProvider[];
-  private readonly enabled: boolean;
+  private enabled: boolean;
 
   constructor(config?: NotificationsConfig) {
     if (!config || !config.enabled) {
@@ -27,6 +27,15 @@ export class NotificationManager {
           return new LogProvider({ logFile: p.logFile, events: p.events });
       }
     });
+  }
+
+  /**
+   * Register an additional notification provider at runtime.
+   * Automatically enables dispatching if it was previously disabled.
+   */
+  addProvider(provider: NotificationProvider): void {
+    this.providers.push(provider);
+    this.enabled = true;
   }
 
   async dispatch(event: CadreEvent): Promise<void> {

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -8,6 +8,8 @@ import type {
   IssueFailedEvent,
   BudgetWarningEvent,
   BudgetExceededEvent,
+  PhaseCompletedEvent,
+  AmbiguityDetectedEvent,
 } from '../logging/events.js';
 
 export type { CadreEvent };
@@ -19,6 +21,8 @@ export type NotificationEvent =
   | IssueStartedEvent
   | IssueCompletedEvent
   | IssueFailedEvent
+  | PhaseCompletedEvent
+  | AmbiguityDetectedEvent
   | BudgetWarningEvent
   | BudgetExceededEvent;
 

--- a/src/util/failure-parser.ts
+++ b/src/util/failure-parser.ts
@@ -1,0 +1,35 @@
+/**
+ * Extracts failing test/build identifiers from command output using line-based heuristics.
+ *
+ * Patterns matched:
+ * - Lines starting with FAIL, FAILED, ✗, or × (test runners)
+ * - TypeScript compiler errors (`error TS\d+:`)
+ * - Generic `error:` / `Error:` lines (under 200 chars)
+ */
+export function extractFailures(
+  output: string,
+  options?: { includeTypeScriptErrors?: boolean },
+): string[] {
+  const includeTS = options?.includeTypeScriptErrors ?? true;
+  const failures = new Set<string>();
+
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim();
+
+    // Common test failure indicators – strip the prefix
+    if (/^(FAIL|FAILED|✗|×)\s+/.test(trimmed)) {
+      const match = trimmed.match(/^(?:FAIL|FAILED|✗|×)\s+(.+)/);
+      if (match) failures.add(match[1].trim());
+    }
+    // TypeScript / build error lines (no prefix to strip)
+    else if (includeTS && /error TS\d+:/.test(trimmed)) {
+      failures.add(trimmed);
+    }
+    // Generic error lines
+    else if (/^\s*(error|Error)\s*:/i.test(trimmed) && trimmed.length < 200) {
+      failures.add(trimmed);
+    }
+  }
+
+  return Array.from(failures);
+}

--- a/tests/context-builder.test.ts
+++ b/tests/context-builder.test.ts
@@ -301,7 +301,7 @@ describe('ContextBuilder', () => {
     });
 
     it('should NOT include outputSchema for fix-surgeon', async () => {
-      await builder.buildForFixSurgeon(42, '/tmp/worktree', task, '/tmp/feedback.md', [], '/tmp/progress', 'review');
+      await builder.buildForFixSurgeon(42, '/tmp/worktree', task.id, '/tmp/feedback.md', [], '/tmp/progress', 'review', 3);
       const ctx = captureWrittenContext();
       expect(ctx.outputSchema).toBeUndefined();
     });

--- a/tests/issue-notifier.test.ts
+++ b/tests/issue-notifier.test.ts
@@ -3,6 +3,7 @@ import { IssueNotifier } from '../src/core/issue-notifier.js';
 import type { CadreConfig } from '../src/config/schema.js';
 import type { PlatformProvider } from '../src/platform/provider.js';
 import type { Logger } from '../src/logging/logger.js';
+import type { CadreEvent } from '../src/logging/events.js';
 
 function makeMockLogger(): Logger {
   return {
@@ -301,6 +302,131 @@ describe('IssueNotifier', () => {
       const notifier = new IssueNotifier(makeConfig(), platform, logger);
       await expect(notifier.notifyBudgetWarning(1, 5000, 10000)).resolves.toBeUndefined();
       expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('notify() – NotificationProvider adapter', () => {
+    it('should dispatch issue-started to notifyStart', async () => {
+      const notifier = new IssueNotifier(makeConfig(), platform, logger);
+      await notifier.notify({ type: 'issue-started', issueNumber: 7, issueTitle: 'My Issue', worktreePath: '/tmp' });
+      expect(platform.addIssueComment).toHaveBeenCalledOnce();
+      const [issueNum, body] = (platform.addIssueComment as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(issueNum).toBe(7);
+      expect(body).toContain('My Issue');
+    });
+
+    it('should dispatch phase-completed to notifyPhaseComplete', async () => {
+      const notifier = new IssueNotifier(makeConfig(), platform, logger);
+      await notifier.notify({ type: 'phase-completed', issueNumber: 5, phase: 2, phaseName: 'Planning', duration: 3500 });
+      expect(platform.addIssueComment).toHaveBeenCalledOnce();
+      const [issueNum, body] = (platform.addIssueComment as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(issueNum).toBe(5);
+      expect(body).toContain('Phase 2');
+      expect(body).toContain('Planning');
+    });
+
+    it('should dispatch issue-completed to notifyComplete', async () => {
+      const notifier = new IssueNotifier(makeConfig(), platform, logger);
+      await notifier.notify({
+        type: 'issue-completed',
+        issueNumber: 10,
+        issueTitle: 'Feature X',
+        success: true,
+        duration: 5000,
+        tokenUsage: 1234,
+        prUrl: 'https://github.com/owner/repo/pull/99',
+      });
+      expect(platform.addIssueComment).toHaveBeenCalledOnce();
+      const [issueNum, body] = (platform.addIssueComment as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(issueNum).toBe(10);
+      expect(body).toContain('Feature X');
+      expect(body).toContain('https://github.com/owner/repo/pull/99');
+    });
+
+    it('should dispatch issue-failed to notifyFailed with phase info', async () => {
+      const notifier = new IssueNotifier(makeConfig(), platform, logger);
+      await notifier.notify({
+        type: 'issue-failed',
+        issueNumber: 3,
+        issueTitle: 'Broken',
+        error: 'crash',
+        phase: 2,
+        phaseName: 'Planning',
+      });
+      expect(platform.addIssueComment).toHaveBeenCalledOnce();
+      const [, body] = (platform.addIssueComment as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(body).toContain('Phase 2');
+      expect(body).toContain('Planning');
+      expect(body).toContain('crash');
+    });
+
+    it('should dispatch issue-failed without phase info when phaseName is absent', async () => {
+      const notifier = new IssueNotifier(makeConfig(), platform, logger);
+      await notifier.notify({
+        type: 'issue-failed',
+        issueNumber: 3,
+        issueTitle: 'Broken',
+        error: 'budget exceeded',
+        phase: 1,
+      });
+      expect(platform.addIssueComment).toHaveBeenCalledOnce();
+      const [, body] = (platform.addIssueComment as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(body).toContain('budget exceeded');
+      expect(body).not.toContain('Phase 1');
+    });
+
+    it('should dispatch budget-warning with scope=issue to notifyBudgetWarning', async () => {
+      const notifier = new IssueNotifier(makeConfig(), platform, logger);
+      await notifier.notify({
+        type: 'budget-warning',
+        scope: 'issue',
+        issueNumber: 7,
+        currentUsage: 8000,
+        budget: 10000,
+        percentUsed: 80,
+      });
+      expect(platform.addIssueComment).toHaveBeenCalledOnce();
+      const [issueNum, body] = (platform.addIssueComment as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(issueNum).toBe(7);
+      expect(body).toContain('80%');
+    });
+
+    it('should ignore budget-warning with scope=fleet', async () => {
+      const notifier = new IssueNotifier(makeConfig(), platform, logger);
+      await notifier.notify({
+        type: 'budget-warning',
+        scope: 'fleet',
+        currentUsage: 8000,
+        budget: 10000,
+        percentUsed: 80,
+      });
+      expect(platform.addIssueComment).not.toHaveBeenCalled();
+    });
+
+    it('should dispatch ambiguity-detected to notifyAmbiguities', async () => {
+      const notifier = new IssueNotifier(makeConfig(), platform, logger);
+      await notifier.notify({
+        type: 'ambiguity-detected',
+        issueNumber: 12,
+        ambiguities: ['Ambiguity one', 'Ambiguity two'],
+      });
+      expect(platform.addIssueComment).toHaveBeenCalledOnce();
+      const [issueNum, body] = (platform.addIssueComment as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(issueNum).toBe(12);
+      expect(body).toContain('Ambiguity one');
+      expect(body).toContain('Ambiguity two');
+    });
+
+    it('should silently ignore unknown event types', async () => {
+      const notifier = new IssueNotifier(makeConfig(), platform, logger);
+      await notifier.notify({ type: 'fleet-started', issueCount: 2, maxParallel: 1 } as CadreEvent);
+      expect(platform.addIssueComment).not.toHaveBeenCalled();
+    });
+
+    it('should respect enabled=false for dispatched events', async () => {
+      const notifier = new IssueNotifier(makeConfig({ enabled: false }), platform, logger);
+      await notifier.notify({ type: 'issue-started', issueNumber: 1, issueTitle: 'X', worktreePath: '/tmp' });
+      expect(platform.addIssueComment).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/issue-orchestrator-ambiguity.test.ts
+++ b/tests/issue-orchestrator-ambiguity.test.ts
@@ -27,14 +27,20 @@ const {
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
 vi.mock('../src/core/issue-notifier.js', () => ({
-  IssueNotifier: vi.fn().mockImplementation(() => ({
-    notifyStart: vi.fn().mockResolvedValue(undefined),
-    notifyPhaseComplete: vi.fn().mockResolvedValue(undefined),
-    notifyComplete: vi.fn().mockResolvedValue(undefined),
-    notifyFailed: vi.fn().mockResolvedValue(undefined),
-    notifyBudgetWarning: vi.fn().mockResolvedValue(undefined),
-    notifyAmbiguities: mockNotifyAmbiguities,
-  })),
+  IssueNotifier: vi.fn().mockImplementation(() => {
+    const methods = {
+      notifyStart: vi.fn().mockResolvedValue(undefined),
+      notifyPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      notifyComplete: vi.fn().mockResolvedValue(undefined),
+      notifyFailed: vi.fn().mockResolvedValue(undefined),
+      notifyBudgetWarning: vi.fn().mockResolvedValue(undefined),
+      notifyAmbiguities: mockNotifyAmbiguities,
+      notify: vi.fn().mockImplementation(async (event: any) => {
+        if (event.type === 'ambiguity-detected') return mockNotifyAmbiguities(event.issueNumber, event.ambiguities);
+      }),
+    };
+    return methods;
+  }),
 }));
 
 vi.mock('../src/core/phase-gate.js', () => ({

--- a/tests/issue-orchestrator-gates.test.ts
+++ b/tests/issue-orchestrator-gates.test.ts
@@ -78,14 +78,20 @@ const {
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
 vi.mock('../src/core/issue-notifier.js', () => ({
-  IssueNotifier: vi.fn().mockImplementation(() => ({
-    notifyStart: vi.fn().mockResolvedValue(undefined),
-    notifyPhaseComplete: vi.fn().mockResolvedValue(undefined),
-    notifyComplete: vi.fn().mockResolvedValue(undefined),
-    notifyFailed: vi.fn().mockResolvedValue(undefined),
-    notifyBudgetWarning: vi.fn().mockResolvedValue(undefined),
-    notifyAmbiguities: mockNotifyAmbiguities,
-  })),
+  IssueNotifier: vi.fn().mockImplementation(() => {
+    const methods = {
+      notifyStart: vi.fn().mockResolvedValue(undefined),
+      notifyPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      notifyComplete: vi.fn().mockResolvedValue(undefined),
+      notifyFailed: vi.fn().mockResolvedValue(undefined),
+      notifyBudgetWarning: vi.fn().mockResolvedValue(undefined),
+      notifyAmbiguities: mockNotifyAmbiguities,
+      notify: vi.fn().mockImplementation(async (event: any) => {
+        if (event.type === 'ambiguity-detected') return mockNotifyAmbiguities(event.issueNumber, event.ambiguities);
+      }),
+    };
+    return methods;
+  }),
 }));
 
 vi.mock('../src/core/phase-gate.js', () => ({

--- a/tests/issue-orchestrator-registry.test.ts
+++ b/tests/issue-orchestrator-registry.test.ts
@@ -417,12 +417,13 @@ describe('IssueOrchestrator – PhaseRegistry dispatch (task-008)', () => {
       expect(ctx.issue).toBe(issue);
       expect(ctx.config).toBe(config);
       expect(ctx.worktree).toBe(worktree);
-      expect(typeof ctx.recordTokens).toBe('function');
-      expect(typeof ctx.checkBudget).toBe('function');
-      expect(ctx.logger).toBeDefined();
-      expect(ctx.launcher).toBeDefined();
-      expect(ctx.checkpoint).toBeDefined();
-      expect(ctx.progressDir).toContain(String(issue.number));
+      expect(typeof ctx.callbacks.recordTokens).toBe('function');
+      expect(typeof ctx.callbacks.checkBudget).toBe('function');
+      expect(typeof ctx.callbacks.updateProgress).toBe('function');
+      expect(ctx.services.logger).toBeDefined();
+      expect(ctx.services.launcher).toBeDefined();
+      expect(ctx.io.checkpoint).toBeDefined();
+      expect(ctx.io.progressDir).toContain(String(issue.number));
     });
   });
 

--- a/tests/issue-orchestrator.test.ts
+++ b/tests/issue-orchestrator.test.ts
@@ -19,6 +19,37 @@ const mockNotifierMethods = {
   notifyComplete: vi.fn().mockResolvedValue(undefined),
   notifyFailed: vi.fn().mockResolvedValue(undefined),
   notifyBudgetWarning: vi.fn().mockResolvedValue(undefined),
+  notifyAmbiguities: vi.fn().mockResolvedValue(undefined),
+  notify: vi.fn().mockImplementation(async (event: { type: string }) => {
+    // The real IssueNotifier.notify() dispatches to inner methods;
+    // we replicate that routing here so assertions on the specific
+    // methods still pass while the orchestrator goes through dispatch.
+    switch (event.type) {
+      case 'issue-started':
+        return mockNotifierMethods.notifyStart((event as any).issueNumber, (event as any).issueTitle);
+      case 'phase-completed':
+        return mockNotifierMethods.notifyPhaseComplete((event as any).issueNumber, (event as any).phase, (event as any).phaseName, (event as any).duration);
+      case 'issue-completed':
+        return mockNotifierMethods.notifyComplete((event as any).issueNumber, (event as any).issueTitle, (event as any).prUrl, (event as any).tokenUsage);
+      case 'issue-failed':
+        return mockNotifierMethods.notifyFailed(
+          (event as any).issueNumber,
+          (event as any).issueTitle,
+          (event as any).phaseName ? { id: (event as any).phase, name: (event as any).phaseName } : undefined,
+          (event as any).failedTask,
+          (event as any).error,
+        );
+      case 'budget-warning':
+        if ((event as any).scope === 'issue' && (event as any).issueNumber != null) {
+          return mockNotifierMethods.notifyBudgetWarning((event as any).issueNumber, (event as any).currentUsage, (event as any).budget);
+        }
+        return;
+      case 'ambiguity-detected':
+        return mockNotifierMethods.notifyAmbiguities((event as any).issueNumber, (event as any).ambiguities);
+      default:
+        return;
+    }
+  }),
 };
 
 vi.mock('../src/core/issue-notifier.js', () => ({
@@ -269,7 +300,7 @@ describe('IssueOrchestrator – notification dispatch', () => {
     it('should dispatch issue-started when notificationManager is provided', async () => {
       const checkpoint = makeCheckpointMock();
       const dispatch = vi.fn().mockResolvedValue(undefined);
-      const nm = { dispatch } as unknown as NotificationManager;
+      const nm = { dispatch, addProvider: vi.fn() } as unknown as NotificationManager;
 
       const orchestrator = new IssueOrchestrator(
         config,
@@ -292,7 +323,7 @@ describe('IssueOrchestrator – notification dispatch', () => {
     it('should dispatch issue-completed on successful pipeline', async () => {
       const checkpoint = makeCheckpointMock();
       const dispatch = vi.fn().mockResolvedValue(undefined);
-      const nm = { dispatch } as unknown as NotificationManager;
+      const nm = { dispatch, addProvider: vi.fn() } as unknown as NotificationManager;
 
       const orchestrator = new IssueOrchestrator(
         config,
@@ -316,7 +347,7 @@ describe('IssueOrchestrator – notification dispatch', () => {
     it('should include duration and tokenUsage in issue-completed event', async () => {
       const checkpoint = makeCheckpointMock();
       const dispatch = vi.fn().mockResolvedValue(undefined);
-      const nm = { dispatch } as unknown as NotificationManager;
+      const nm = { dispatch, addProvider: vi.fn() } as unknown as NotificationManager;
 
       const orchestrator = new IssueOrchestrator(
         config,
@@ -387,7 +418,7 @@ describe('IssueOrchestrator – notification dispatch', () => {
       });
       vi.mocked(fsUtils.ensureDir).mockRejectedValueOnce(new Error('simulated phase failure'));
       const dispatch = vi.fn().mockResolvedValue(undefined);
-      const nm = { dispatch } as unknown as NotificationManager;
+      const nm = { dispatch, addProvider: vi.fn() } as unknown as NotificationManager;
 
       const orchestrator = new IssueOrchestrator(
         config,
@@ -414,7 +445,7 @@ describe('IssueOrchestrator – notification dispatch', () => {
       });
       vi.mocked(fsUtils.ensureDir).mockRejectedValueOnce(new Error('phase 1 error'));
       const dispatch = vi.fn().mockResolvedValue(undefined);
-      const nm = { dispatch } as unknown as NotificationManager;
+      const nm = { dispatch, addProvider: vi.fn() } as unknown as NotificationManager;
 
       const orchestrator = new IssueOrchestrator(
         config,
@@ -462,7 +493,7 @@ describe('IssueOrchestrator – notification dispatch', () => {
       });
       vi.mocked(fsUtils.ensureDir).mockRejectedValueOnce(new Error('phase 1 error'));
       const dispatch = vi.fn().mockResolvedValue(undefined);
-      const nm = { dispatch } as unknown as NotificationManager;
+      const nm = { dispatch, addProvider: vi.fn() } as unknown as NotificationManager;
 
       const orchestrator = new IssueOrchestrator(
         config,
@@ -492,7 +523,7 @@ describe('IssueOrchestrator – notification dispatch', () => {
         callOrder.push(event.type);
         return Promise.resolve(undefined);
       });
-      const nm = { dispatch } as unknown as NotificationManager;
+      const nm = { dispatch, addProvider: vi.fn() } as unknown as NotificationManager;
 
       const orchestrator = new IssueOrchestrator(
         config,
@@ -530,6 +561,35 @@ describe('IssueOrchestrator notifier integration', () => {
     mockNotifierMethods.notifyComplete.mockResolvedValue(undefined);
     mockNotifierMethods.notifyFailed.mockResolvedValue(undefined);
     mockNotifierMethods.notifyBudgetWarning.mockResolvedValue(undefined);
+    mockNotifierMethods.notifyAmbiguities.mockResolvedValue(undefined);
+    // Re-apply notify routing after clearAllMocks
+    mockNotifierMethods.notify.mockImplementation(async (event: { type: string }) => {
+      switch (event.type) {
+        case 'issue-started':
+          return mockNotifierMethods.notifyStart((event as any).issueNumber, (event as any).issueTitle);
+        case 'phase-completed':
+          return mockNotifierMethods.notifyPhaseComplete((event as any).issueNumber, (event as any).phase, (event as any).phaseName, (event as any).duration);
+        case 'issue-completed':
+          return mockNotifierMethods.notifyComplete((event as any).issueNumber, (event as any).issueTitle, (event as any).prUrl, (event as any).tokenUsage);
+        case 'issue-failed':
+          return mockNotifierMethods.notifyFailed(
+            (event as any).issueNumber,
+            (event as any).issueTitle,
+            (event as any).phaseName ? { id: (event as any).phase, name: (event as any).phaseName } : undefined,
+            (event as any).failedTask,
+            (event as any).error,
+          );
+        case 'budget-warning':
+          if ((event as any).scope === 'issue' && (event as any).issueNumber != null) {
+            return mockNotifierMethods.notifyBudgetWarning((event as any).issueNumber, (event as any).currentUsage, (event as any).budget);
+          }
+          return;
+        case 'ambiguity-detected':
+          return mockNotifierMethods.notifyAmbiguities((event as any).issueNumber, (event as any).ambiguities);
+        default:
+          return;
+      }
+    });
     tempDir = join(tmpdir(), `cadre-notif-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     worktreePath = join(tempDir, 'worktree');
     await mkdir(worktreePath, { recursive: true });

--- a/tests/notification-types.test.ts
+++ b/tests/notification-types.test.ts
@@ -76,12 +76,12 @@ describe('NotificationEvent type union', () => {
   });
 
   it('should accept issue-completed event', () => {
-    const event: NotificationEvent = { type: 'issue-completed', issueNumber: 42, success: true, prNumber: 99, duration: 120, tokenUsage: 5000 };
+    const event: NotificationEvent = { type: 'issue-completed', issueNumber: 42, issueTitle: 'Fix bug', success: true, prNumber: 99, duration: 120, tokenUsage: 5000 };
     expect(event.type).toBe('issue-completed');
   });
 
   it('should accept issue-failed event', () => {
-    const event: NotificationEvent = { type: 'issue-failed', issueNumber: 42, error: 'timeout', phase: 2 };
+    const event: NotificationEvent = { type: 'issue-failed', issueNumber: 42, issueTitle: 'Fix bug', error: 'timeout', phase: 2 };
     expect(event.type).toBe('issue-failed');
   });
 

--- a/tests/phase-executor.test.ts
+++ b/tests/phase-executor.test.ts
@@ -68,25 +68,32 @@ describe('PhaseContext', () => {
       },
       worktree: { path: '/tmp/worktree', branch: 'cadre/issue-42', baseCommit: 'abc123', issueNumber: 42 } as never,
       config: {} as never,
-      progressDir: '/tmp/progress',
-      contextBuilder: {} as never,
-      launcher: {} as never,
-      resultParser: {} as never,
-      checkpoint: {} as never,
-      commitManager: {} as never,
-      retryExecutor: {} as never,
-      tokenTracker: {} as never,
-      progressWriter: {} as never,
       platform: {} as never,
-      recordTokens: vi.fn(),
-      checkBudget: vi.fn(),
-      logger: {} as never,
+      services: {
+        launcher: {} as never,
+        retryExecutor: {} as never,
+        tokenTracker: {} as never,
+        contextBuilder: {} as never,
+        resultParser: {} as never,
+        logger: {} as never,
+      },
+      io: {
+        progressDir: '/tmp/progress',
+        progressWriter: {} as never,
+        checkpoint: {} as never,
+        commitManager: {} as never,
+      },
+      callbacks: {
+        recordTokens: vi.fn(),
+        checkBudget: vi.fn(),
+        updateProgress: vi.fn().mockResolvedValue(undefined),
+      },
     };
 
-    expect(ctx.progressDir).toBe('/tmp/progress');
+    expect(ctx.io.progressDir).toBe('/tmp/progress');
     expect(ctx.issue.number).toBe(42);
-    expect(typeof ctx.recordTokens).toBe('function');
-    expect(typeof ctx.checkBudget).toBe('function');
+    expect(typeof ctx.callbacks.recordTokens).toBe('function');
+    expect(typeof ctx.callbacks.checkBudget).toBe('function');
   });
 
   it('recordTokens should accept agent name and nullable token count', () => {
@@ -95,23 +102,30 @@ describe('PhaseContext', () => {
       issue: {} as never,
       worktree: {} as never,
       config: {} as never,
-      progressDir: '',
-      contextBuilder: {} as never,
-      launcher: {} as never,
-      resultParser: {} as never,
-      checkpoint: {} as never,
-      commitManager: {} as never,
-      retryExecutor: {} as never,
-      tokenTracker: {} as never,
-      progressWriter: {} as never,
       platform: {} as never,
-      recordTokens,
-      checkBudget: vi.fn(),
-      logger: {} as never,
+      services: {
+        launcher: {} as never,
+        retryExecutor: {} as never,
+        tokenTracker: {} as never,
+        contextBuilder: {} as never,
+        resultParser: {} as never,
+        logger: {} as never,
+      },
+      io: {
+        progressDir: '',
+        progressWriter: {} as never,
+        checkpoint: {} as never,
+        commitManager: {} as never,
+      },
+      callbacks: {
+        recordTokens,
+        checkBudget: vi.fn(),
+        updateProgress: vi.fn().mockResolvedValue(undefined),
+      },
     };
 
-    ctx.recordTokens('issue-analyst', 1500);
-    ctx.recordTokens('code-writer', null);
+    ctx.callbacks.recordTokens('issue-analyst', 1500);
+    ctx.callbacks.recordTokens('code-writer', null);
 
     expect(recordTokens).toHaveBeenCalledWith('issue-analyst', 1500);
     expect(recordTokens).toHaveBeenCalledWith('code-writer', null);
@@ -123,22 +137,29 @@ describe('PhaseContext', () => {
       issue: {} as never,
       worktree: {} as never,
       config: {} as never,
-      progressDir: '',
-      contextBuilder: {} as never,
-      launcher: {} as never,
-      resultParser: {} as never,
-      checkpoint: {} as never,
-      commitManager: {} as never,
-      retryExecutor: {} as never,
-      tokenTracker: {} as never,
-      progressWriter: {} as never,
       platform: {} as never,
-      recordTokens: vi.fn(),
-      checkBudget,
-      logger: {} as never,
+      services: {
+        launcher: {} as never,
+        retryExecutor: {} as never,
+        tokenTracker: {} as never,
+        contextBuilder: {} as never,
+        resultParser: {} as never,
+        logger: {} as never,
+      },
+      io: {
+        progressDir: '',
+        progressWriter: {} as never,
+        checkpoint: {} as never,
+        commitManager: {} as never,
+      },
+      callbacks: {
+        recordTokens: vi.fn(),
+        checkBudget,
+        updateProgress: vi.fn().mockResolvedValue(undefined),
+      },
     };
 
-    ctx.checkBudget();
+    ctx.callbacks.checkBudget();
     expect(checkBudget).toHaveBeenCalledOnce();
   });
 });

--- a/tests/webhook-provider.test.ts
+++ b/tests/webhook-provider.test.ts
@@ -153,6 +153,7 @@ describe('WebhookProvider', () => {
       const event: CadreEvent = {
         type: 'issue-completed',
         issueNumber: 42,
+        issueTitle: 'Fix bug',
         success: true,
         prNumber: 7,
         duration: 300,


### PR DESCRIPTION
## Summary

Reorganizes the flat `PhaseContext` type into three cohesive sub-objects to improve clarity and reduce constructor sprawl.

### Changes

**`src/core/phase-executor.ts`** — introduces three new types:
- `PhaseServices` — cross-cutting execution services (`launcher`, `retryExecutor`, `tokenTracker`, `contextBuilder`, `resultParser`, `logger`)
- `PhaseIO` — persistence and I/O dependencies (`progressDir`, `progressWriter`, `checkpoint`, `commitManager`)
- `PhaseCallbacks` — orchestrator-injected callbacks (`recordTokens`, `checkBudget`, `updateProgress`)

**`src/executors/helpers.ts`** *(new)* — shared `launchWithRetry()` helper that consolidates the budget-check / launch / token-record / retry pattern duplicated across every phase executor.

**`src/util/failure-parser.ts`** *(new)* — extracts structured failure information from agent error output.

**Phase executors** (`analysis`, `implementation`, `integration`, `planning`, `pr-composition`) — updated to use the new grouped context shape and the shared `launchWithRetry()` helper, significantly reducing boilerplate.

**Other updated files** — `issue-orchestrator.ts`, `fleet-orchestrator.ts`, `phase-registry.ts`, `issue-notifier.ts`, `notifications/manager.ts`, `logging/events.ts` — updated to match new signatures and surface additional notification/event types.

**Tests** — all affected test files updated to reflect the new `PhaseContext` structure.

### Stats
31 files changed, 1026 insertions(+), 720 deletions(-)
