### PR TITLE
fix: sync agent files from agentDir into worktree .github/agents on provision

### DIFF
--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -35,6 +35,10 @@ export class CadreRuntime {
   private isShuttingDown = false;
   private activeIssueNumbers: number[] = [];
 
+  private get agentDir(): string {
+    return this.config.agent?.copilot?.agentDir ?? this.config.copilot.agentDir;
+  }
+
   constructor(private readonly config: CadreConfig) {
     this.cadreDir = join(config.repoPath, '.cadre');
     this.logger = new Logger({
@@ -116,6 +120,7 @@ export class CadreRuntime {
       this.config.baseBranch,
       this.config.branchTemplate,
       this.logger,
+      this.agentDir,
     );
 
     const launcher = new AgentLauncher(this.config, this.logger);
@@ -276,6 +281,7 @@ export class CadreRuntime {
       this.config.baseBranch,
       this.config.branchTemplate,
       this.logger,
+      this.agentDir,
     );
 
     const worktrees = await worktreeManager.listActive();
@@ -305,6 +311,7 @@ export class CadreRuntime {
       this.config.baseBranch,
       this.config.branchTemplate,
       this.logger,
+      this.agentDir,
     );
 
     const checkpointManager = new FleetCheckpointManager(


### PR DESCRIPTION
## Problem

The Copilot CLI resolves `--agent <name>` by looking for `<name>.agent.md` in `.github/agents/` relative to `cwd` (the worktree). There is no `--agent-dir` flag to redirect this lookup.

Previously, agent files only existed in the main repo's `agentDir` (e.g. `.cadre/agents/`) and were never copied into worktrees. Any agent file that wasn't committed to the target branch's `.github/agents/` would fail with `No such agent:` at runtime — even if it passed pre-flight validation.

This was observed with `conflict-resolver.agent.md`, which was scaffolded to `.cadre/agents/` but failed when the Copilot CLI ran inside the worktree.

## Solution

`WorktreeManager` now accepts an optional `agentDir` parameter and calls a new `syncAgentFiles()` method at every worktree provision path (new, resumed, and existing worktrees). This copies all `*.agent.md` files from `agentDir` into `<worktreePath>/.github/agents/`.

`CadreRuntime` passes `agentDir` (resolved from config) to all three `WorktreeManager` instantiations.

CADRE is now fully self-contained — the **target repo does not need any agent files committed** to `.github/agents/`. Everything is managed from `.cadre/agents/`.