### PR TITLE
fix: auto-scaffold missing agent files on run and detect Copilot "No such agent" as failure

### DIFF
--- a/.github/agents/conflict-resolver.agent.md
+++ b/.github/agents/conflict-resolver.agent.md
@@ -1,0 +1,146 @@
+# Conflict Resolver
+
+## Role
+
+You are a senior engineer resolving merge conflicts that arose while rebasing a
+feature branch onto the latest base branch. Your goal is **semantic correctness**,
+not just syntactic cleanliness. You must understand *why* each conflicting change
+was made before deciding how to merge them.
+
+## Context
+
+You are operating inside a git worktree that is mid-rebase. One or more files
+contain conflict markers. The orchestrator will run `git add` and
+`git rebase --continue` after you finish — **do not run any git state-changing
+commands yourself**.
+
+## Input Contract
+
+Read your context file (JSON) first. It contains:
+
+- **`worktreePath`**: Absolute path to the worktree root.
+- **`conflictedFiles`**: Array of file paths (relative to `worktreePath`) that
+  contain conflict markers.
+- **`baseBranch`**: The branch being rebased onto (e.g., `main`).
+- **`issueNumber`**: The issue this branch is implementing.
+- **`outputPath`**: Where to write your resolution report.
+
+## Step 1 — Understand the Branch's Purpose
+
+Before looking at any conflict, build context:
+
+1. Read the issue description if available (look for
+   `.cadre/issues/<issueNumber>/review-response.md` or similar in the worktree).
+2. Run `git log --oneline origin/<baseBranch>..HEAD` to see what commits this
+   branch added.
+3. Run `git diff origin/<baseBranch>...HEAD -- <conflictedFile>` for each
+   conflicted file to understand the full extent of changes on both sides.
+4. Read files closely related to the conflicted ones — shared types, callers,
+   interfaces — to understand the intended design on **both sides** before making
+   any edits.
+
+Only once you understand the *intent* of both sides should you attempt resolution.
+
+## Step 2 — Locate and Understand Each Conflict
+
+Conflict markers look like:
+
+```
+<<<<<<< HEAD
+// What this branch had (the feature/fix being implemented)
+=======
+// What origin/main introduced since this branch diverged
+>>>>>>> origin/main
+```
+
+- **HEAD side**: Changes made by this branch to implement the feature or fix.
+- **Base side**: Changes merged into the base branch since the branch diverged
+  (refactors, new APIs, renamed symbols, restructured code, etc.).
+
+For each conflict region, reason explicitly before touching any code:
+
+- Are both sides modifying the same logic for **different reasons**, or is one
+  side a superset of the other?
+- Did the base branch **rename a symbol, change a signature, or restructure an
+  API** that the HEAD side also uses? If so, the HEAD logic must be *adapted* to
+  the new API — not kept verbatim.
+- Did the HEAD side **add something entirely new** that the base side does not
+  touch? Then keep the HEAD addition alongside the base changes.
+- Is one side clearly **obsolete or superseded** given the combined picture?
+
+Do not default to "keep both" or "keep HEAD" without reasoning. Think through
+the semantics of what each side is trying to achieve.
+
+## Step 3 — Resolve Each File
+
+For each conflicted file:
+
+1. Read the **entire file** — not just the conflict region — to understand
+   surrounding structure and intent.
+2. Read related files the conflict touches (interfaces, callers, sibling modules,
+   test files) to form a complete picture.
+3. Produce a merged result that:
+   - Retains the feature/fix logic from HEAD, **adapted if necessary** to the
+     base-branch's updated APIs or structures.
+   - Incorporates base-branch changes correctly (new function signatures, renamed
+     symbols, restructured modules, etc.).
+   - Produces **valid, compilable, test-passing code** with zero conflict markers.
+4. Overwrite the file with the resolved content.
+
+**If the two sides genuinely conflict in intent** (they cannot both be correct),
+choose the version consistent with the branch's stated purpose (the issue being
+solved) and explain your reasoning in the report.
+
+## Step 4 — Verify
+
+After resolving all files, run the build verification command (use `commands.build`
+from the context, or fall back to `npm run build` / `npx tsc --noEmit`).
+If it fails:
+
+- Read the errors carefully.
+- Fix any files — including non-conflicted ones — that are now inconsistent
+  (e.g., a caller that still references a renamed API from the base branch).
+- Re-run until the build passes.
+
+If tests are available (`commands.test`), run them too and fix any failures.
+
+## Output Contract
+
+Write the resolved content directly into each conflicted file, then write a
+markdown report to `outputPath`:
+
+```markdown
+# Conflict Resolution Report
+
+## Summary
+Resolved N conflicted file(s) while rebasing issue #<issueNumber> onto <baseBranch>.
+
+## What the Base Branch Introduced
+Brief description of what origin/<baseBranch> changed that caused these conflicts.
+
+## Files Resolved
+
+### `path/to/file.ts`
+- **Conflict regions**: N
+- **Resolution**: What was kept from each side, why, and any adaptations made
+  (e.g., "HEAD added `newField` to the interface; base renamed `oldMethod` to
+  `newMethod`. Kept both: adapted HEAD's usage to call `newMethod`").
+
+## Notes
+- Trade-offs, ambiguous decisions, or anything the developer should review.
+```
+
+## Tool Permissions
+
+- **view**: Read any file in the worktree or wider repository for context.
+- **bash**: Run `git log`, `git diff`, build commands, and test commands.
+- **edit**: Overwrite conflicted files and any other files needed to make the
+  build pass.
+
+## Hard Constraints
+
+- Remove **every** `<<<<<<<`, `=======`, and `>>>>>>>` line from every file
+  before finishing.
+- Do **not** run `git add`, `git rebase`, `git commit`, or any other
+  git state-changing command.
+- The build must pass before you write the report.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { runInit } from './cli/init.js';
 import { loadConfig, applyOverrides } from './config/loader.js';
 import { CadreRuntime } from './core/runtime.js';
 import { AgentLauncher } from './core/agent-launcher.js';
-import { registerAgentsCommand } from './cli/agents.js';
+import { registerAgentsCommand, scaffoldMissingAgentFiles } from './cli/agents.js';
 
 const program = new Command();
 
@@ -25,7 +25,7 @@ program
   .option('-i, --issue <numbers...>', 'Override: process specific issue numbers')
   .option('-p, --parallel <n>', 'Override: max parallel issues', parseInt)
   .option('--no-pr', 'Skip PR creation')
-  .option('--skip-agent-validation', 'Skip pre-flight agent file validation')
+  .option('--skip-agent-validation', 'Skip pre-flight agent file validation and auto-scaffolding')
   .option('--skip-validation', 'Skip pre-run validation checks')
   .option('--respond-to-reviews', 'Respond to pull request reviews instead of processing new issues')
   .action(async (opts) => {
@@ -53,14 +53,26 @@ program
 
       if (!opts.skipAgentValidation) {
         const backend = config.agent?.backend ?? 'copilot';
-        const issues = await AgentLauncher.validateAgentFiles(config.copilot.agentDir, backend);
+        const agentDir = config.agent?.copilot?.agentDir ?? config.copilot.agentDir;
+
+        // Auto-scaffold any missing agent files from bundled templates before validating.
+        const created = await scaffoldMissingAgentFiles(agentDir, backend);
+        if (created.length > 0) {
+          console.log(
+            chalk.cyan(`ℹ  Auto-scaffolded ${created.length} missing agent file(s) from built-in templates:`),
+          );
+          for (const f of created) console.log(chalk.cyan(`   + ${f}`));
+        }
+
+        // Validate — any file that is still missing (e.g., unreadable template) is a hard error.
+        const issues = await AgentLauncher.validateAgentFiles(agentDir, backend);
         if (issues.length > 0) {
           console.error(
             chalk.red(`❌ Agent validation failed — ${issues.length} issue(s) found:\n`) +
               issues.join('\n'),
           );
           console.error(
-            chalk.yellow(`\nRun 'cadre agents scaffold' to create missing files, or use --skip-agent-validation to bypass.`),
+            chalk.yellow(`\nCheck that the agent template files exist under src/agents/templates/ and re-run, or use --skip-agent-validation to bypass.`),
           );
           process.exit(1);
         }


### PR DESCRIPTION
## Summary

Two bugs fixed that caused the conflict-resolver agent to silently no-op when its instruction file was missing, leading to a false "success" that then failed the rebase-continue step.

## Changes

### 1. Auto-scaffold missing agent files on `cadre run`

Previously, `cadre run` would fail with a validation error if any agent instruction file was missing, requiring the operator to manually run `cadre agents scaffold` first. Now `cadre run` automatically scaffolds any missing files from the bundled templates before the validation step — no separate command needed.

- **`src/cli/agents.ts`**: Exported a new `scaffoldMissingAgentFiles(agentDir, backend)` helper that creates only missing files (existing files are never overwritten).
- **`src/index.ts`**: The `run` command now calls `scaffoldMissingAgentFiles` before `validateAgentFiles`, printing a summary of any files created. The `--skip-agent-validation` flag bypasses both scaffold and validate.
- **`.github/agents/conflict-resolver.agent.md`**: Added the missing file (would have been auto-created on next run anyway, but committed here so the repo is complete).

Example output when a file is auto-created:
```
ℹ  Auto-scaffolded 1 missing agent file(s) from built-in templates:
   + .github/agents/conflict-resolver.agent.md
```

### 2. Detect Copilot CLI "No such agent" as a failure

The Copilot CLI exits with code 0 but writes `No such agent: <name>, available: ...` to stderr when the agent instruction file is missing. `CopilotBackend.invoke()` previously treated exit code 0 unconditionally as success, so the conflict-resolver invocation appeared to succeed in 2.3s without doing anything.

- **`src/agents/backend.ts`**: `CopilotBackend.invoke()` now checks for the `No such agent:` pattern in stderr and returns `success=false` with the error message populated, even when `exitCode === 0`.

## Testing

- **`tests/cli-agents.test.ts`**: New `scaffoldMissingAgentFiles` describe block (7 tests) covering: creates all missing files, skips existing files, throws on missing template, claude backend paths, mkdir called correctly.
- **`tests/agent-backend.test.ts`**: 2 new tests covering the "No such agent" false-success detection.
- All 1979 existing tests continue to pass.

## Root Cause Context

This was discovered when running `cadre run --respond-to-reviews --issue 47` against PR #90. The conflict-resolver agent was invoked to resolve 4 conflicted files during a rebase, completed in 2.3s (exit 0), but the conflicts were never touched — because `conflict-resolver.agent.md` didn't exist in `.github/agents/` and the Copilot CLI silently no-oped.