### PR TITLE
fix: use cadre-json fence in all agent output templates

### DIFF
--- a/src/agents/templates/code-reviewer.md
+++ b/src/agents/templates/code-reviewer.md
@@ -25,9 +25,9 @@ Do **not** flag issues for:
 - Personal preferences
 
 ## Output
-Respond with a JSON object matching the `ReviewResult` structure:
+Respond with a `cadre-json` fenced block matching the `ReviewResult` structure. **The fence language must be `cadre-json` exactly — cadre uses this marker to parse the output; a plain `json` block will not be detected.**
 
-```json
+```cadre-json
 {
   "verdict": "pass" | "needs-fixes",
   "summary": "One or two sentences summarizing your findings.",

--- a/src/agents/templates/codebase-scout.md
+++ b/src/agents/templates/codebase-scout.md
@@ -47,6 +47,12 @@ A list of existing test files that cover the relevant source files. Note any gap
 
 A short paragraph or bullet list estimating how many files need to change, which are most complex, and any risk areas (e.g., shared utilities with many dependents, complex type hierarchies).
 
+## Machine-readable output (MANDATORY)
+
+After all human-readable sections, you MUST append a `cadre-json` fenced block containing the structured scout report. **cadre does not read the markdown prose — it reads only this block. If the block is missing or uses a different fence language (e.g. plain `json`), the pipeline will fail.**
+
+The block must match the `ScoutReport` schema: `relevantFiles` (array of `{ path, reason }`), `dependencyMap` (object mapping file path → array of imported file paths), `testFiles` (array of strings), `estimatedChanges` (array of `{ path, linesEstimate }`).
+
 ## Example Output
 
 ```markdown
@@ -75,4 +81,28 @@ A short paragraph or bullet list estimating how many files need to change, which
 ## Estimated Change Surface
 
 3 files require changes. `runner.ts` is the most complex (dispatches agent tasks). `types.ts` change is low-risk (additive interface). Config change is minimal. No shared utilities are affected.
+```
+
+```cadre-json
+{
+  "relevantFiles": [
+    { "path": "src/agents/runner.ts", "reason": "Entry point that must be updated to support new agent type" },
+    { "path": "src/agents/types.ts", "reason": "Shared type definitions; new interface needed here" },
+    { "path": "src/config.ts", "reason": "Reads config file; new config key must be added" }
+  ],
+  "dependencyMap": {
+    "src/agents/runner.ts": ["src/agents/types.ts", "src/config.ts"],
+    "src/agents/types.ts": [],
+    "src/config.ts": []
+  },
+  "testFiles": [
+    "tests/runner.test.ts",
+    "tests/config.test.ts"
+  ],
+  "estimatedChanges": [
+    { "path": "src/agents/runner.ts", "linesEstimate": 50 },
+    { "path": "src/agents/types.ts", "linesEstimate": 15 },
+    { "path": "src/config.ts", "linesEstimate": 5 }
+  ]
+}
 ```

--- a/src/agents/templates/integration-checker.md
+++ b/src/agents/templates/integration-checker.md
@@ -39,9 +39,9 @@ If it exists, read it. It contains a list of test/check names that were already 
 If `.cadre/baseline-results.json` does not exist, treat all failures as regressions.
 
 ## Output
-Respond with a JSON object matching the `IntegrationReport` structure:
+Respond with a `cadre-json` fenced block matching the `IntegrationReport` structure. **The fence language must be `cadre-json` exactly — cadre uses this marker to parse the output.**
 
-```json
+```cadre-json
 {
   "buildResult": {
     "command": "npm run build",
@@ -63,8 +63,7 @@ Respond with a JSON object matching the `IntegrationReport` structure:
   },
   "baselineFailures": ["foo"],
   "regressionFailures": ["bar"],
-  "overallPass": false,
-  "summary": "Build and lint passed. 1 regression failure detected (bar). 1 pre-existing failure unchanged (foo)."
+  "overallPass": false
 }
 ```
 

--- a/src/agents/templates/issue-analyst.md
+++ b/src/agents/templates/issue-analyst.md
@@ -39,6 +39,12 @@ List the directories, modules, or subsystems that will likely need changes based
 ### Ambiguities
 List any unclear requirements, missing context, or decisions that need clarification before implementation can begin. If none, write "None identified."
 
+## Machine-readable output (MANDATORY)
+
+After all human-readable sections, you MUST append a `cadre-json` fenced block containing the structured analysis. **cadre does not read the markdown prose — it reads only this block. If the block is missing or uses a different fence language (e.g. plain `json`), the pipeline will fail.**
+
+The block must match the `AnalysisResult` schema: `requirements` (string array), `changeType` (one of `"bug-fix"`, `"feature"`, `"refactor"`, `"docs"`, `"chore"`), `scope` (one of `"small"`, `"medium"`, `"large"`), `affectedAreas` (string array), `ambiguities` (string array).
+
 ## Tool Permissions
 
 - **GitHub issue read**: Fetch issue details, comments, and labels
@@ -66,4 +72,25 @@ small
 ## Ambiguities
 - Should the timeout apply per-task or to the entire run? The issue says "run command" but does not clarify.
 - Should a timed-out run still produce a partial report?
+```
+
+```cadre-json
+{
+  "requirements": [
+    "Add a --timeout flag to the CLI run command",
+    "Default timeout should be 30 seconds when not specified",
+    "Display a clear error message when the timeout is exceeded"
+  ],
+  "changeType": "feature",
+  "scope": "small",
+  "affectedAreas": [
+    "src/cli/",
+    "src/executor/",
+    "tests/"
+  ],
+  "ambiguities": [
+    "Should the timeout apply per-task or to the entire run?",
+    "Should a timed-out run still produce a partial report?"
+  ]
+}
 ```

--- a/src/agents/templates/pr-composer.md
+++ b/src/agents/templates/pr-composer.md
@@ -14,9 +14,9 @@ Read all task result summaries before composing the PR. Understand the full scop
 
 ## Output Contract
 
-Return a `PRContent` object with the following fields:
+Return a `PRContent` object in a `cadre-json` fenced block. **The fence language must be `cadre-json` exactly — cadre uses this marker to parse the output; a plain `json` block will not be detected.**
 
-```json
+```cadre-json
 {
   "title": "Short, imperative-mood PR title (50 chars or fewer)",
   "body": "Full PR body in GitHub Flavored Markdown",

--- a/tests/code-reviewer-template.test.ts
+++ b/tests/code-reviewer-template.test.ts
@@ -96,8 +96,8 @@ describe('code-reviewer.md template', () => {
       expect(content).toMatch(/"verdict"/);
     });
 
-    it('should show a JSON code block example', () => {
-      expect(content).toMatch(/```json/);
+    it('should show a cadre-json code block example', () => {
+      expect(content).toMatch(/```cadre-json/);
     });
   });
 });


### PR DESCRIPTION
## Summary

Five agent templates were instructing agents to emit plain `` ```json `` fenced blocks (or no machine-readable block at all). `ResultParser` looks for `` ```cadre-json `` as the primary parse path and falls back to fragile regex parsing with a deprecation warning when that fence is absent. This PR fixes all five templates.

## Changes

### Templates updated to use `` ```cadre-json `` fence

- **`src/agents/templates/code-reviewer.md`** — changed `` ```json `` → `` ```cadre-json `` in the `## Output` section; added an explicit note that the exact fence language is required for cadre to parse the output.
- **`src/agents/templates/integration-checker.md`** — changed `` ```json `` → `` ```cadre-json ``; also removed the `summary` field from the example that is not present in the `IntegrationReport` Zod schema.
- **`src/agents/templates/pr-composer.md`** — changed `` ```json `` → `` ```cadre-json `` in the `## Output Contract` section.

### Templates updated to add mandatory cadre-json block

- **`src/agents/templates/issue-analyst.md`** — added a `## Machine-readable output (MANDATORY)` section before the example, with the `AnalysisResult` schema (`requirements`, `changeType`, `scope`, `affectedAreas`, `ambiguities`) and a complete `` ```cadre-json `` example. Human-readable prose sections are preserved.
- **`src/agents/templates/codebase-scout.md`** — added a `## Machine-readable output (MANDATORY)` section before the example, with the `ScoutReport` schema (`relevantFiles`, `dependencyMap`, `testFiles`, `estimatedChanges`) and a complete `` ```cadre-json `` example. Human-readable markdown sections are preserved.

### Test updated

- **`tests/code-reviewer-template.test.ts`** — updated assertion from `expect(content).toMatch(/\`\`\`json/)` to `expect(content).toMatch(/\`\`\`cadre-json/)`.

All field names match the Zod schemas in `src/agents/schemas/`. Pattern follows the approach established in `implementation-planner.md`.

## Testing

`npm run build` — ✅ clean  
`npx vitest run` — ✅ 1968 tests passing, 107 test files
