### PR TITLE
docs: add CI, npm, coverage, and download badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # CADRE — Coordinated Agent Development Runtime Engine
 
+[![CI](https://github.com/jafreck/cadre/actions/workflows/ci.yml/badge.svg)](https://github.com/jafreck/cadre/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/cadre)](https://www.npmjs.com/package/cadre)
+[![npm downloads](https://img.shields.io/npm/dw/cadre)](https://www.npmjs.com/package/cadre)
+[![Coverage](https://img.shields.io/codecov/c/github/jafreck/cadre)](https://codecov.io/gh/jafreck/cadre)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 CADRE is a framework for **parallel agent-based software development** against a set of open GitHub issues. Given a repository and a list of issues, CADRE provisions one git worktree per issue, then orchestrates a coordinated team of single-purpose agents within each worktree to analyze the issue, plan the implementation, write code, write tests, verify correctness, and open a pull request — all in parallel across issues, with checkpointing and resume at every level.


### PR DESCRIPTION
Adds shields.io badges to the README header for at-a-glance repo health:

- **CI** — GitHub Actions build status (`ci.yml`)
- **npm version** — current published version
- **npm downloads** — weekly download count
- **Coverage** — Codecov coverage percentage
- **License** — existing MIT badge (kept, reordered to end)