### PR TITLE
fix: make push and PR description update fatal in review-response orchestrator

### DIFF
--- a/src/core/review-response-orchestrator.ts
+++ b/src/core/review-response-orchestrator.ts
@@ -189,6 +189,7 @@ export class ReviewResponseOrchestrator {
               `Issue #${issueNumber}: push failed: ${pushErr}`,
               { issueNumber },
             );
+            throw pushErr;
           }
 
           // Update the existing PR body with the pr-composer's output
@@ -216,6 +217,7 @@ export class ReviewResponseOrchestrator {
               `Issue #${issueNumber}: failed to update PR #${pr.number}: ${updateErr}`,
               { issueNumber },
             );
+            throw updateErr;
           }
         }
 


### PR DESCRIPTION
## Problem

In `ReviewResponseOrchestrator.run()`, the post-pipeline steps — pushing the branch and updating the PR description — caught and swallowed their errors. The issue was still counted as `succeeded` even when either step threw.

This caused a silent failure mode: code changes could fail to reach the remote branch while the orchestrator proceeded to post an "addressed" comment to reviewers, leaving them to check a PR diff that hadn't actually changed.

## Changes

**`src/core/review-response-orchestrator.ts`**
- Both `catch` blocks in the push and `updatePullRequest` steps now re-throw after logging, so failures bubble to the outer `try/catch` which correctly increments `result.failed`.

**`tests/review-response-orchestrator.test.ts`**
- Added `'counts the issue as failed and logs when push throws'`
- Added `'counts the issue as failed and logs when updatePullRequest throws'`
- Fixed `'does not push or update PR when pipeline fails'`: removed a stale `CommitManager.mockImplementationOnce` that was never consumed (the code never reaches `new CommitManager()` when `issueResult.success === false`), and replaced the stale `pushSpy` assertion with `expect(CommitManager).not.toHaveBeenCalled()`
