### PR TITLE
refactor: consolidate extractCadreJson into shared util

### DIFF
--- a/src/agents/result-parser.ts
+++ b/src/agents/result-parser.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { extractCadreJson } from '../util/cadre-json.js';
 import type {
   ImplementationTask,
   AnalysisResult,
@@ -22,16 +23,6 @@ export class ResultParser {
   constructor() {}
 
   /**
-   * Extract and JSON-parse the first ```cadre-json``` fenced block in content.
-   * Returns the parsed value, or null if no such block exists.
-   */
-  private extractCadreJson(content: string): unknown | null {
-    const match = content.match(/```cadre-json\s*\n([\s\S]*?)```/);
-    if (!match) return null;
-    return JSON.parse(match[1].trim());
-  }
-
-  /**
    * Normalize a markdown string that may contain JSON-style escape sequences
    * (e.g. `\\n` → actual newline, `\\t` → actual tab).
    *
@@ -53,7 +44,7 @@ export class ResultParser {
   async parseImplementationPlan(planPath: string): Promise<ImplementationTask[]> {
     const content = await readFile(planPath, 'utf-8');
 
-    const parsed = this.extractCadreJson(content);
+    const parsed = extractCadreJson(content);
     if (parsed !== null) {
       return implementationPlanSchema.parse(parsed);
     }
@@ -71,7 +62,7 @@ export class ResultParser {
   async parseReview(reviewPath: string): Promise<ReviewResult> {
     const content = await readFile(reviewPath, 'utf-8');
 
-    const parsed = this.extractCadreJson(content);
+    const parsed = extractCadreJson(content);
     if (parsed !== null) {
       const result = reviewSchema.parse(parsed);
       return {
@@ -96,7 +87,7 @@ export class ResultParser {
   async parseIntegrationReport(reportPath: string): Promise<IntegrationReport> {
     const content = await readFile(reportPath, 'utf-8');
 
-    const parsed = this.extractCadreJson(content);
+    const parsed = extractCadreJson(content);
     if (parsed !== null) {
       return integrationReportSchema.parse(parsed);
     }
@@ -113,7 +104,7 @@ export class ResultParser {
   async parsePRContent(contentPath: string): Promise<PRContent> {
     const content = await readFile(contentPath, 'utf-8');
 
-    const parsed = this.extractCadreJson(content);
+    const parsed = extractCadreJson(content);
     if (parsed !== null) {
       const result = prContentSchema.parse(parsed);
       return { ...result, body: this.unescapeText(result.body) };
@@ -131,7 +122,7 @@ export class ResultParser {
   async parseScoutReport(reportPath: string): Promise<ScoutReport> {
     const content = await readFile(reportPath, 'utf-8');
 
-    const parsed = this.extractCadreJson(content);
+    const parsed = extractCadreJson(content);
     if (parsed !== null) {
       return scoutReportSchema.parse(parsed);
     }
@@ -148,7 +139,7 @@ export class ResultParser {
   async parseAnalysis(analysisPath: string): Promise<AnalysisResult> {
     const content = await readFile(analysisPath, 'utf-8');
 
-    const parsed = this.extractCadreJson(content);
+    const parsed = extractCadreJson(content);
     if (parsed !== null) {
       const result = analysisSchema.parse(parsed);
       return {

--- a/src/core/phase-gate.ts
+++ b/src/core/phase-gate.ts
@@ -8,6 +8,7 @@ import {
   integrationReportSchema,
 } from '../agents/schemas/index.js';
 import { TaskQueue } from '../execution/task-queue.js';
+import { extractCadreJson } from '../util/cadre-json.js';
 
 /** Context passed to every gate validator. */
 export interface GateContext {
@@ -40,20 +41,6 @@ function pass(warnings: string[] = []): GateResult {
 
 function fail(errors: string[], warnings: string[] = []): GateResult {
   return { status: 'fail', warnings, errors };
-}
-
-/**
- * Extract and JSON-parse the first ```cadre-json``` fenced block from content.
- * Returns the parsed value, or null if no such block exists or the JSON is invalid.
- */
-function extractCadreJson(content: string): unknown | null {
-  const match = content.match(/```cadre-json\s*\n([\s\S]*?)```/);
-  if (!match) return null;
-  try {
-    return JSON.parse(match[1].trim());
-  } catch {
-    return null;
-  }
 }
 
 // ── Gate 1→2: Analysis → Planning ────────────────────────────────────────────

--- a/src/util/cadre-json.ts
+++ b/src/util/cadre-json.ts
@@ -1,0 +1,13 @@
+/**
+ * Extract and JSON-parse the first ```cadre-json``` fenced block from content.
+ * Returns the parsed value, or null if no such block exists or the JSON is invalid.
+ */
+export function extractCadreJson(content: string): unknown | null {
+  const match = content.match(/```cadre-json\s*\n([\s\S]*?)```/);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[1].trim());
+  } catch {
+    return null;
+  }
+}

--- a/tests/result-parser.test.ts
+++ b/tests/result-parser.test.ts
@@ -54,7 +54,7 @@ describe('ResultParser', () => {
       const content = '```cadre-json\n{ not valid json }\n```';
       vi.mocked(readFile).mockResolvedValue(content);
 
-      await expect(parser.parseImplementationPlan('/tmp/plan.md')).rejects.toThrow(SyntaxError);
+      await expect(parser.parseImplementationPlan('/tmp/plan.md')).rejects.toThrow(/cadre-json/);
     });
   });
 


### PR DESCRIPTION
## Summary

Three copies of the same `extractCadreJson` regex + JSON.parse pattern existed independently:

- A private method in `ResultParser` (threw raw `SyntaxError` on invalid JSON)
- A module-level function in `phase-gate.ts` (returned `null` on invalid JSON)
- An inline regex in `IssueOrchestrator.readAmbiguitiesFromAnalysis()` (slightly different regex, manual `JSON.parse`)

## Changes

- **`src/util/cadre-json.ts`** — New file with the single canonical `extractCadreJson(content)`. Uses the same regex as before and returns `null` for both a missing block and invalid JSON (the most defensive variant).
- **`src/agents/result-parser.ts`** — Removes the private method; all 6 `parse*` methods call the shared import.
- **`src/core/phase-gate.ts`** — Removes the duplicate local function; adds import.
- **`src/core/issue-orchestrator.ts`** — Replaces the inline regex + `JSON.parse` with the shared function.
- **Test updates** — `result-parser.test.ts` updated to expect the descriptive "cadre-json block" error instead of a raw `SyntaxError`. Ambiguity test fixtures in `issue-orchestrator-ambiguity.test.ts` and `issue-orchestrator-gates.test.ts` updated to emit `cadre-json` blocks instead of `## Ambiguities` markdown headings, matching how the orchestrator actually reads ambiguities.

## Behaviour change

Invalid JSON inside a ` ```cadre-json ``` ` block now returns `null` (treated as missing block) rather than propagating a `SyntaxError`. All call sites already handle the `null` case and throw a descriptive error, so end-user-visible error messages are unchanged.