### PR TITLE
fix: push branch and update PR body after review-response pipeline

### DIFF
--- a/src/core/review-response-orchestrator.ts
+++ b/src/core/review-response-orchestrator.ts
@@ -177,8 +177,7 @@ export class ReviewResponseOrchestrator {
         // 9. Push the branch and update the existing PR body on success
         if (issueResult.success) {
           // Push any new commits made by the implementation phase
-          const issueLogger = this.logger.child(issueNumber, join(this.cadreDir, 'logs'));
-          const commitManager = new CommitManager(worktree.path, this.config.commits, issueLogger);
+          const commitManager = new CommitManager(worktree.path, this.config.commits, this.logger);
           try {
             await commitManager.push();
             this.logger.info(
@@ -195,7 +194,7 @@ export class ReviewResponseOrchestrator {
           // Update the existing PR body with the pr-composer's output
           const prContentPath = join(progressDir, 'pr-content.md');
           try {
-            const resultParser = new ResultParser(issueLogger);
+            const resultParser = new ResultParser(this.logger);
             const prContent = await resultParser.parsePRContent(prContentPath);
             const newTitle = prContent.title
               ? `${prContent.title} (#${issueNumber})`


### PR DESCRIPTION
## Problem

`cadre run --respond-to-reviews` ran phases 3–5 successfully in the worktree but the code changes never reached GitHub — the branch wasn't pushed and the PR description wasn't updated.

Phase 5 (`PRCompositionPhaseExecutor`) does push + create PR when `autoCreate: true`, but in review-response mode the `createPullRequest` call fails silently (PR already exists), and there was no path to update the existing PR description with the pr-composer's output.

## Fix

In `ReviewResponseOrchestrator`, after `issueOrchestrator.run()` succeeds:

1. **Push the branch** — creates a `CommitManager` for the worktree and pushes to origin, ensuring review-response code changes land on the remote branch (and therefore appear in the existing PR diff).

2. **Update the PR description** — reads `pr-content.md` written by the pr-composer agent and calls `platform.updatePullRequest` to refresh the PR title/body with the reviewer-feedback-aware description.

Both operations are non-fatal: errors are logged but the issue is still counted as `succeeded` since the code changes are the primary artifact.

## Imports added

- `CommitManager` from `../git/commit.js`
- `ResultParser` from `../agents/result-parser.js`