### PR TITLE
fix: quote dogfooding label color to prevent YAML sci-notation parse

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -51,7 +51,7 @@
   description: Issues related to the cadre pipeline execution
 
 - name: dogfooding
-  color: 5319E7
+  color: "5319E7"
   description: Issues identified from cadre self-hosting runs
 
 - name: cadre-generated


### PR DESCRIPTION
## Problem

The `label-sync` CI job was failing with:

```
Error: ✗ "Parsed YAML file is invalid:\n.color should be a string (received: number, index: 10)"
```

The `dogfooding` label (index 10) has color `5319E7`. YAML 1.1 parsers interpret this as scientific notation (`5319 × 10^7`), producing a number instead of a string.

## Fix

Wrap the hex color value in double quotes so YAML always parses it as a string:

```yaml
- name: dogfooding
  color: "5319E7"   # was: 5319E7
```