### PR TITLE
fix: mandate cadre-json output in implementation-planner and fix plan parser

### DIFF
--- a/src/agents/templates/implementation-planner.md
+++ b/src/agents/templates/implementation-planner.md
@@ -13,7 +13,11 @@ Read both files carefully before producing the plan. Use the affected areas and 
 
 ## Output Contract
 
-Produce an **implementation-plan.md** file containing an ordered list of tasks. Each task must follow this exact format:
+Produce an **implementation-plan.md** file. You MUST include **two sections** in your output:
+
+### 1. Human-readable task list (required for reviewability)
+
+First write each task as a markdown section:
 
 ```
 ## task-XXX – {Task Name}
@@ -27,6 +31,41 @@ Produce an **implementation-plan.md** file containing an ordered list of tasks. 
 - {Specific, testable criterion}
 ```
 
+### 2. Machine-readable cadre-json block (MANDATORY — cadre cannot parse the plan without this)
+
+At the very end of the file, after all task sections, you MUST append a fenced `cadre-json` block containing the complete task list as a JSON array. cadre reads this block to execute the plan. **If this block is missing or malformed, the entire run will fail.**
+
+The block must match this exact schema:
+
+````
+```cadre-json
+[
+  {
+    "id": "task-001",
+    "name": "Short task name",
+    "description": "One or two sentences.",
+    "files": ["src/example.ts", "tests/example.test.ts"],
+    "dependencies": [],
+    "complexity": "simple",
+    "acceptanceCriteria": [
+      "Specific verifiable criterion"
+    ]
+  }
+]
+```
+````
+
+**Schema rules for the cadre-json block:**
+- The top-level value is a JSON **array** of task objects — not an object with a `tasks` key.
+- `id`: string, sequential, e.g. `"task-001"`, `"task-002"`.
+- `name`: short descriptive string.
+- `description`: one or two sentences.
+- `files`: JSON array of strings (file paths relative to repo root).
+- `dependencies`: JSON array of task ID strings (empty array `[]` when none).
+- `complexity`: one of `"simple"`, `"moderate"`, `"complex"`.
+- `acceptanceCriteria`: JSON array of strings; each entry is a single testable criterion.
+- All string values must be valid JSON (escape quotes, no trailing commas).
+
 ### Rules
 - You MUST read every source file you intend to reference before making any claims about its contents or structure.
 - Task IDs must be sequential: `task-001`, `task-002`, etc.
@@ -36,12 +75,13 @@ Produce an **implementation-plan.md** file containing an ordered list of tasks. 
 - Acceptance criteria must be concrete and verifiable (not vague goals).
 - Order tasks so that no task depends on one that appears later.
 - Do not include tasks for changes outside the scope identified in analysis.md.
+- **The cadre-json block must be the last thing in the file.**
 
 ## Tool Permissions
 
 - **Read files** (required): Read analysis.md, scout-report.md, and every source file you intend to reference before making any claims about its contents or structure.
 
-## Example Task Block
+## Example Output
 
 ```
 ## task-001 – Add timeout configuration constant
@@ -64,4 +104,34 @@ Produce an **implementation-plan.md** file containing an ordered list of tasks. 
 - `loginHandler` accepts an optional `timeout?: number` parameter
 - When `timeout` is omitted, the handler uses `DEFAULT_TIMEOUT`
 - Existing tests continue to pass without modification
+```
+
+```cadre-json
+[
+  {
+    "id": "task-001",
+    "name": "Add timeout configuration constant",
+    "description": "Define a DEFAULT_TIMEOUT constant in the shared config module so all components can reference a single source of truth for the default timeout value.",
+    "files": ["src/config.ts"],
+    "dependencies": [],
+    "complexity": "simple",
+    "acceptanceCriteria": [
+      "`DEFAULT_TIMEOUT` is exported from `src/config.ts`",
+      "Value is `30` (seconds)"
+    ]
+  },
+  {
+    "id": "task-002",
+    "name": "Accept timeout parameter in login handler",
+    "description": "Update the loginHandler function to accept an optional `timeout` parameter, falling back to `DEFAULT_TIMEOUT` when not provided.",
+    "files": ["src/auth/login.ts", "tests/auth/login.test.ts"],
+    "dependencies": ["task-001"],
+    "complexity": "moderate",
+    "acceptanceCriteria": [
+      "`loginHandler` accepts an optional `timeout?: number` parameter",
+      "When `timeout` is omitted, the handler uses `DEFAULT_TIMEOUT`",
+      "Existing tests continue to pass without modification"
+    ]
+  }
+]
 ```

--- a/src/executors/planning-phase-executor.ts
+++ b/src/executors/planning-phase-executor.ts
@@ -36,7 +36,12 @@ export class PlanningPhaseExecutor implements PhaseExecutor {
     const tasks = await ctx.services.resultParser.parseImplementationPlan(planPath);
 
     if (tasks.length === 0) {
-      throw new Error('Implementation plan produced zero tasks');
+      throw new Error(
+        'Implementation plan produced zero tasks. ' +
+        'The implementation-planner agent did not emit a valid `cadre-json` block or any parseable task sections. ' +
+        `Check ${join(ctx.io.progressDir, 'implementation-plan.md')} — the agent must output a ` +
+        '```cadre-json``` fenced block containing a JSON array of task objects (see agent template for schema).',
+      );
     }
 
     // Validate dependency graph is acyclic


### PR DESCRIPTION
## Problem

The `implementation-planner` agent template only described a human-readable markdown format for tasks (`## task-XXX – Name`), but never mentioned the `cadre-json` block that `parseImplementationPlan()` requires as its primary parsing path. The regex fallback was also broken — it split on `## Task: task-xxx -` (legacy format) but the template produces `## task-XXX – Name` (em-dash, no "Task:" prefix), so **both** parsing paths failed silently and the run aborted with the unhelpful error `"Implementation plan produced zero tasks"`.

Observed in the dogfood run for issue #113.

## Changes

### `src/agents/templates/implementation-planner.md`
- **Mandates a `cadre-json` fenced block** at the end of `implementation-plan.md` as the machine-readable output cadre actually parses
- Documents the exact JSON schema (`id`, `name`, `description`, `files`, `dependencies`, `complexity`, `acceptanceCriteria`)
- Shows a complete two-task example with both the human-readable markdown section and the corresponding `cadre-json` block
- Adds a prominent warning: _"If this block is missing or malformed, the entire run will fail"_

### `src/agents/result-parser.ts`
- Regex fallback splitter now handles the actual template heading format (`## task-XXX – Name` with em-dash) in addition to the legacy `## Task: task-XXX` format
- Header line parser now accepts both `–` (em-dash) and `-` (hyphen) as separators
- Zero-tasks warning now includes the root cause and fix guidance (missing `cadre-json` block), not just the file path

### `src/executors/planning-phase-executor.ts`
- Zero-tasks error now explicitly identifies the cause (missing `cadre-json` block) and points to the agent template for the required schema

## Testing

All 118 existing tests pass (`result-parser`, `implementation-phase-executor`, `analysis-phase-executor`).