### PR TITLE
fix: pick up PR review bodies in respond-to-reviews mode

### DIFF
--- a/src/github/api.ts
+++ b/src/github/api.ts
@@ -230,6 +230,18 @@ export class GitHubAPI {
   }
 
   /**
+   * Get top-level reviews for a pull request (review bodies, not inline threads).
+   */
+  async getPRReviews(prNumber: number): Promise<unknown> {
+    return this.mcp.callTool<unknown>('pull_request_read', {
+      method: 'get_reviews',
+      owner: this.owner,
+      repo: this.repo,
+      pullNumber: prNumber,
+    });
+  }
+
+  /**
    * List pull requests, optionally filtered by head branch.
    */
   async listPullRequests(filters?: {

--- a/src/platform/azure-devops-provider.ts
+++ b/src/platform/azure-devops-provider.ts
@@ -8,6 +8,7 @@ import type {
   ListIssuesParams,
   ReviewThread,
   PRComment,
+  PRReview,
 } from './provider.js';
 import { Logger } from '../logging/logger.js';
 
@@ -398,6 +399,11 @@ export class AzureDevOpsProvider implements PlatformProvider {
 
   async listPRComments(_prNumber: number): Promise<PRComment[]> {
     this.logger.warn('listPRComments: review-response mode is not yet supported on Azure DevOps');
+    return [];
+  }
+
+  async listPRReviews(_prNumber: number): Promise<PRReview[]> {
+    this.logger.warn('listPRReviews: review-response mode is not yet supported on Azure DevOps');
     return [];
   }
 

--- a/src/platform/provider.ts
+++ b/src/platform/provider.ts
@@ -63,6 +63,20 @@ export interface ReviewComment {
 }
 
 /**
+ * A top-level pull request review (submitted via the Reviews API, with an optional body).
+ */
+export interface PRReview {
+  id: string;
+  author: string;
+  /** Whether the author account is a bot (e.g. github-actions[bot]). */
+  isBot: boolean;
+  body: string;
+  /** Review state: APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED, etc. */
+  state: string;
+  submittedAt: string;
+}
+
+/**
  * A regular (non-review) pull request comment (issue-style comment on the PR conversation).
  */
 export interface PRComment {
@@ -159,6 +173,8 @@ export interface PlatformProvider {
   listPRReviewComments(prNumber: number): Promise<ReviewThread[]>;
   /** List regular (non-review) conversation comments on a pull request. */
   listPRComments(prNumber: number): Promise<PRComment[]>;
+  /** List top-level pull request reviews (review bodies, not inline thread comments). */
+  listPRReviews(prNumber: number): Promise<PRReview[]>;
 
   // ── Issue Linking ──
 

--- a/tests/helpers/mock-platform-provider.ts
+++ b/tests/helpers/mock-platform-provider.ts
@@ -4,6 +4,7 @@ import type {
   ListIssuesParams,
   ListPullRequestsParams,
   PRComment,
+  PRReview,
   PlatformProvider,
   PullRequestInfo,
   ReviewThread,
@@ -87,6 +88,10 @@ export class MockPlatformProvider implements PlatformProvider {
   }
 
   async listPRComments(_prNumber: number): Promise<PRComment[]> {
+    return [];
+  }
+
+  async listPRReviews(_prNumber: number): Promise<PRReview[]> {
     return [];
   }
 

--- a/tests/review-response-orchestrator.test.ts
+++ b/tests/review-response-orchestrator.test.ts
@@ -126,6 +126,7 @@ function makeMockDeps() {
     listPullRequests: vi.fn().mockResolvedValue([]),
     listPRReviewComments: vi.fn().mockResolvedValue([]),
     listPRComments: vi.fn().mockResolvedValue([]),
+    listPRReviews: vi.fn().mockResolvedValue([]),
     getIssue: vi.fn().mockResolvedValue({
       number: 1,
       title: 'Issue 1',


### PR DESCRIPTION
## Problem

When running `--respond-to-reviews`, cadre only checked two data sources:
1. Inline review threads (`listPRReviewComments`)
2. PR conversation comments (`listPRComments`)

A top-level review body submitted via the GitHub Reviews API (e.g. a `COMMENTED` review) was completely invisible, causing cadre to log "all review threads resolved or outdated, skipping" even when actionable feedback existed. This is what happened with PR #128.

## Solution

Add a third data source: **top-level PR review bodies** via a new `listPRReviews()` method.

- Non-bot reviews with non-empty bodies are now included in the skip guard
- Each actionable review body becomes a task in the implementation plan passed to the code-writer agent

## Changes

| File | Change |
|---|---|
| `src/platform/provider.ts` | Add `PRReview` interface; add `listPRReviews()` to `PlatformProvider` |
| `src/github/api.ts` | Add `getPRReviews()` calling `pull_request_read` / `get_reviews` |
| `src/platform/github-provider.ts` | Implement `listPRReviews()` + `parsePRReviews()` with bot detection |
| `src/platform/azure-devops-provider.ts` | Add no-op stub |
| `src/core/review-response-orchestrator.ts` | Fetch reviews (step 4c), include in skip guard, generate tasks |
| `tests/helpers/mock-platform-provider.ts` | Add `listPRReviews` stub |
| `tests/review-response-orchestrator.test.ts` | Add `listPRReviews` mock to `makeMockDeps()` |