### PR TITLE
feat: agent-driven conflict resolution during review-response rebase

### DIFF
--- a/src/agents/context-builder.ts
+++ b/src/agents/context-builder.ts
@@ -339,6 +339,36 @@ export class ContextBuilder {
   }
 
   /**
+   * Build a context file for the conflict-resolver agent.
+   * @param issueNumber   Issue associated with this worktree.
+   * @param worktreePath  Absolute path to the worktree root.
+   * @param conflictedFiles  Paths (relative to worktreePath) of files with conflict markers.
+   * @param progressDir   Directory where context and output files are written.
+   */
+  async buildForConflictResolver(
+    issueNumber: number,
+    worktreePath: string,
+    conflictedFiles: string[],
+    progressDir: string,
+  ): Promise<string> {
+    return this.writeContext(progressDir, 'conflict-resolver', issueNumber, {
+      agent: 'conflict-resolver',
+      issueNumber,
+      projectName: this.config.projectName,
+      repository: this.config.repository,
+      worktreePath,
+      phase: 0,
+      config: { commands: this.config.commands },
+      inputFiles: conflictedFiles.map((f) => join(worktreePath, f)),
+      outputPath: join(progressDir, 'conflict-resolution-report.md'),
+      payload: {
+        conflictedFiles,
+        baseBranch: this.config.baseBranch,
+      },
+    });
+  }
+
+  /**
    * Write a context JSON file and return the path.
    */
   private async writeContext(

--- a/src/agents/templates/conflict-resolver.md
+++ b/src/agents/templates/conflict-resolver.md
@@ -1,0 +1,146 @@
+# Conflict Resolver
+
+## Role
+
+You are a senior engineer resolving merge conflicts that arose while rebasing a
+feature branch onto the latest base branch. Your goal is **semantic correctness**,
+not just syntactic cleanliness. You must understand *why* each conflicting change
+was made before deciding how to merge them.
+
+## Context
+
+You are operating inside a git worktree that is mid-rebase. One or more files
+contain conflict markers. The orchestrator will run `git add` and
+`git rebase --continue` after you finish — **do not run any git state-changing
+commands yourself**.
+
+## Input Contract
+
+Read your context file (JSON) first. It contains:
+
+- **`worktreePath`**: Absolute path to the worktree root.
+- **`conflictedFiles`**: Array of file paths (relative to `worktreePath`) that
+  contain conflict markers.
+- **`baseBranch`**: The branch being rebased onto (e.g., `main`).
+- **`issueNumber`**: The issue this branch is implementing.
+- **`outputPath`**: Where to write your resolution report.
+
+## Step 1 — Understand the Branch's Purpose
+
+Before looking at any conflict, build context:
+
+1. Read the issue description if available (look for
+   `.cadre/issues/<issueNumber>/review-response.md` or similar in the worktree).
+2. Run `git log --oneline origin/<baseBranch>..HEAD` to see what commits this
+   branch added.
+3. Run `git diff origin/<baseBranch>...HEAD -- <conflictedFile>` for each
+   conflicted file to understand the full extent of changes on both sides.
+4. Read files closely related to the conflicted ones — shared types, callers,
+   interfaces — to understand the intended design on **both sides** before making
+   any edits.
+
+Only once you understand the *intent* of both sides should you attempt resolution.
+
+## Step 2 — Locate and Understand Each Conflict
+
+Conflict markers look like:
+
+```
+<<<<<<< HEAD
+// What this branch had (the feature/fix being implemented)
+=======
+// What origin/main introduced since this branch diverged
+>>>>>>> origin/main
+```
+
+- **HEAD side**: Changes made by this branch to implement the feature or fix.
+- **Base side**: Changes merged into the base branch since the branch diverged
+  (refactors, new APIs, renamed symbols, restructured code, etc.).
+
+For each conflict region, reason explicitly before touching any code:
+
+- Are both sides modifying the same logic for **different reasons**, or is one
+  side a superset of the other?
+- Did the base branch **rename a symbol, change a signature, or restructure an
+  API** that the HEAD side also uses? If so, the HEAD logic must be *adapted* to
+  the new API — not kept verbatim.
+- Did the HEAD side **add something entirely new** that the base side does not
+  touch? Then keep the HEAD addition alongside the base changes.
+- Is one side clearly **obsolete or superseded** given the combined picture?
+
+Do not default to "keep both" or "keep HEAD" without reasoning. Think through
+the semantics of what each side is trying to achieve.
+
+## Step 3 — Resolve Each File
+
+For each conflicted file:
+
+1. Read the **entire file** — not just the conflict region — to understand
+   surrounding structure and intent.
+2. Read related files the conflict touches (interfaces, callers, sibling modules,
+   test files) to form a complete picture.
+3. Produce a merged result that:
+   - Retains the feature/fix logic from HEAD, **adapted if necessary** to the
+     base-branch's updated APIs or structures.
+   - Incorporates base-branch changes correctly (new function signatures, renamed
+     symbols, restructured modules, etc.).
+   - Produces **valid, compilable, test-passing code** with zero conflict markers.
+4. Overwrite the file with the resolved content.
+
+**If the two sides genuinely conflict in intent** (they cannot both be correct),
+choose the version consistent with the branch's stated purpose (the issue being
+solved) and explain your reasoning in the report.
+
+## Step 4 — Verify
+
+After resolving all files, run the build verification command (use `commands.build`
+from the context, or fall back to `npm run build` / `npx tsc --noEmit`).
+If it fails:
+
+- Read the errors carefully.
+- Fix any files — including non-conflicted ones — that are now inconsistent
+  (e.g., a caller that still references a renamed API from the base branch).
+- Re-run until the build passes.
+
+If tests are available (`commands.test`), run them too and fix any failures.
+
+## Output Contract
+
+Write the resolved content directly into each conflicted file, then write a
+markdown report to `outputPath`:
+
+```markdown
+# Conflict Resolution Report
+
+## Summary
+Resolved N conflicted file(s) while rebasing issue #<issueNumber> onto <baseBranch>.
+
+## What the Base Branch Introduced
+Brief description of what origin/<baseBranch> changed that caused these conflicts.
+
+## Files Resolved
+
+### `path/to/file.ts`
+- **Conflict regions**: N
+- **Resolution**: What was kept from each side, why, and any adaptations made
+  (e.g., "HEAD added `newField` to the interface; base renamed `oldMethod` to
+  `newMethod`. Kept both: adapted HEAD's usage to call `newMethod`").
+
+## Notes
+- Trade-offs, ambiguous decisions, or anything the developer should review.
+```
+
+## Tool Permissions
+
+- **view**: Read any file in the worktree or wider repository for context.
+- **bash**: Run `git log`, `git diff`, build commands, and test commands.
+- **edit**: Overwrite conflicted files and any other files needed to make the
+  build pass.
+
+## Hard Constraints
+
+- Remove **every** `<<<<<<<`, `=======`, and `>>>>>>>` line from every file
+  before finishing.
+- Do **not** run `git add`, `git rebase`, `git commit`, or any other
+  git state-changing command.
+- The build must pass before you write the report.

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -14,6 +14,7 @@ export type AgentName =
   | 'fix-surgeon'
   | 'integration-checker'
   | 'pr-composer'
+  | 'conflict-resolver'
   | 'issue-orchestrator'
   | 'cadre-runner';
 
@@ -124,6 +125,14 @@ export const AGENT_DEFINITIONS: readonly AgentDefinition[] = [
     description: 'Writes a clear, informative pull request title and body summarizing all changes made.',
     hasStructuredOutput: true,
     templateFile: 'pr-composer.md',
+  },
+  {
+    name: 'conflict-resolver',
+    phase: 0,
+    phaseName: 'Orchestration',
+    description: 'Resolves merge conflict markers in files left by a paused git rebase, producing valid compilable code.',
+    hasStructuredOutput: false,
+    templateFile: 'conflict-resolver.md',
   },
 ] as const;
 

--- a/tests/agent-templates.test.ts
+++ b/tests/agent-templates.test.ts
@@ -7,8 +7,8 @@ const TEMPLATES_DIR = resolve(__dirname, '../src/agents/templates');
 
 describe('Agent Template Files', () => {
   describe('AGENT_DEFINITIONS templateFile entries', () => {
-    it('should have 12 agent definitions', () => {
-      expect(AGENT_DEFINITIONS).toHaveLength(12);
+    it('should have 13 agent definitions', () => {
+      expect(AGENT_DEFINITIONS).toHaveLength(13);
     });
 
     it('each templateFile should be a .md file', () => {
@@ -52,9 +52,9 @@ describe('Agent Template Files', () => {
   });
 
   describe('src/agents/templates/ directory', () => {
-    it('should contain exactly 12 .md files', () => {
+    it('should contain exactly 13 .md files', () => {
       const files = readdirSync(TEMPLATES_DIR).filter((f) => f.endsWith('.md'));
-      expect(files).toHaveLength(12);
+      expect(files).toHaveLength(13);
     });
 
     it('should not contain any non-.md files', () => {

--- a/tests/agent-types.test.ts
+++ b/tests/agent-types.test.ts
@@ -18,8 +18,8 @@ const ALL_AGENT_NAMES: AgentName[] = [
 ];
 
 describe('AGENT_DEFINITIONS', () => {
-  it('should contain exactly 12 entries', () => {
-    expect(AGENT_DEFINITIONS).toHaveLength(12);
+  it('should contain exactly 13 entries', () => {
+    expect(AGENT_DEFINITIONS).toHaveLength(13);
   });
 
   it('should have one entry for each AgentName', () => {
@@ -77,6 +77,7 @@ describe('AGENT_DEFINITIONS', () => {
     expect(unstructured).toContain('code-writer');
     expect(unstructured).toContain('test-writer');
     expect(unstructured).toContain('fix-surgeon');
+    expect(unstructured).toContain('conflict-resolver');
   });
 
   it('should group orchestration agents in phase 0', () => {

--- a/tests/agents-cli.test.ts
+++ b/tests/agents-cli.test.ts
@@ -44,8 +44,8 @@ function makeProgram(): Command {
 }
 
 describe('AGENT_DEFINITIONS registry', () => {
-  it('should contain exactly 12 entries', () => {
-    expect(AGENT_DEFINITIONS).toHaveLength(12);
+  it('should contain exactly 13 entries', () => {
+    expect(AGENT_DEFINITIONS).toHaveLength(13);
   });
 
   it('should have all required fields for every entry', () => {

--- a/tests/postbuild-script.test.ts
+++ b/tests/postbuild-script.test.ts
@@ -47,9 +47,9 @@ describe('dist/agents/templates/ after build', () => {
     expect(existsSync(DIST_TEMPLATES_DIR)).toBe(true);
   });
 
-  it.skipIf(!existsSync(DIST_TEMPLATES_DIR))('should contain exactly 12 .md template files', () => {
+  it.skipIf(!existsSync(DIST_TEMPLATES_DIR))('should contain exactly 13 .md template files', () => {
     const files = readdirSync(DIST_TEMPLATES_DIR).filter((f) => f.endsWith('.md'));
-    expect(files).toHaveLength(12);
+    expect(files).toHaveLength(13);
   });
 
   it.each(EXPECTED_TEMPLATES)('%s should be present in dist/agents/templates/', (template) => {


### PR DESCRIPTION
## Summary

When `--respond-to-reviews` rebases a PR branch onto the base branch and encounters merge conflicts, instead of failing the issue, CADRE now invokes a new `conflict-resolver` agent to resolve them in place before continuing the rebase.

## Changes

### `src/git/worktree.ts`
Split `rebase()` into three composable methods:
- `rebaseStart()` — starts the rebase; on conflict leaves the worktree paused (does **not** abort) and returns `{ status: 'conflict', conflictedFiles, worktreePath }`
- `rebaseContinue()` — stages all files (`git add -A`) and runs `GIT_EDITOR=true git rebase --continue`
- `rebaseAbort()` — cleans up a paused rebase

`rebase()` is kept for backward compat; it now delegates to `rebaseStart()` and aborts on conflict.

### New `conflict-resolver` agent
- **`src/agents/types.ts`** — added to `AgentName` union and `AGENT_DEFINITIONS` (phase 0, `phaseName: 'Orchestration'`, no structured output)
- **`src/agents/templates/conflict-resolver.md`** — template that instructs the agent to:
  1. Understand the branch's purpose first via `git log` and `git diff` before touching any file
  2. Reason explicitly about each conflict region (adapt HEAD to new base APIs rather than blindly keeping it verbatim)
  3. Read related files (interfaces, callers, sibling modules) for full context
  4. Verify the build passes after resolving, fixing any cascading breakage
- **`src/agents/context-builder.ts`** — added `buildForConflictResolver()`

### `src/core/review-response-orchestrator.ts`
Replaced the single `rebase()` call with an orchestrated flow:

```
rebaseStart()
  → status: clean  → continue pipeline
  → status: conflict
      → buildForConflictResolver()
      → launchAgent('conflict-resolver')
          → failure → rebaseAbort() + throw
      → rebaseContinue()
          → failure → rebaseAbort() + throw
      → continue pipeline
```

### Tests
- Updated `makeMockDeps()`: `rebase` → `rebaseStart / rebaseContinue / rebaseAbort`
- Rewrote rebase describe block: 7 tests covering clean path, conflict agent invocation, `rebaseContinue` called after agent, abort+throw on agent failure, abort+throw on continue failure, full conflict resolution success, force-push
- Updated agent count assertions from 12 → 13 in `agent-templates.test.ts`, `agent-types.test.ts`, `agents-cli.test.ts`, `postbuild-script.test.ts`
- **1895/1895 tests passing**