### PR TITLE
improve(code-reviewer): add silent-arg-omission, duplicate-test-block, and intra-PR consistency checks

### DIFF
--- a/src/agents/templates/code-reviewer.md
+++ b/src/agents/templates/code-reviewer.md
@@ -16,6 +16,8 @@ Only flag an issue as `needs-fixes` if it falls into one of these categories:
 1. **Bugs** – incorrect logic, off-by-one errors, null/undefined dereferences, broken control flow
 2. **Security vulnerabilities** – injection flaws, improper authentication/authorization, exposed secrets, unsafe deserialization
 3. **Logic errors** – misuse of APIs, incorrect assumptions about data shape, race conditions, incorrect error handling
+4. **Silent argument omission** – when a function accepts a configuration/behavioural parameter that has a fallback default (e.g. `backend = 'copilot'`, `env = 'production'`), verify that every call site in the diff passes that argument explicitly. A missing argument that silently uses a hard-coded default is a logic error; flag it as `warning`.
+5. **Duplicate test blocks** – when reviewing test files, flag `describe` or `it` blocks that share a name or cover overlapping scenarios with another block in the same file as `warning`. Duplicate test structure gives false confidence and masks missing coverage.
 
 Do **not** flag issues for:
 - Code style or formatting
@@ -23,6 +25,9 @@ Do **not** flag issues for:
 - Test coverage (unless explicitly asked)
 - Refactoring opportunities
 - Personal preferences
+
+## Intra-PR Consistency (suggestion only)
+When the diff touches multiple files that perform the same category of user-facing output (e.g. progress notices, error messages), check whether they use a consistent mechanism (e.g. both use `chalk`, or both use plain `console.log`). If they differ within the same PR, flag it as `suggestion` severity — this never affects the verdict.
 
 ## Output
 Respond with a `cadre-json` fenced block matching the `ReviewResult` structure. **The fence language must be `cadre-json` exactly — cadre uses this marker to parse the output; a plain `json` block will not be detected.**


### PR DESCRIPTION
## Summary

Sharpens the code-reviewer agent's criteria based on issues that slipped through review of PR #113.

## Changes to `src/agents/templates/code-reviewer.md`

### New `needs-fixes` criteria

**4. Silent argument omission** — when a function has a parameter with a behavioural default (e.g. `backend = 'copilot'`), the reviewer now checks every call site in the diff to ensure the argument is passed explicitly. A missing argument that silently falls back to a hard-coded default is a logic error; flagged as `warning`.

**5. Duplicate test blocks** — when reviewing test files, the reviewer now flags `describe`/`it` blocks that share a name or cover overlapping scenarios with another block in the same file as `warning`. Duplicate structure gives false confidence and can mask missing coverage.

### New "Intra-PR Consistency" section

When the diff touches multiple files that perform the same category of user-facing output (e.g. progress notices), the reviewer now checks whether they use a consistent mechanism (e.g. both `chalk`, or both plain `console.log`). Differences are flagged as `suggestion` severity — never affects the verdict.

## Motivation

PR #113's reviewer passed despite:
- `scaffoldMissingAgents` being called without the `backend` argument in `init.ts` (silent default bug)
- Two duplicate `describe('scaffoldMissingAgents helper', ...)` blocks in the test file
- Inconsistent logging style between `init.ts` (chalk) and `index.ts` (plain string)

The first two are now explicitly covered by the new criteria. The third is covered by the consistency section.