### PR TITLE
refactor: introduce RuntimeConfig type and replace CadreConfig throughout

### DIFF
--- a/src/agents/backend-factory.ts
+++ b/src/agents/backend-factory.ts
@@ -1,12 +1,12 @@
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import type { Logger } from '../logging/logger.js';
 import { type AgentBackend, CopilotBackend, ClaudeBackend } from './backend.js';
 
 /**
  * Creates and returns the appropriate agent backend based on `config.agent.backend`.
  */
-export function createAgentBackend(config: CadreConfig, logger: Logger): AgentBackend {
-  const backend = config.agent?.backend ?? 'copilot';
+export function createAgentBackend(config: RuntimeConfig, logger: Logger): AgentBackend {
+  const backend = config.agent.backend;
 
   switch (backend) {
     case 'copilot':

--- a/src/agents/backend.ts
+++ b/src/agents/backend.ts
@@ -1,6 +1,6 @@
 import { join, resolve } from 'node:path';
 import { writeFile, copyFile } from 'node:fs/promises';
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import type { AgentInvocation, AgentResult } from './types.js';
 import { spawnProcess, stripVSCodeEnv, trackProcess, type ProcessResult } from '../util/process.js';
 import { exists, ensureDir } from '../util/fs.js';
@@ -22,7 +22,7 @@ export interface AgentBackend {
 function buildEnv(
   invocation: AgentInvocation,
   worktreePath: string,
-  config: CadreConfig,
+  config: RuntimeConfig,
 ): Record<string, string | undefined> {
   let env = { ...process.env };
 
@@ -129,14 +129,14 @@ export class CopilotBackend implements AgentBackend {
   private readonly defaultModel: string | undefined;
 
   constructor(
-    private readonly config: CadreConfig,
+    private readonly config: RuntimeConfig,
     private readonly logger: Logger,
   ) {
     // Prefer config.agent.copilot settings, fall back to legacy config.copilot
-    this.cliCommand = config.agent?.copilot?.cliCommand ?? config.copilot.cliCommand;
-    this.agentDir = config.agent!.copilot.agentDir;
-    this.defaultTimeout = config.agent?.timeout ?? config.copilot.timeout;
-    this.defaultModel = config.agent?.model ?? config.copilot.model;
+    this.cliCommand = config.agent.copilot.cliCommand;
+    this.agentDir = config.agent.copilot.agentDir;
+    this.defaultTimeout = config.agent.timeout ?? config.copilot.timeout;
+    this.defaultModel = config.agent.model;
   }
 
   async init(): Promise<void> {
@@ -248,12 +248,12 @@ export class ClaudeBackend implements AgentBackend {
   private readonly defaultModel: string | undefined;
 
   constructor(
-    private readonly config: CadreConfig,
+    private readonly config: RuntimeConfig,
     private readonly logger: Logger,
   ) {
-    this.cliCommand = config.agent?.claude?.cliCommand ?? 'claude';
-    this.defaultTimeout = config.agent?.timeout ?? config.copilot.timeout;
-    this.defaultModel = config.agent?.model;
+    this.cliCommand = config.agent.claude.cliCommand || 'claude';
+    this.defaultTimeout = config.agent.timeout ?? config.copilot.timeout;
+    this.defaultModel = config.agent.model;
   }
 
   async init(): Promise<void> {

--- a/src/cli/agents.ts
+++ b/src/cli/agents.ts
@@ -24,11 +24,11 @@ function resolveAgentDir(
   config: Awaited<ReturnType<typeof loadConfig>>,
   overrideBackend?: string,
 ): string {
-  const backend = overrideBackend ?? config.agent?.backend ?? 'copilot';
+  const backend = overrideBackend ?? config.agent.backend;
   if (backend === 'claude') {
-    return config.agent?.claude.agentDir ?? '.claude/agents';
+    return config.agent.claude.agentDir;
   }
-  return config.agent!.copilot.agentDir;
+  return config.agent.copilot.agentDir;
 }
 
 /**

--- a/src/core/agent-launcher.ts
+++ b/src/core/agent-launcher.ts
@@ -1,5 +1,5 @@
 import { resolve, join } from 'node:path';
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import type { AgentInvocation, AgentResult } from '../agents/types.js';
 import { AGENT_DEFINITIONS } from '../agents/types.js';
 import { statOrNull } from '../util/fs.js';
@@ -14,7 +14,7 @@ export class AgentLauncher {
   private readonly backend: AgentBackend;
 
   constructor(
-    private readonly config: CadreConfig,
+    private readonly config: RuntimeConfig,
     private readonly logger: Logger,
   ) {
     this.backend = createAgentBackend(config, logger);

--- a/src/core/fleet-orchestrator.ts
+++ b/src/core/fleet-orchestrator.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import pLimit from 'p-limit';
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import type { IssueDetail, PullRequestInfo } from '../platform/provider.js';
 import type { PlatformProvider } from '../platform/provider.js';
 import { WorktreeManager, RemoteBranchMissingError } from '../git/worktree.js';
@@ -43,7 +43,7 @@ export class FleetOrchestrator {
   private fleetBudgetExceeded = false;
 
   constructor(
-    private readonly config: CadreConfig,
+    private readonly config: RuntimeConfig,
     private readonly issues: IssueDetail[],
     private readonly worktreeManager: WorktreeManager,
     private readonly launcher: AgentLauncher,

--- a/src/core/issue-notifier.ts
+++ b/src/core/issue-notifier.ts
@@ -1,4 +1,4 @@
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import type { PlatformProvider } from '../platform/provider.js';
 import type { Logger } from '../logging/logger.js';
 import type { CadreEvent } from '../logging/events.js';
@@ -12,14 +12,14 @@ import type { NotificationProvider } from '../notifications/types.js';
  * and receive events through a single dispatch channel.
  */
 export class IssueNotifier implements NotificationProvider {
-  private readonly updates: CadreConfig['issueUpdates'];
+  private readonly updates: RuntimeConfig['issueUpdates'];
 
   constructor(
-    private readonly config: CadreConfig,
+    private readonly config: RuntimeConfig,
     private readonly platform: PlatformProvider,
     private readonly logger: Logger,
   ) {
-    this.updates = config.issueUpdates ?? { enabled: false, onStart: false, onPhaseComplete: false, onComplete: false, onFailed: false, onBudgetWarning: false };
+    this.updates = config.issueUpdates;
   }
 
   /** Post a comment when an issue pipeline starts. */

--- a/src/core/issue-orchestrator.ts
+++ b/src/core/issue-orchestrator.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import type { PhaseResult } from '../agents/types.js';
 import type { IssueDetail, PullRequestInfo, PlatformProvider } from '../platform/provider.js';
 import type { WorktreeInfo } from '../git/worktree.js';
@@ -79,7 +79,7 @@ export class IssueOrchestrator {
   private createdPR: PullRequestInfo | undefined;
 
   constructor(
-    private readonly config: CadreConfig,
+    private readonly config: RuntimeConfig,
     private readonly issue: IssueDetail,
     private readonly worktree: WorktreeInfo,
     private readonly checkpoint: CheckpointManager,

--- a/src/core/phase-executor.ts
+++ b/src/core/phase-executor.ts
@@ -1,4 +1,4 @@
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import type { IssueDetail, PlatformProvider } from '../platform/provider.js';
 import type { WorktreeInfo } from '../git/worktree.js';
 import type { CheckpointManager } from './checkpoint.js';
@@ -42,7 +42,7 @@ export type PhaseCallbacks = {
 export type PhaseContext = {
   issue: IssueDetail;
   worktree: WorktreeInfo;
-  config: CadreConfig;
+  config: RuntimeConfig;
   platform: PlatformProvider;
   services: PhaseServices;
   io: PhaseIO;

--- a/src/core/review-response-orchestrator.ts
+++ b/src/core/review-response-orchestrator.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import { mkdir, writeFile } from 'node:fs/promises';
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import type { IssueDetail, PullRequestInfo } from '../platform/provider.js';
 import type { PlatformProvider } from '../platform/provider.js';
 import { WorktreeManager } from '../git/worktree.js';
@@ -45,7 +45,7 @@ export class ReviewResponseOrchestrator {
   private readonly cadreDir: string;
 
   constructor(
-    private readonly config: CadreConfig,
+    private readonly config: RuntimeConfig,
     private readonly worktreeManager: WorktreeManager,
     private readonly launcher: AgentLauncher,
     private readonly platform: PlatformProvider,
@@ -53,8 +53,7 @@ export class ReviewResponseOrchestrator {
     private readonly notifications: NotificationManager = new NotificationManager(),
   ) {
     this.contextBuilder = new ContextBuilder(config, logger);
-    // stateDir is resolved by loadConfig; fall back to repoPath/.cadre for unit-test compat
-    this.cadreDir = config.stateDir!;
+    this.cadreDir = config.stateDir;
   }
 
   /**

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import { WorktreeManager } from '../git/worktree.js';
 import { AgentLauncher } from './agent-launcher.js';
 import { FleetOrchestrator, type FleetResult } from './fleet-orchestrator.js';
@@ -36,15 +36,15 @@ export class CadreRuntime {
   private activeIssueNumbers: number[] = [];
 
   private get agentDir(): string {
-    return this.config.agent!.copilot.agentDir;
+    return this.config.agent.copilot.agentDir;
   }
 
   private get backend(): string {
-    return this.config.agent?.backend ?? 'copilot';
+    return this.config.agent.backend;
   }
 
-  constructor(private readonly config: CadreConfig) {
-    this.cadreDir = config.stateDir!;
+  constructor(private readonly config: RuntimeConfig) {
+    this.cadreDir = config.stateDir;
     this.logger = new Logger({
       source: 'fleet',
       logDir: join(this.cadreDir, 'logs'),
@@ -123,7 +123,7 @@ export class CadreRuntime {
     // 3. Initialize components
     const worktreeManager = new WorktreeManager(
       this.config.repoPath,
-      this.config.worktreeRoot ?? join(this.cadreDir, 'worktrees'),
+      this.config.worktreeRoot,
       this.config.baseBranch,
       this.config.branchTemplate,
       this.logger,
@@ -285,7 +285,7 @@ export class CadreRuntime {
   async listWorktrees(): Promise<void> {
     const worktreeManager = new WorktreeManager(
       this.config.repoPath,
-      this.config.worktreeRoot ?? join(this.cadreDir, 'worktrees'),
+      this.config.worktreeRoot,
       this.config.baseBranch,
       this.config.branchTemplate,
       this.logger,
@@ -316,7 +316,7 @@ export class CadreRuntime {
   async pruneWorktrees(): Promise<void> {
     const worktreeManager = new WorktreeManager(
       this.config.repoPath,
-      this.config.worktreeRoot ?? join(this.cadreDir, 'worktrees'),
+      this.config.worktreeRoot,
       this.config.baseBranch,
       this.config.branchTemplate,
       this.logger,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,11 +47,11 @@ program
       }
 
       if (!opts.skipAgentValidation) {
-        const backend = config.agent?.backend ?? 'copilot';
+        const backend = config.agent.backend;
         const agentDir =
           backend === 'claude'
-            ? (config.agent?.claude?.agentDir ?? '.claude/agents')
-            : (config.agent?.copilot?.agentDir ?? config.copilot.agentDir);
+            ? config.agent.claude.agentDir
+            : config.agent.copilot.agentDir;
         let issues = await AgentLauncher.validateAgentFiles(agentDir);
 
         if (issues.length > 0) {

--- a/src/notifications/manager.ts
+++ b/src/notifications/manager.ts
@@ -1,5 +1,6 @@
 import type { CadreEvent } from '../logging/events.js';
-import type { CadreConfig, NotificationsConfig } from '../config/schema.js';
+import type { NotificationsConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import type { NotificationProvider } from './types.js';
 import { WebhookProvider } from './webhook-provider.js';
 import { SlackProvider } from './slack-provider.js';
@@ -47,6 +48,6 @@ export class NotificationManager {
   }
 }
 
-export function createNotificationManager(config: CadreConfig): NotificationManager {
+export function createNotificationManager(config: RuntimeConfig): NotificationManager {
   return new NotificationManager(config.notifications);
 }

--- a/src/platform/factory.ts
+++ b/src/platform/factory.ts
@@ -1,4 +1,4 @@
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import type { PlatformProvider } from './provider.js';
 import { GitHubProvider } from './github-provider.js';
 import { AzureDevOpsProvider } from './azure-devops-provider.js';
@@ -70,7 +70,7 @@ function resolveGitHubAuthEnv(
  * Defaults to GitHub when `platform` is omitted for backward compatibility.
  */
 export function createPlatformProvider(
-  config: CadreConfig,
+  config: RuntimeConfig,
   logger: Logger,
 ): PlatformProvider {
   const platform = config.platform ?? 'github';

--- a/src/reporting/report-writer.ts
+++ b/src/reporting/report-writer.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path';
 import { readdir } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import type { FleetResult } from '../core/fleet-orchestrator.js';
 import type { IssueDetail } from '../platform/provider.js';
 import { CostEstimator } from '../budget/cost-estimator.js';
@@ -11,7 +11,7 @@ import type { RunReport, RunIssueSummary, RunPhaseSummary, RunTotals } from './t
 
 export class ReportWriter {
   constructor(
-    private readonly config: CadreConfig,
+    private readonly config: RuntimeConfig,
     private readonly costEstimator: CostEstimator,
   ) {}
 

--- a/src/validation/agent-backend-validator.ts
+++ b/src/validation/agent-backend-validator.ts
@@ -1,17 +1,17 @@
 import { exec } from '../util/process.js';
 import { exists } from '../util/fs.js';
 import type { PreRunValidator, ValidationResult } from './types.js';
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 
 export const agentBackendValidator: PreRunValidator = {
   name: 'agent-backend-validator',
 
-  async validate(config: CadreConfig): Promise<ValidationResult> {
+  async validate(config: RuntimeConfig): Promise<ValidationResult> {
     const errors: string[] = [];
     const warnings: string[] = [];
 
     // loadConfig always synthesizes config.agent before returning
-    const agent = config.agent!;
+    const agent = config.agent;
     const isClaudeBackend = agent.backend === 'claude';
 
     const cliCommand = isClaudeBackend ? agent.claude.cliCommand : agent.copilot.cliCommand;

--- a/src/validation/command-validator.ts
+++ b/src/validation/command-validator.ts
@@ -1,11 +1,11 @@
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import { exec } from '../util/process.js';
 import type { PreRunValidator, ValidationResult } from './types.js';
 
 export const commandValidator: PreRunValidator = {
   name: 'command',
 
-  async validate(config: CadreConfig): Promise<ValidationResult> {
+  async validate(config: RuntimeConfig): Promise<ValidationResult> {
     const errors: string[] = [];
     const warnings: string[] = [];
 

--- a/src/validation/disk-validator.ts
+++ b/src/validation/disk-validator.ts
@@ -1,5 +1,4 @@
-import { join } from 'node:path';
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import { statOrNull } from '../util/fs.js';
 import { exec } from '../util/process.js';
 import type { PreRunValidator, ValidationResult } from './types.js';
@@ -7,7 +6,7 @@ import type { PreRunValidator, ValidationResult } from './types.js';
 export const diskValidator: PreRunValidator = {
   name: 'disk',
 
-  async validate(config: CadreConfig): Promise<ValidationResult> {
+  async validate(config: RuntimeConfig): Promise<ValidationResult> {
     const errors: string[] = [];
     const warnings: string[] = [];
 
@@ -27,11 +26,11 @@ export const diskValidator: PreRunValidator = {
       return { passed: false, errors: [`Could not parse repo size from du output: ${duResult.stdout.trim()}`], warnings: [] };
     }
 
-    const maxParallelIssues = config.options?.maxParallelIssues ?? 3;
+    const maxParallelIssues = config.options.maxParallelIssues;
     const estimateKb = repoSizeKb * maxParallelIssues;
 
-    // Use worktreeRoot for df; fall back to repoPath if not set
-    const worktreeRoot = config.worktreeRoot ?? join(config.repoPath, '.cadre', 'worktrees');
+    // Use worktreeRoot for df (always set by loadConfig)
+    const worktreeRoot = config.worktreeRoot;
 
     // Get available disk space in KB using df -k
     const dfResult = await exec('df', ['-k', worktreeRoot]);

--- a/src/validation/git-validator.ts
+++ b/src/validation/git-validator.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import { exists } from '../util/fs.js';
 import { exec } from '../util/process.js';
 import type { PreRunValidator, ValidationResult } from './types.js';
@@ -7,7 +7,7 @@ import type { PreRunValidator, ValidationResult } from './types.js';
 export const gitValidator: PreRunValidator = {
   name: 'git',
 
-  async validate(config: CadreConfig): Promise<ValidationResult> {
+  async validate(config: RuntimeConfig): Promise<ValidationResult> {
     const errors: string[] = [];
     const warnings: string[] = [];
     const cwd = config.repoPath;

--- a/src/validation/platform-validator.ts
+++ b/src/validation/platform-validator.ts
@@ -1,6 +1,6 @@
 import { exec } from '../util/process.js';
 import type { PreRunValidator, ValidationResult } from './types.js';
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 
 /** Expand ${ENV_VAR} placeholders using process.env. Returns empty string if any variable is unset/empty. */
 function expandEnvVar(value: string): string {
@@ -10,7 +10,7 @@ function expandEnvVar(value: string): string {
 export const platformValidator: PreRunValidator = {
   name: 'platform',
 
-  async validate(config: CadreConfig): Promise<ValidationResult> {
+  async validate(config: RuntimeConfig): Promise<ValidationResult> {
     const errors: string[] = [];
     const warnings: string[] = [];
 

--- a/src/validation/suite.ts
+++ b/src/validation/suite.ts
@@ -1,10 +1,10 @@
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 import type { PreRunValidator } from './types.js';
 
 export class PreRunValidationSuite {
   constructor(private readonly validators: PreRunValidator[]) {}
 
-  async run(config: CadreConfig): Promise<boolean> {
+  async run(config: RuntimeConfig): Promise<boolean> {
     const results = await Promise.allSettled(
       this.validators.map((v) => v.validate(config).then((r) => ({ validator: v, result: r }))),
     );

--- a/src/validation/types.ts
+++ b/src/validation/types.ts
@@ -1,4 +1,4 @@
-import type { CadreConfig } from '../config/schema.js';
+import type { RuntimeConfig } from '../config/loader.js';
 
 export interface ValidationResult {
   passed: boolean;
@@ -8,5 +8,5 @@ export interface ValidationResult {
 
 export interface PreRunValidator {
   name: string;
-  validate(config: CadreConfig): Promise<ValidationResult>;
+  validate(config: RuntimeConfig): Promise<ValidationResult>;
 }

--- a/tests/agent-backend-factory.test.ts
+++ b/tests/agent-backend-factory.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 vi.mock('../src/util/process.js', () => ({
   spawnProcess: vi.fn(),
@@ -19,18 +19,8 @@ vi.mock('node:fs/promises', () => ({
 import { CopilotBackend, ClaudeBackend } from '../src/agents/backend.js';
 import { createAgentBackend } from '../src/agents/backend-factory.js';
 
-function makeConfig(backend: 'copilot' | 'claude' | string = 'copilot'): CadreConfig {
-  return {
-    projectName: 'test-project',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
-    copilot: {
-      cliCommand: 'copilot',
-      agentDir: '.github/agents',
-      timeout: 300_000,
-    },
+function makeConfig(backend: 'copilot' | 'claude' | string = 'copilot') {
+  return makeRuntimeConfig({
     agent: {
       backend: backend as 'copilot' | 'claude',
       copilot: {
@@ -39,13 +29,10 @@ function makeConfig(backend: 'copilot' | 'claude' | string = 'copilot'): CadreCo
       },
       claude: {
         cliCommand: 'claude',
+        agentDir: '/tmp/.cadre/test-project/agents',
       },
     },
-    environment: {
-      inheritShellPath: true,
-      extraPath: [],
-    },
-  } as unknown as CadreConfig;
+  });
 }
 
 function makeLogger() {

--- a/tests/agent-backend-validator.test.ts
+++ b/tests/agent-backend-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 vi.mock('../src/util/process.js', () => ({
   exec: vi.fn(),
@@ -13,47 +13,38 @@ import { exec } from '../src/util/process.js';
 import { exists } from '../src/util/fs.js';
 import { agentBackendValidator } from '../src/validation/agent-backend-validator.js';
 
-const makeConfig = (overrides: Partial<{ cliCommand: string; agentDir: string }> = {}): CadreConfig =>
-  ({
-    projectName: 'test-project',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
+const makeConfig = (overrides: Partial<{ cliCommand: string; agentDir: string }> = {}) =>
+  makeRuntimeConfig({
     copilot: {
       cliCommand: overrides.cliCommand ?? 'copilot',
+      model: 'claude-sonnet-4.6',
       agentDir: overrides.agentDir ?? '/tmp/agents',
-      timeout: 300000,
+      timeout: 300_000,
     },
-    // Mirrors what loadConfig always synthesizes
     agent: {
       backend: 'copilot' as const,
       copilot: { cliCommand: overrides.cliCommand ?? 'copilot', agentDir: overrides.agentDir ?? '/tmp/agents' },
-      claude: { cliCommand: 'claude', agentDir: '.claude/agents' },
+      claude: { cliCommand: 'claude', agentDir: '/tmp/.cadre/test-project/agents' },
     },
-  }) as unknown as CadreConfig;
+  });
 
 const makeConfigWithAgent = (
   backend: 'copilot' | 'claude',
   overrides: Partial<{ copilotCli: string; claudeCli: string; agentDir: string }> = {},
-): CadreConfig =>
-  ({
-    projectName: 'test-project',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
+) =>
+  makeRuntimeConfig({
     copilot: {
       cliCommand: 'copilot',
+      model: 'claude-sonnet-4.6',
       agentDir: overrides.agentDir ?? '/tmp/agents',
-      timeout: 300000,
+      timeout: 300_000,
     },
     agent: {
       backend,
       copilot: { cliCommand: overrides.copilotCli ?? 'copilot', agentDir: '/tmp/agents' },
       claude: { cliCommand: overrides.claudeCli ?? 'claude', agentDir: overrides.agentDir ?? '/tmp/agents' },
     },
-  }) as unknown as CadreConfig;
+  });
 
 describe('agentBackendValidator', () => {
   beforeEach(() => {

--- a/tests/agent-backend.test.ts
+++ b/tests/agent-backend.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 import type { AgentInvocation } from '../src/agents/types.js';
 
 vi.mock('../src/util/process.js', () => ({
@@ -59,15 +59,11 @@ function makeConfig(overrides: Partial<{
   timeout: number;
   extraPath: string[];
   claudeCli: string;
-}> = {}): CadreConfig {
-  return {
-    projectName: 'test-project',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
+}> = {}) {
+  return makeRuntimeConfig({
     copilot: {
       cliCommand: overrides.cliCommand ?? 'copilot',
+      model: 'claude-sonnet-4.6',
       agentDir: overrides.agentDir ?? '.github/agents',
       timeout: overrides.timeout ?? 300_000,
     },
@@ -81,13 +77,14 @@ function makeConfig(overrides: Partial<{
       },
       claude: {
         cliCommand: overrides.claudeCli ?? 'claude',
+        agentDir: overrides.agentDir ?? '.github/agents',
       },
     },
     environment: {
       inheritShellPath: true,
       extraPath: overrides.extraPath ?? [],
     },
-  } as unknown as CadreConfig;
+  });
 }
 
 function makeInvocation(overrides: Partial<AgentInvocation> = {}): AgentInvocation {
@@ -124,7 +121,7 @@ describe('AgentBackend interface', () => {
 
 describe('CopilotBackend', () => {
   let logger: ReturnType<typeof vi.fn>;
-  let config: CadreConfig;
+  let config: ReturnType<typeof makeConfig>;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -378,7 +375,7 @@ describe('CopilotBackend', () => {
 
 describe('ClaudeBackend', () => {
   let logger: ReturnType<typeof vi.fn>;
-  let config: CadreConfig;
+  let config: ReturnType<typeof makeConfig>;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -565,19 +562,13 @@ describe('ClaudeBackend', () => {
   });
 
   it('should default to "claude" CLI when config.agent.claude.cliCommand is absent', async () => {
-    const legacyConfig = {
-      projectName: 'test',
-      repository: 'owner/repo',
-      repoPath: '/tmp/repo',
-      baseBranch: 'main',
-      issues: { ids: [1] },
-      copilot: {
-        cliCommand: 'copilot',
-        agentDir: '.github/agents',
-        timeout: 300_000,
+    const legacyConfig = makeRuntimeConfig({
+      agent: {
+        backend: 'copilot',
+        copilot: { cliCommand: 'copilot', agentDir: '.github/agents' },
+        claude: { cliCommand: '', agentDir: '.github/agents' },
       },
-      environment: { inheritShellPath: true, extraPath: [] },
-    } as unknown as CadreConfig;
+    });
 
     const backend = new ClaudeBackend(legacyConfig, logger as never);
     setupSpawn(makeProcessResult());
@@ -589,7 +580,7 @@ describe('ClaudeBackend', () => {
 
 describe('parseTokenUsage (via invoke)', () => {
   let logger: ReturnType<typeof vi.fn>;
-  let config: CadreConfig;
+  let config: ReturnType<typeof makeConfig>;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/tests/backend-factory.test.ts
+++ b/tests/backend-factory.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 vi.mock('../src/util/process.js', () => ({
   spawnProcess: vi.fn(),
@@ -19,25 +19,14 @@ vi.mock('node:fs/promises', () => ({
 import { CopilotBackend, ClaudeBackend } from '../src/agents/backend.js';
 import { createAgentBackend } from '../src/agents/backend-factory.js';
 
-function makeConfig(backend: string = 'copilot'): CadreConfig {
-  return {
-    projectName: 'test-project',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
-    copilot: {
-      cliCommand: 'copilot',
-      agentDir: '.github/agents',
-      timeout: 300_000,
-    },
+function makeConfig(backend: string = 'copilot') {
+  return makeRuntimeConfig({
     agent: {
       backend: backend as 'copilot' | 'claude',
       copilot: { cliCommand: 'copilot', agentDir: '.github/agents' },
-      claude: { cliCommand: 'claude' },
+      claude: { cliCommand: 'claude', agentDir: '/tmp/.cadre/test-project/agents' },
     },
-    environment: { inheritShellPath: true, extraPath: [] },
-  } as unknown as CadreConfig;
+  });
 }
 
 function makeLogger() {

--- a/tests/cli-index.test.ts
+++ b/tests/cli-index.test.ts
@@ -4,7 +4,11 @@ import { registerAgentsCommand } from '../src/cli/agents.js';
 
 vi.mock('../src/config/loader.js', () => ({
   loadConfig: vi.fn().mockResolvedValue({
-    agent: { backend: 'copilot' },
+    agent: {
+      backend: 'copilot',
+      copilot: { agentDir: '/fake/agents' },
+      claude: { agentDir: '/fake/agents' },
+    },
     copilot: { agentDir: '/fake/agents' },
   }),
   applyOverrides: vi.fn((c: unknown) => c),
@@ -277,7 +281,11 @@ describe('cadre run autoscaffold behavior', () => {
     vi.doMock('../src/config/loader.js', () => ({
       loadConfig: vi.fn().mockResolvedValue({
         copilot: { agentDir: '/agent-dir' },
-        agent: { backend: 'copilot' },
+        agent: {
+          backend: 'copilot',
+          copilot: { agentDir: '/agent-dir' },
+          claude: { agentDir: '/agent-dir' },
+        },
       }),
       applyOverrides: vi.fn((c: unknown) => c),
     }));

--- a/tests/command-validator.test.ts
+++ b/tests/command-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 vi.mock('../src/util/process.js', () => ({
   exec: vi.fn(),
@@ -10,21 +10,15 @@ import { commandValidator } from '../src/validation/command-validator.js';
 
 const makeConfig = (
   overrides: Partial<{ build: string; test: string; install: string; lint: string }> = {},
-): CadreConfig =>
-  ({
-    projectName: 'test-project',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
-    copilot: { cliCommand: 'copilot', agentDir: '.github/agents', timeout: 300000 },
+): ReturnType<typeof makeRuntimeConfig> =>
+  makeRuntimeConfig({
     commands: {
       build: overrides.build ?? 'npm run build',
       test: overrides.test ?? 'npx vitest run',
       ...(overrides.install !== undefined ? { install: overrides.install } : {}),
       ...(overrides.lint !== undefined ? { lint: overrides.lint } : {}),
     },
-  }) as unknown as CadreConfig;
+  });
 
 const okResult = { exitCode: 0, stdout: '', stderr: '', signal: null, timedOut: false } as const;
 const failResult = { exitCode: 1, stdout: '', stderr: '', signal: null, timedOut: false } as const;

--- a/tests/disk-validator.test.ts
+++ b/tests/disk-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 vi.mock('../src/util/process.js', () => ({
   exec: vi.fn(),
@@ -15,19 +15,14 @@ import { diskValidator } from '../src/validation/disk-validator.js';
 
 const makeConfig = (
   overrides: Partial<{ repoPath: string; worktreeRoot: string; maxParallelIssues: number }> = {},
-): CadreConfig =>
-  ({
-    projectName: 'test-project',
-    repository: 'owner/repo',
+) =>
+  makeRuntimeConfig({
     repoPath: overrides.repoPath ?? '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
-    copilot: { cliCommand: 'copilot', agentDir: '.github/agents', timeout: 300000 },
     ...(overrides.worktreeRoot !== undefined ? { worktreeRoot: overrides.worktreeRoot } : {}),
     ...(overrides.maxParallelIssues !== undefined
-      ? { options: { maxParallelIssues: overrides.maxParallelIssues } }
+      ? { options: { maxParallelIssues: overrides.maxParallelIssues, maxParallelAgents: 3, maxRetriesPerTask: 3, dryRun: false, resume: false, invocationDelayMs: 0, buildVerification: true, testVerification: true, perTaskBuildCheck: true, maxBuildFixRounds: 2, skipValidation: false, maxIntegrationFixRounds: 1, ambiguityThreshold: 5, haltOnAmbiguity: false, respondToReviews: false } }
       : {}),
-  }) as unknown as CadreConfig;
+  });
 
 const okResult = { exitCode: 0, stdout: '', stderr: '', signal: null, timedOut: false } as const;
 const failResult = { exitCode: 1, stdout: '', stderr: 'error', signal: null, timedOut: false } as const;
@@ -287,14 +282,15 @@ describe('diskValidator', () => {
       expect(exec).toHaveBeenCalledWith('df', ['-k', '/custom/worktrees']);
     });
 
-    it('should call df on default worktreeRoot path when worktreeRoot is not configured', async () => {
+    it('should call df on the configured worktreeRoot (always set by loadConfig)', async () => {
       vi.mocked(exec)
         .mockResolvedValueOnce({ ...okResult, stdout: makeDuOutput(50000) })
         .mockResolvedValueOnce({ ...okResult, stdout: makeDfOutput(50000 * 3 * 2) });
 
-      await diskValidator.validate(makeConfig({ repoPath: '/tmp/myrepo' }));
+      const config = makeConfig({ repoPath: '/tmp/myrepo' });
+      await diskValidator.validate(config);
 
-      expect(exec).toHaveBeenCalledWith('df', ['-k', '/tmp/myrepo/.cadre/worktrees']);
+      expect(exec).toHaveBeenCalledWith('df', ['-k', config.worktreeRoot]);
     });
 
     it('should call du on repoPath', async () => {

--- a/tests/fleet-orchestrator.test.ts
+++ b/tests/fleet-orchestrator.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { FleetOrchestrator } from '../src/core/fleet-orchestrator.js';
 import { NotificationManager } from '../src/notifications/manager.js';
 import { RemoteBranchMissingError } from '../src/git/worktree.js';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
+import type { RuntimeConfig } from '../src/config/loader.js';
 import type { IssueDetail } from '../src/platform/provider.js';
 
 // Mock heavy dependencies to keep tests fast and isolated
@@ -86,13 +87,8 @@ vi.mock('../src/logging/logger.js', () => ({
   Logger: vi.fn(),
 }));
 
-function makeConfig(overrides: Partial<CadreConfig['options']> = {}): CadreConfig {
-  return {
-    projectName: 'test-project',
-    platform: 'github',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
+function makeConfig(overrides: Partial<RuntimeConfig['options']> = {}) {
+  return makeRuntimeConfig({
     branchTemplate: 'cadre/issue-{issue}',
     issues: { ids: [1] },
     commits: { conventional: true, sign: false, commitPerPhase: true, squashBeforePR: false },
@@ -106,12 +102,16 @@ function makeConfig(overrides: Partial<CadreConfig['options']> = {}): CadreConfi
       invocationDelayMs: 0,
       buildVerification: false,
       testVerification: false,
+      perTaskBuildCheck: true,
+      maxBuildFixRounds: 2,
+      skipValidation: false,
+      maxIntegrationFixRounds: 1,
+      ambiguityThreshold: 5,
+      haltOnAmbiguity: false,
+      respondToReviews: false,
       ...overrides,
     },
-    commands: {},
-    copilot: { cliCommand: 'copilot', model: 'claude-sonnet-4', agentDir: '.github/agents', timeout: 300000, costOverrides: {} },
-    notifications: { enabled: false, providers: [] },
-  } as unknown as CadreConfig;
+  });
 }
 
 function makeIssue(number = 1): IssueDetail {

--- a/tests/git-validator.test.ts
+++ b/tests/git-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 vi.mock('../src/util/process.js', () => ({
   exec: vi.fn(),
@@ -13,15 +13,11 @@ import { exec } from '../src/util/process.js';
 import { exists } from '../src/util/fs.js';
 import { gitValidator } from '../src/validation/git-validator.js';
 
-const makeConfig = (overrides: Partial<{ repoPath: string; baseBranch: string }> = {}): CadreConfig =>
-  ({
-    projectName: 'test-project',
-    repository: 'owner/repo',
+const makeConfig = (overrides: Partial<{ repoPath: string; baseBranch: string }> = {}) =>
+  makeRuntimeConfig({
     repoPath: overrides.repoPath ?? '/tmp/repo',
     baseBranch: overrides.baseBranch ?? 'main',
-    issues: { ids: [1] },
-    copilot: { cliCommand: 'copilot', agentDir: '.github/agents', timeout: 300000 },
-  }) as unknown as CadreConfig;
+  });
 
 const okResult = { exitCode: 0, stdout: '', stderr: '', signal: null, timedOut: false } as const;
 const failResult = { exitCode: 1, stdout: '', stderr: '', signal: null, timedOut: false } as const;

--- a/tests/helpers/make-runtime-config.ts
+++ b/tests/helpers/make-runtime-config.ts
@@ -1,0 +1,70 @@
+import type { RuntimeConfig } from '../../src/config/loader.js';
+
+export function makeRuntimeConfig(overrides: Partial<RuntimeConfig> = {}): RuntimeConfig {
+  return {
+    projectName: 'test-project',
+    platform: 'github',
+    repository: 'owner/repo',
+    repoPath: '/tmp/test-repo',
+    stateDir: '/tmp/.cadre/test-project',
+    worktreeRoot: '/tmp/.cadre/test-project/worktrees',
+    baseBranch: 'main',
+    branchTemplate: 'cadre/issue-{issue}',
+    issues: { ids: [1] },
+    commits: { conventional: true, sign: false, commitPerPhase: true, squashBeforePR: false },
+    pullRequest: {
+      autoCreate: true,
+      draft: true,
+      labels: ['cadre-generated'],
+      reviewers: [],
+      linkIssue: true,
+    },
+    options: {
+      maxParallelIssues: 3,
+      maxParallelAgents: 3,
+      maxRetriesPerTask: 3,
+      dryRun: false,
+      resume: false,
+      invocationDelayMs: 0,
+      buildVerification: true,
+      testVerification: true,
+      perTaskBuildCheck: true,
+      maxBuildFixRounds: 2,
+      skipValidation: false,
+      maxIntegrationFixRounds: 1,
+      ambiguityThreshold: 5,
+      haltOnAmbiguity: false,
+      respondToReviews: false,
+    },
+    commands: {},
+    copilot: {
+      cliCommand: 'copilot',
+      model: 'claude-sonnet-4.6',
+      agentDir: '/tmp/.cadre/test-project/agents',
+      timeout: 300_000,
+    },
+    environment: { inheritShellPath: true, extraPath: [] },
+    agent: {
+      backend: 'copilot',
+      copilot: {
+        cliCommand: 'copilot',
+        agentDir: '/tmp/.cadre/test-project/agents',
+      },
+      claude: {
+        cliCommand: 'claude',
+        agentDir: '/tmp/.cadre/test-project/agents',
+      },
+    },
+    issueUpdates: {
+      enabled: true,
+      onStart: true,
+      onPhaseComplete: false,
+      onComplete: true,
+      onFailed: true,
+      onBudgetWarning: true,
+    },
+    notifications: { enabled: false, providers: [] },
+    reviewResponse: { autoReplyOnResolved: false },
+    ...overrides,
+  } as RuntimeConfig;
+}

--- a/tests/issue-notifier.test.ts
+++ b/tests/issue-notifier.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { IssueNotifier } from '../src/core/issue-notifier.js';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
+import type { RuntimeConfig } from '../src/config/loader.js';
 import type { PlatformProvider } from '../src/platform/provider.js';
 import type { Logger } from '../src/logging/logger.js';
 import type { CadreEvent } from '../src/logging/events.js';
@@ -20,17 +21,11 @@ function makeMockPlatform(): PlatformProvider {
   } as unknown as PlatformProvider;
 }
 
-function makeConfig(issueUpdates: Partial<CadreConfig['issueUpdates']> = {}): CadreConfig {
-  return {
-    projectName: 'test',
-    repository: 'owner/repo',
-    platform: 'github',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
+function makeConfig(issueUpdates: Partial<RuntimeConfig['issueUpdates']> = {}) {
+  return makeRuntimeConfig({
     branchTemplate: 'cadre/issue-{issue}',
     issues: { ids: [1] },
-    commits: { signOff: false },
-    agents: { backend: 'claude', model: 'claude-sonnet-4-5' },
+    commits: { conventional: true, sign: false, commitPerPhase: true, squashBeforePR: false },
     issueUpdates: {
       enabled: true,
       onStart: true,
@@ -40,7 +35,7 @@ function makeConfig(issueUpdates: Partial<CadreConfig['issueUpdates']> = {}): Ca
       onBudgetWarning: true,
       ...issueUpdates,
     },
-  } as unknown as CadreConfig;
+  });
 }
 
 describe('IssueNotifier', () => {

--- a/tests/issue-orchestrator-ambiguity.test.ts
+++ b/tests/issue-orchestrator-ambiguity.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { IssueOrchestrator } from '../src/core/issue-orchestrator.js';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 import type { CheckpointManager } from '../src/core/checkpoint.js';
 import type { AgentLauncher } from '../src/core/agent-launcher.js';
 import type { PlatformProvider, IssueDetail } from '../src/platform/provider.js';
@@ -152,13 +152,9 @@ function buildAnalysisMd(ambiguities: string[]): string {
   ].join('\n');
 }
 
-function makeConfig(overrides: Record<string, unknown> = {}): CadreConfig {
-  return {
+function makeConfig(overrides: Record<string, unknown> = {}) {
+  return makeRuntimeConfig({
     projectName: 'test',
-    repository: 'owner/repo',
-    platform: 'github',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
     branchTemplate: 'cadre/issue-{issue}',
     issues: { ids: [42] },
     commits: {
@@ -185,13 +181,15 @@ function makeConfig(overrides: Record<string, unknown> = {}): CadreConfig {
       testVerification: false,
       ambiguityThreshold: 2,
       haltOnAmbiguity: false,
-      tokenBudget: null,
-      ...overrides,
-    },
-    commands: {},
+      perTaskBuildCheck: true,
+      maxBuildFixRounds: 2,
+      skipValidation: false,
+      maxIntegrationFixRounds: 1,
+      respondToReviews: false,
+      ...overrides as Partial<Record<string, unknown>>,
+    } as any,
     copilot: { cliCommand: 'copilot', agentDir: '.agents', timeout: 300000, model: 'claude-sonnet-4.6' },
-    environment: { inheritShellPath: true, extraPath: [] },
-  } as unknown as CadreConfig;
+  });
 }
 
 function makeIssue(): IssueDetail {

--- a/tests/issue-orchestrator-zod-retry.test.ts
+++ b/tests/issue-orchestrator-zod-retry.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ZodError } from 'zod';
 import { IssueOrchestrator } from '../src/core/issue-orchestrator.js';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 import type { CheckpointManager } from '../src/core/checkpoint.js';
 import type { AgentLauncher } from '../src/core/agent-launcher.js';
 import type { PlatformProvider, IssueDetail } from '../src/platform/provider.js';
@@ -189,13 +189,9 @@ vi.mock('node:fs/promises', () => ({
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function makeConfig(): CadreConfig {
-  return {
+function makeConfig() {
+  return makeRuntimeConfig({
     projectName: 'test',
-    repository: 'owner/repo',
-    platform: 'github',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
     branchTemplate: 'cadre/issue-{issue}',
     issues: { ids: [42] },
     commits: {
@@ -220,11 +216,16 @@ function makeConfig(): CadreConfig {
       invocationDelayMs: 0,
       buildVerification: false,
       testVerification: false,
+      perTaskBuildCheck: true,
+      maxBuildFixRounds: 2,
+      skipValidation: false,
+      maxIntegrationFixRounds: 1,
+      ambiguityThreshold: 5,
+      haltOnAmbiguity: false,
+      respondToReviews: false,
     },
-    commands: {},
     copilot: { cliCommand: 'copilot', agentDir: '.agents', timeout: 300000, model: 'claude-sonnet-4.6' },
-    environment: { inheritShellPath: true, extraPath: [] },
-  } as unknown as CadreConfig;
+  });
 }
 
 function makeIssue(): IssueDetail {

--- a/tests/notification-manager.test.ts
+++ b/tests/notification-manager.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NotificationManager, createNotificationManager } from '../src/notifications/manager.js';
 import type { CadreEvent } from '../src/notifications/types.js';
-import type { CadreConfig, NotificationsConfig } from '../src/config/schema.js';
+import type { NotificationsConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 vi.mock('../src/notifications/webhook-provider.js', () => ({
   WebhookProvider: vi.fn().mockImplementation(() => ({ notify: vi.fn().mockResolvedValue(undefined) })),
@@ -248,7 +249,7 @@ describe('createNotificationManager', () => {
   });
 
   it('should return a NotificationManager instance', () => {
-    const config = { notifications: makeConfig() } as unknown as CadreConfig;
+    const config = makeRuntimeConfig({ notifications: makeConfig() });
     const manager = createNotificationManager(config);
     expect(manager).toBeInstanceOf(NotificationManager);
   });
@@ -257,11 +258,11 @@ describe('createNotificationManager', () => {
     const webhookNotify = vi.fn().mockResolvedValue(undefined);
     MockWebhookProvider.mockImplementation(() => ({ notify: webhookNotify }));
 
-    const config = {
+    const config = makeRuntimeConfig({
       notifications: makeConfig({
         providers: [{ type: 'webhook', url: 'https://example.com/hook' }],
       }),
-    } as unknown as CadreConfig;
+    });
 
     const manager = createNotificationManager(config);
     await manager.dispatch(sampleEvent);

--- a/tests/platform-validator.test.ts
+++ b/tests/platform-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 vi.mock('../src/util/process.js', () => ({
   exec: vi.fn(),
@@ -13,36 +13,21 @@ const failResult = { exitCode: 1, stdout: '', stderr: 'not found', signal: null,
 
 const makeGithubConfig = (
   overrides: Partial<{ token: string | undefined; envToken: string | undefined }> = {},
-): CadreConfig =>
-  ({
-    projectName: 'test-project',
+) =>
+  makeRuntimeConfig({
     platform: 'github',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
-    copilot: { cliCommand: 'copilot', agentDir: '.github/agents', timeout: 300000 },
-    github:
-      overrides.token !== undefined
-        ? { auth: { token: overrides.token } }
-        : undefined,
-  }) as unknown as CadreConfig;
+    ...(overrides.token !== undefined ? { github: { auth: { token: overrides.token } } } : {}),
+  });
 
-const makeAzureConfig = (pat: string): CadreConfig =>
-  ({
-    projectName: 'test-project',
+const makeAzureConfig = (pat: string) =>
+  makeRuntimeConfig({
     platform: 'azure-devops',
-    repository: 'my-repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
-    copilot: { cliCommand: 'copilot', agentDir: '.github/agents', timeout: 300000 },
     azureDevOps: {
       organization: 'myorg',
       project: 'myproject',
       auth: { pat },
     },
-  }) as unknown as CadreConfig;
+  });
 
 describe('platformValidator', () => {
   beforeEach(() => {

--- a/tests/report-writer.test.ts
+++ b/tests/report-writer.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { join } from 'node:path';
 import { ReportWriter } from '../src/reporting/report-writer.js';
 import { CostEstimator } from '../src/budget/cost-estimator.js';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
+import type { RuntimeConfig } from '../src/config/loader.js';
 import type { FleetResult } from '../src/core/fleet-orchestrator.js';
 import type { IssueDetail } from '../src/platform/provider.js';
 import type { RunReport } from '../src/reporting/types.js';
@@ -21,9 +22,8 @@ vi.mock('node:fs/promises', () => ({
 import * as fsUtil from '../src/util/fs.js';
 import { readdir } from 'node:fs/promises';
 
-const makeConfig = (overrides: Partial<CadreConfig> = {}): CadreConfig =>
-  ({
-    projectName: 'test-project',
+const makeConfig = (overrides: Partial<RuntimeConfig> = {}) =>
+  makeRuntimeConfig({
     repoPath: '/repo',
     copilot: {
       model: 'gpt-4o',
@@ -32,7 +32,7 @@ const makeConfig = (overrides: Partial<CadreConfig> = {}): CadreConfig =>
       timeout: 300000,
     },
     ...overrides,
-  }) as unknown as CadreConfig;
+  });
 
 const makeFleetResult = (
   overrides: Partial<FleetResult> = {},
@@ -67,13 +67,13 @@ const makeIssues = (): IssueDetail[] => [
 
 describe('ReportWriter', () => {
   let writer: ReportWriter;
-  let config: CadreConfig;
+  let config: ReturnType<typeof makeConfig>;
   let estimator: CostEstimator;
 
   beforeEach(() => {
     vi.clearAllMocks();
     config = makeConfig();
-    estimator = new CostEstimator(config.copilot as CadreConfig['copilot']);
+    estimator = new CostEstimator(config.copilot);
     writer = new ReportWriter(config, estimator);
   });
 

--- a/tests/review-response-orchestrator.test.ts
+++ b/tests/review-response-orchestrator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ReviewResponseOrchestrator, REVIEW_RESPONSE_PHASES } from '../src/core/review-response-orchestrator.js';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
+import type { RuntimeConfig } from '../src/config/loader.js';
 import type { PullRequestInfo, ReviewThread } from '../src/platform/provider.js';
 
 // Mock heavy I/O dependencies
@@ -59,14 +60,9 @@ vi.mock('../src/notifications/manager.js', () => ({
   })),
 }));
 
-function makeConfig(reviewResponseOverrides: Partial<CadreConfig['reviewResponse']> = {}): CadreConfig {
-  return {
-    projectName: 'test-project',
-    platform: 'github',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
+function makeConfig(reviewResponseOverrides: Partial<RuntimeConfig['reviewResponse']> = {}) {
+  return makeRuntimeConfig({
     stateDir: '/tmp/cadre-state',
-    baseBranch: 'main',
     branchTemplate: 'cadre/issue-{issue}',
     issues: { ids: [1] },
     commits: { conventional: true, sign: false, commitPerPhase: true, squashBeforePR: false },
@@ -80,12 +76,16 @@ function makeConfig(reviewResponseOverrides: Partial<CadreConfig['reviewResponse
       invocationDelayMs: 0,
       buildVerification: false,
       testVerification: false,
+      perTaskBuildCheck: true,
+      maxBuildFixRounds: 2,
+      skipValidation: false,
+      maxIntegrationFixRounds: 1,
+      ambiguityThreshold: 5,
+      haltOnAmbiguity: false,
+      respondToReviews: false,
     },
-    commands: {},
-    copilot: { cliCommand: 'copilot', model: 'claude-sonnet-4', agentDir: '.github/agents', timeout: 300000, costOverrides: {} },
-    notifications: { enabled: false, providers: [] },
     reviewResponse: { autoReplyOnResolved: false, ...reviewResponseOverrides },
-  } as unknown as CadreConfig;
+  });
 }
 
 function makePR(overrides: Partial<PullRequestInfo> = {}): PullRequestInfo {

--- a/tests/runtime-status.test.ts
+++ b/tests/runtime-status.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 // Mock heavy dependencies
 vi.mock('../src/logging/logger.js', () => ({
@@ -119,14 +119,9 @@ const mockExists = exists as ReturnType<typeof vi.fn>;
 const mockRenderFleetStatus = renderFleetStatus as ReturnType<typeof vi.fn>;
 const mockRenderIssueDetail = renderIssueDetail as ReturnType<typeof vi.fn>;
 
-function makeConfig(): CadreConfig {
-  return {
-    projectName: 'test-project',
-    platform: 'github',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
+function makeConfig() {
+  return makeRuntimeConfig({
     stateDir: '/tmp/cadre-state',
-    baseBranch: 'main',
     branchTemplate: 'cadre/issue-{issue}',
     issues: { ids: [1] },
     commits: { conventional: true, sign: false, commitPerPhase: true, squashBeforePR: false },
@@ -140,12 +135,15 @@ function makeConfig(): CadreConfig {
       invocationDelayMs: 0,
       buildVerification: false,
       testVerification: false,
+      perTaskBuildCheck: true,
+      maxBuildFixRounds: 2,
       skipValidation: true,
+      maxIntegrationFixRounds: 1,
+      ambiguityThreshold: 5,
+      haltOnAmbiguity: false,
+      respondToReviews: false,
     },
-    commands: {},
-    copilot: { cliCommand: 'copilot', model: 'claude-sonnet-4', agentDir: '.github/agents', timeout: 300000, costOverrides: {} },
-    notifications: { enabled: false, providers: [] },
-  } as unknown as CadreConfig;
+  });
 }
 
 describe('CadreRuntime.status() — no fleet checkpoint', () => {

--- a/tests/runtime-validation.test.ts
+++ b/tests/runtime-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 // Mock heavy dependencies before importing CadreRuntime
 vi.mock('../src/logging/logger.js', () => {
@@ -37,16 +37,11 @@ vi.mock('../src/validation/index.js', () => ({
 import { CadreRuntime } from '../src/core/runtime.js';
 import { PreRunValidationSuite } from '../src/validation/index.js';
 
-const makeConfig = (skipValidation = false): CadreConfig =>
-  ({
-    projectName: 'test-project',
-    platform: 'github',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
+const makeConfig = (skipValidation = false) =>
+  makeRuntimeConfig({
     stateDir: '/tmp/cadre-state',
-    baseBranch: 'main',
-    issues: { ids: [1] },
     branchTemplate: 'cadre/issue-{issue}',
+    issues: { ids: [1] },
     commits: { conventional: true, sign: false, commitPerPhase: true, squashBeforePR: false },
     pullRequest: { autoCreate: true, draft: true, labels: ['cadre-generated'], reviewers: [], linkIssue: true },
     options: {
@@ -58,12 +53,15 @@ const makeConfig = (skipValidation = false): CadreConfig =>
       invocationDelayMs: 0,
       buildVerification: true,
       testVerification: true,
+      perTaskBuildCheck: true,
+      maxBuildFixRounds: 2,
       skipValidation,
+      maxIntegrationFixRounds: 1,
+      ambiguityThreshold: 5,
+      haltOnAmbiguity: false,
+      respondToReviews: false,
     },
-    commands: {},
-    copilot: { cliCommand: 'copilot', model: 'claude-sonnet-4.6', agentDir: '.github/agents', timeout: 300_000 },
-    environment: { inheritShellPath: true, extraPath: [] },
-  }) as unknown as CadreConfig;
+  });
 
 describe('CadreRuntime.validate()', () => {
   let mockRunSuite: ReturnType<typeof vi.fn>;

--- a/tests/validation-agent-backend.test.ts
+++ b/tests/validation-agent-backend.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 vi.mock('../src/util/process.js', () => ({
   exec: vi.fn(),
@@ -13,25 +13,23 @@ import { exec } from '../src/util/process.js';
 import { exists } from '../src/util/fs.js';
 import { agentBackendValidator } from '../src/validation/agent-backend-validator.js';
 
-const makeConfig = (overrides: Partial<{ cliCommand: string; agentDir: string }> = {}): CadreConfig =>
-  ({
-    projectName: 'test-project',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
+const makeConfig = (overrides: Partial<{ cliCommand: string; agentDir: string }> = {}) =>
+  makeRuntimeConfig({
     copilot: {
       cliCommand: overrides.cliCommand ?? 'copilot',
-      agentDir: overrides.agentDir ?? '/tmp/agents',
-      timeout: 300000,
+      model: 'claude-sonnet-4.6',
+      agentDir: overrides.agentDir ?? '/tmp/.cadre/test-project/agents',
+      timeout: 300_000,
     },
-    // Mirrors what loadConfig always synthesizes
     agent: {
       backend: 'copilot' as const,
-      copilot: { cliCommand: overrides.cliCommand ?? 'copilot', agentDir: overrides.agentDir ?? '/tmp/agents' },
-      claude: { cliCommand: 'claude', agentDir: '.claude/agents' },
+      copilot: {
+        cliCommand: overrides.cliCommand ?? 'copilot',
+        agentDir: overrides.agentDir ?? '/tmp/.cadre/test-project/agents',
+      },
+      claude: { cliCommand: 'claude', agentDir: '/tmp/.cadre/test-project/agents' },
     },
-  }) as unknown as CadreConfig;
+  });
 
 const ok = { exitCode: 0, stdout: '/usr/local/bin/copilot', stderr: '', signal: null, timedOut: false } as const;
 const fail = { exitCode: 1, stdout: '', stderr: 'not found', signal: null, timedOut: false } as const;

--- a/tests/validation-command.test.ts
+++ b/tests/validation-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 vi.mock('../src/util/process.js', () => ({
   exec: vi.fn(),
@@ -10,21 +10,15 @@ import { commandValidator } from '../src/validation/command-validator.js';
 
 const makeConfig = (
   overrides: Partial<{ build: string; test: string; install?: string; lint?: string }> = {},
-): CadreConfig =>
-  ({
-    projectName: 'test-project',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
-    copilot: { cliCommand: 'copilot', agentDir: '.github/agents', timeout: 300000 },
+) =>
+  makeRuntimeConfig({
     commands: {
       build: overrides.build ?? 'npm run build',
       test: overrides.test ?? 'npx vitest run',
       ...(overrides.install !== undefined ? { install: overrides.install } : {}),
       ...(overrides.lint !== undefined ? { lint: overrides.lint } : {}),
     },
-  }) as unknown as CadreConfig;
+  });
 
 const ok = { exitCode: 0, stdout: '', stderr: '', signal: null, timedOut: false } as const;
 const fail = { exitCode: 1, stdout: '', stderr: '', signal: null, timedOut: false } as const;

--- a/tests/validation-disk.test.ts
+++ b/tests/validation-disk.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 vi.mock('../src/util/process.js', () => ({
   exec: vi.fn(),
@@ -15,18 +15,13 @@ import { diskValidator } from '../src/validation/disk-validator.js';
 
 const makeConfig = (
   overrides: Partial<{ repoPath: string; maxParallelIssues: number }> = {},
-): CadreConfig =>
-  ({
-    projectName: 'test-project',
-    repository: 'owner/repo',
+) =>
+  makeRuntimeConfig({
     repoPath: overrides.repoPath ?? '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
-    copilot: { cliCommand: 'copilot', agentDir: '.github/agents', timeout: 300000 },
     ...(overrides.maxParallelIssues !== undefined
-      ? { options: { maxParallelIssues: overrides.maxParallelIssues } }
+      ? { options: { maxParallelIssues: overrides.maxParallelIssues, maxParallelAgents: 3, maxRetriesPerTask: 3, dryRun: false, resume: false, invocationDelayMs: 0, buildVerification: true, testVerification: true, perTaskBuildCheck: true, maxBuildFixRounds: 2, skipValidation: false, maxIntegrationFixRounds: 1, ambiguityThreshold: 5, haltOnAmbiguity: false, respondToReviews: false } }
       : {}),
-  }) as unknown as CadreConfig;
+  });
 
 const ok = { exitCode: 0, stdout: '', stderr: '', signal: null, timedOut: false } as const;
 const fail = { exitCode: 1, stdout: '', stderr: 'error', signal: null, timedOut: false } as const;

--- a/tests/validation-git.test.ts
+++ b/tests/validation-git.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 vi.mock('../src/util/process.js', () => ({
   exec: vi.fn(),
@@ -13,15 +13,7 @@ import { exec } from '../src/util/process.js';
 import { exists } from '../src/util/fs.js';
 import { gitValidator } from '../src/validation/git-validator.js';
 
-const makeConfig = (): CadreConfig =>
-  ({
-    projectName: 'test-project',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
-    copilot: { cliCommand: 'copilot', agentDir: '.github/agents', timeout: 300000 },
-  }) as unknown as CadreConfig;
+const makeConfig = () => makeRuntimeConfig({ repoPath: '/tmp/repo' });
 
 const ok = { exitCode: 0, stdout: '', stderr: '', signal: null, timedOut: false } as const;
 const fail = { exitCode: 1, stdout: '', stderr: '', signal: null, timedOut: false } as const;

--- a/tests/validation-platform.test.ts
+++ b/tests/validation-platform.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 
 vi.mock('../src/util/process.js', () => ({
   exec: vi.fn(),
@@ -11,29 +11,17 @@ import { platformValidator } from '../src/validation/platform-validator.js';
 const ok = { exitCode: 0, stdout: '/usr/local/bin/github-mcp-server', stderr: '', signal: null, timedOut: false } as const;
 const fail = { exitCode: 1, stdout: '', stderr: 'not found', signal: null, timedOut: false } as const;
 
-const makeGithubConfig = (token?: string): CadreConfig =>
-  ({
-    projectName: 'test-project',
+const makeGithubConfig = (token?: string) =>
+  makeRuntimeConfig({
     platform: 'github',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
-    copilot: { cliCommand: 'copilot', agentDir: '.github/agents', timeout: 300000 },
-    github: token !== undefined ? { auth: { token } } : undefined,
-  }) as unknown as CadreConfig;
+    ...(token !== undefined ? { github: { auth: { token } } } : {}),
+  });
 
-const makeAzureConfig = (pat: string): CadreConfig =>
-  ({
-    projectName: 'test-project',
+const makeAzureConfig = (pat: string) =>
+  makeRuntimeConfig({
     platform: 'azure-devops',
-    repository: 'my-repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
-    copilot: { cliCommand: 'copilot', agentDir: '.github/agents', timeout: 300000 },
     azureDevOps: { organization: 'myorg', project: 'myproject', auth: { pat } },
-  }) as unknown as CadreConfig;
+  });
 
 describe('validation-platform', () => {
   beforeEach(() => {

--- a/tests/validation-suite.test.ts
+++ b/tests/validation-suite.test.ts
@@ -1,17 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
 import type { PreRunValidator, ValidationResult } from '../src/validation/types.js';
 import { PreRunValidationSuite } from '../src/validation/suite.js';
 
-const makeConfig = (): CadreConfig =>
-  ({
-    projectName: 'test-project',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    baseBranch: 'main',
-    issues: { ids: [1] },
-    copilot: { cliCommand: 'copilot', agentDir: '.github/agents', timeout: 300000 },
-  }) as unknown as CadreConfig;
+const makeConfig = () => makeRuntimeConfig();
 
 const makeValidator = (name: string, result: ValidationResult): PreRunValidator => ({
   name,

--- a/tests/validation-types.test.ts
+++ b/tests/validation-types.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { ValidationResult, PreRunValidator } from '../src/validation/types.js';
-import type { CadreConfig } from '../src/config/schema.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
+import type { RuntimeConfig } from '../src/config/loader.js';
 
 describe('ValidationResult', () => {
   it('should allow a passing result with no errors or warnings', () => {
@@ -37,7 +38,7 @@ describe('PreRunValidator', () => {
   it('should expose a name string', () => {
     const validator: PreRunValidator = {
       name: 'my-validator',
-      validate: async (_config: CadreConfig) => ({ passed: true, errors: [], warnings: [] }),
+      validate: async (_config: RuntimeConfig) => ({ passed: true, errors: [], warnings: [] }),
     };
     expect(validator.name).toBe('my-validator');
   });
@@ -45,20 +46,20 @@ describe('PreRunValidator', () => {
   it('should return a ValidationResult promise from validate()', async () => {
     const validator: PreRunValidator = {
       name: 'test-validator',
-      validate: async (_config: CadreConfig) => ({
+      validate: async (_config: RuntimeConfig) => ({
         passed: false,
         errors: ['bad config'],
         warnings: [],
       }),
     };
 
-    const minimalConfig = {
+    const minimalConfig = makeRuntimeConfig({
       projectName: 'test',
       repository: 'owner/repo',
       repoPath: '/tmp/repo',
       platform: 'github',
       issues: { ids: [1] },
-    } as unknown as CadreConfig;
+    });
 
     const result = await validator.validate(minimalConfig);
     expect(result.passed).toBe(false);
@@ -69,10 +70,10 @@ describe('PreRunValidator', () => {
   it('should allow a validator that resolves passed:true', async () => {
     const validator: PreRunValidator = {
       name: 'always-pass',
-      validate: async (_config: CadreConfig) => ({ passed: true, errors: [], warnings: [] }),
+      validate: async (_config: RuntimeConfig) => ({ passed: true, errors: [], warnings: [] }),
     };
 
-    const minimalConfig = {} as unknown as CadreConfig;
+    const minimalConfig = makeRuntimeConfig();
     const result = await validator.validate(minimalConfig);
     expect(result.passed).toBe(true);
   });


### PR DESCRIPTION
## Summary

Introduces a `RuntimeConfig` interface that represents the config as consumed at runtime — after `loadConfig()` has resolved all paths and synthesized required fields. This replaces the widespread use of `CadreConfig` with unsafe `!` non-null assertions and `?? fallback` expressions throughout the codebase.

## Changes

### `src/config/loader.ts`
- Add `RuntimeConfig` interface extending `CadreConfig` with `stateDir`, `worktreeRoot`, and `agent` narrowed to required (non-optional)
- Update `loadConfig()` return type from `Readonly<CadreConfig>` to `RuntimeConfig`
- Update `applyOverrides()` to accept and return `RuntimeConfig`

### Source files updated (`CadreConfig` → `RuntimeConfig`)
- `src/agents/backend.ts` / `backend-factory.ts`
- `src/cli/agents.ts`
- `src/core/agent-launcher.ts`, `fleet-orchestrator.ts`, `issue-notifier.ts`, `issue-orchestrator.ts`, `phase-executor.ts`, `review-response-orchestrator.ts`, `runtime.ts`
- `src/notifications/manager.ts`
- `src/platform/factory.ts`
- `src/reporting/report-writer.ts`
- `src/validation/agent-backend-validator.ts`, `command-validator.ts`, `disk-validator.ts`, `git-validator.ts`, `platform-validator.ts`, `suite.ts`, `types.ts`
- `src/index.ts`

### Optional-chaining / fallback removal
All `config.agent?.backend ?? 'copilot'`, `config.stateDir!`, `config.worktreeRoot ?? join(...)`, etc. replaced with direct property access since `RuntimeConfig` guarantees these fields.

### Tests
- Add `tests/helpers/make-runtime-config.ts` — a shared factory with sensible defaults for all required fields
- Update all affected test files to use `makeRuntimeConfig()` instead of `as unknown as CadreConfig` casts