### PR TITLE
test: add coverage for mcp-client, prompts, parallel-executor, config loader, and ado-provider

### DIFF
--- a/cadre.config.json
+++ b/cadre.config.json
@@ -44,7 +44,7 @@
   "copilot": {
     "cliCommand": "copilot",
     "model": "claude-sonnet-4.6",
-    "timeout": 300000
+    "timeout": 600000
   },
   "environment": {
     "inheritShellPath": true,

--- a/tests/config-loader-paths.test.ts
+++ b/tests/config-loader-paths.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join, resolve } from 'node:path';
+import { homedir } from 'node:os';
+
+vi.mock('../src/util/fs.js', () => ({
+  exists: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+import { readFile } from 'node:fs/promises';
+import { exists } from '../src/util/fs.js';
+import { loadConfig } from '../src/config/loader.js';
+
+const mockExists = vi.mocked(exists);
+const mockReadFile = vi.mocked(readFile);
+
+/** Minimal valid config fixture. stateDir is set to a known absolute path by default. */
+function makeConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    projectName: 'test-project',
+    repository: 'owner/repo',
+    repoPath: '/tmp/repo',
+    baseBranch: 'main',
+    issues: { ids: [1] },
+    stateDir: '/abs/state',
+    copilot: {
+      cliCommand: 'gh copilot',
+      model: 'claude-sonnet-4.6',
+      agentDir: 'agents', // default bare name
+      timeout: 300_000,
+    },
+    ...overrides,
+  };
+}
+
+/** Set up file-system mocks for a given config object. */
+function setupFs(config: object) {
+  mockExists.mockImplementation(async (p: string) => {
+    // .git always exists (valid repo), config file always exists
+    return true;
+  });
+  mockReadFile.mockResolvedValue(JSON.stringify(config) as unknown as Buffer);
+}
+
+describe('loadConfig – resolveAgentDir branches', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns an absolute agentDir unchanged', async () => {
+    setupFs(makeConfig({
+      copilot: {
+        cliCommand: 'gh copilot',
+        model: 'claude-sonnet-4.6',
+        agentDir: '/absolute/path/agents',
+        timeout: 300_000,
+      },
+    }));
+
+    const config = await loadConfig('/tmp/cadre.config.json');
+    expect(config.copilot.agentDir).toBe('/absolute/path/agents');
+  });
+
+  it('resolves a .cadre/-prefixed agentDir under stateDir (strips prefix)', async () => {
+    setupFs(makeConfig({
+      copilot: {
+        cliCommand: 'gh copilot',
+        model: 'claude-sonnet-4.6',
+        agentDir: '.cadre/my-agents',
+        timeout: 300_000,
+      },
+    }));
+
+    const config = await loadConfig('/tmp/cadre.config.json');
+    expect(config.copilot.agentDir).toBe('/abs/state/my-agents');
+  });
+
+  it('resolves a .claude/-prefixed agentDir under stateDir (strips prefix)', async () => {
+    setupFs(makeConfig({
+      copilot: {
+        cliCommand: 'gh copilot',
+        model: 'claude-sonnet-4.6',
+        agentDir: '.claude/agents',
+        timeout: 300_000,
+      },
+    }));
+
+    const config = await loadConfig('/tmp/cadre.config.json');
+    expect(config.copilot.agentDir).toBe('/abs/state/agents');
+  });
+
+  it('resolves a bare name (no /) under stateDir', async () => {
+    setupFs(makeConfig({
+      copilot: {
+        cliCommand: 'gh copilot',
+        model: 'claude-sonnet-4.6',
+        agentDir: 'agents',
+        timeout: 300_000,
+      },
+    }));
+
+    const config = await loadConfig('/tmp/cadre.config.json');
+    expect(config.copilot.agentDir).toBe('/abs/state/agents');
+  });
+
+  it('resolves a repo-relative path (contains / but not .cadre/ or .claude/) under repoPath', async () => {
+    setupFs(makeConfig({
+      copilot: {
+        cliCommand: 'gh copilot',
+        model: 'claude-sonnet-4.6',
+        agentDir: '.github/agents',
+        timeout: 300_000,
+      },
+    }));
+
+    const config = await loadConfig('/tmp/cadre.config.json');
+    expect(config.copilot.agentDir).toBe('/tmp/repo/.github/agents');
+  });
+});
+
+describe('loadConfig – agent field handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('synthesizes agent from copilot fields when config.agent is absent', async () => {
+    setupFs(makeConfig());
+    const config = await loadConfig('/tmp/cadre.config.json');
+    expect(config.agent).toBeDefined();
+    expect(config.agent.backend).toBe('copilot');
+  });
+
+  it('uses config.agent verbatim when it is present', async () => {
+    setupFs(makeConfig({
+      agent: {
+        backend: 'claude',
+        model: 'claude-opus-4.5',
+        timeout: 60_000,
+        copilot: { cliCommand: 'gh copilot', agentDir: '/abs/state/agents' },
+        claude: { cliCommand: '/usr/local/bin/claude', agentDir: '/abs/state/agents' },
+      },
+    }));
+
+    const config = await loadConfig('/tmp/cadre.config.json');
+    expect(config.agent.backend).toBe('claude');
+    expect(config.agent.model).toBe('claude-opus-4.5');
+  });
+});
+
+describe('loadConfig – stateDir resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults stateDir to ~/.cadre/<projectName> when absent from config', async () => {
+    const cfg = makeConfig();
+    // Remove stateDir
+    delete (cfg as Record<string, unknown>).stateDir;
+    setupFs(cfg);
+
+    const config = await loadConfig('/tmp/cadre.config.json');
+    const expected = join(homedir(), '.cadre', 'test-project');
+    expect(config.stateDir).toBe(expected);
+  });
+
+  it('uses stateDir verbatim when it is an absolute path', async () => {
+    setupFs(makeConfig({ stateDir: '/custom/absolute/state' }));
+
+    const config = await loadConfig('/tmp/cadre.config.json');
+    expect(config.stateDir).toBe('/custom/absolute/state');
+  });
+
+  it('resolves a relative stateDir against process.cwd()', async () => {
+    setupFs(makeConfig({ stateDir: 'relative/state' }));
+
+    const config = await loadConfig('/tmp/cadre.config.json');
+    expect(config.stateDir).toBe(resolve(process.cwd(), 'relative/state'));
+  });
+});
+
+describe('loadConfig – worktreeRoot resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults worktreeRoot to <stateDir>/worktrees when absent from config', async () => {
+    const cfg = makeConfig({ stateDir: '/abs/state' });
+    // Ensure no worktreeRoot
+    delete (cfg as Record<string, unknown>).worktreeRoot;
+    setupFs(cfg);
+
+    const config = await loadConfig('/tmp/cadre.config.json');
+    expect(config.worktreeRoot).toBe('/abs/state/worktrees');
+  });
+
+  it('uses worktreeRoot verbatim when it is an absolute path', async () => {
+    setupFs(makeConfig({ worktreeRoot: '/custom/worktrees' }));
+
+    const config = await loadConfig('/tmp/cadre.config.json');
+    expect(config.worktreeRoot).toBe('/custom/worktrees');
+  });
+
+  it('resolves a relative worktreeRoot against repoPath', async () => {
+    setupFs(makeConfig({ worktreeRoot: 'relative/worktrees' }));
+
+    const config = await loadConfig('/tmp/cadre.config.json');
+    // repoPath is /tmp/repo (absolute in fixture)
+    expect(config.worktreeRoot).toBe('/tmp/repo/relative/worktrees');
+  });
+
+  it('worktreeRoot defaults to stateDir/worktrees using the default stateDir when both are absent', async () => {
+    const cfg = makeConfig();
+    delete (cfg as Record<string, unknown>).stateDir;
+    delete (cfg as Record<string, unknown>).worktreeRoot;
+    setupFs(cfg);
+
+    const config = await loadConfig('/tmp/cadre.config.json');
+    const expectedStateDir = join(homedir(), '.cadre', 'test-project');
+    expect(config.worktreeRoot).toBe(join(expectedStateDir, 'worktrees'));
+  });
+});

--- a/tests/github-mcp-client.test.ts
+++ b/tests/github-mcp-client.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Logger } from '../src/logging/logger.js';
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    connect: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    callTool: vi.fn(),
+  })),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: vi.fn().mockImplementation(() => ({})),
+}));
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { GitHubMCPClient, type MCPServerConfig } from '../src/github/mcp-client.js';
+
+const serverConfig: MCPServerConfig = {
+  command: 'gh',
+  args: ['mcp', 'stdio'],
+};
+
+function makeLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as unknown as Logger;
+}
+
+function getMockClientInstance() {
+  return vi.mocked(Client).mock.results[vi.mocked(Client).mock.results.length - 1].value as {
+    connect: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+    callTool: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('GitHubMCPClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── isConnected ──────────────────────────────────────────────────────────
+
+  describe('isConnected()', () => {
+    it('returns false before connect', () => {
+      const client = new GitHubMCPClient(serverConfig, makeLogger());
+      expect(client.isConnected()).toBe(false);
+    });
+
+    it('returns true after connect', async () => {
+      const client = new GitHubMCPClient(serverConfig, makeLogger());
+      await client.connect();
+      expect(client.isConnected()).toBe(true);
+    });
+
+    it('returns false after disconnect', async () => {
+      const client = new GitHubMCPClient(serverConfig, makeLogger());
+      await client.connect();
+      await client.disconnect();
+      expect(client.isConnected()).toBe(false);
+    });
+  });
+
+  // ── connect ──────────────────────────────────────────────────────────────
+
+  describe('connect()', () => {
+    it('calls client.connect with the transport', async () => {
+      const logger = makeLogger();
+      const mcpClient = new GitHubMCPClient(serverConfig, logger);
+      await mcpClient.connect();
+
+      const instance = getMockClientInstance();
+      expect(instance.connect).toHaveBeenCalledTimes(1);
+      // transport is an instance of StdioClientTransport
+      expect(StdioClientTransport).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets isConnected to true', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      await mcpClient.connect();
+      expect(mcpClient.isConnected()).toBe(true);
+    });
+
+    it('logs info on connect', async () => {
+      const logger = makeLogger();
+      const mcpClient = new GitHubMCPClient(serverConfig, logger);
+      await mcpClient.connect();
+      expect(logger.info).toHaveBeenCalled();
+    });
+
+    it('is idempotent — second call is a no-op', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      await mcpClient.connect();
+      await mcpClient.connect();
+
+      // Client and transport should only be constructed once
+      expect(Client).toHaveBeenCalledTimes(1);
+      expect(StdioClientTransport).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── disconnect ───────────────────────────────────────────────────────────
+
+  describe('disconnect()', () => {
+    it('sets isConnected to false', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      await mcpClient.connect();
+      await mcpClient.disconnect();
+      expect(mcpClient.isConnected()).toBe(false);
+    });
+
+    it('calls client.close', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      await mcpClient.connect();
+      const instance = getMockClientInstance();
+      await mcpClient.disconnect();
+      expect(instance.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs info on disconnect', async () => {
+      const logger = makeLogger();
+      const mcpClient = new GitHubMCPClient(serverConfig, logger);
+      await mcpClient.connect();
+      vi.clearAllMocks();
+      await mcpClient.disconnect();
+      expect(logger.info).toHaveBeenCalled();
+    });
+
+    it('is idempotent on already-disconnected client', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      // Never connected — should not throw
+      await expect(mcpClient.disconnect()).resolves.toBeUndefined();
+    });
+
+    it('swallows error from client.close', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      await mcpClient.connect();
+      const instance = getMockClientInstance();
+      instance.close.mockRejectedValueOnce(new Error('close failed'));
+
+      await expect(mcpClient.disconnect()).resolves.toBeUndefined();
+      expect(mcpClient.isConnected()).toBe(false);
+    });
+
+    it('logs debug when client.close throws', async () => {
+      const logger = makeLogger();
+      const mcpClient = new GitHubMCPClient(serverConfig, logger);
+      await mcpClient.connect();
+      const instance = getMockClientInstance();
+      instance.close.mockRejectedValueOnce(new Error('close failed'));
+      vi.clearAllMocks();
+
+      await mcpClient.disconnect();
+      expect(logger.debug).toHaveBeenCalled();
+    });
+  });
+
+  // ── callTool ─────────────────────────────────────────────────────────────
+
+  describe('callTool()', () => {
+    it('throws when not connected', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      await expect(mcpClient.callTool('search_repositories', {})).rejects.toThrow(
+        'MCP client not connected',
+      );
+    });
+
+    it('passes toolName and args to client.callTool', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      await mcpClient.connect();
+      const instance = getMockClientInstance();
+      instance.callTool.mockResolvedValueOnce({
+        content: [{ type: 'text', text: '{"result": 42}' }],
+        isError: false,
+      });
+
+      await mcpClient.callTool('search_repositories', { query: 'cadre' });
+
+      expect(instance.callTool).toHaveBeenCalledWith({
+        name: 'search_repositories',
+        arguments: { query: 'cadre' },
+      });
+    });
+
+    it('parses JSON text content and returns it', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      await mcpClient.connect();
+      const instance = getMockClientInstance();
+      instance.callTool.mockResolvedValueOnce({
+        content: [{ type: 'text', text: '{"login": "octocat"}' }],
+        isError: false,
+      });
+
+      const result = await mcpClient.callTool<{ login: string }>('get_me', {});
+      expect(result).toEqual({ login: 'octocat' });
+    });
+
+    it('throws when isError is true', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      await mcpClient.connect();
+      const instance = getMockClientInstance();
+      instance.callTool.mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'not found' }],
+        isError: true,
+      });
+
+      await expect(mcpClient.callTool('get_repo', { owner: 'x', repo: 'y' })).rejects.toThrow(
+        'MCP tool get_repo failed: not found',
+      );
+    });
+
+    it('throws when content is empty', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      await mcpClient.connect();
+      const instance = getMockClientInstance();
+      instance.callTool.mockResolvedValueOnce({
+        content: [],
+        isError: false,
+      });
+
+      await expect(mcpClient.callTool('some_tool', {})).rejects.toThrow(
+        'MCP tool some_tool returned no content',
+      );
+    });
+
+    it('throws when content has no text block', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      await mcpClient.connect();
+      const instance = getMockClientInstance();
+      instance.callTool.mockResolvedValueOnce({
+        content: [{ type: 'image' }],
+        isError: false,
+      });
+
+      await expect(mcpClient.callTool('some_tool', {})).rejects.toThrow(
+        'MCP tool some_tool returned no text content',
+      );
+    });
+
+    it('returns plain text as-is when JSON.parse throws', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      await mcpClient.connect();
+      const instance = getMockClientInstance();
+      instance.callTool.mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'plain text response' }],
+        isError: false,
+      });
+
+      const result = await mcpClient.callTool<string>('list_tools', {});
+      expect(result).toBe('plain text response');
+    });
+  });
+
+  // ── checkAuth ────────────────────────────────────────────────────────────
+
+  describe('checkAuth()', () => {
+    it('returns true when callTool get_me succeeds', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      await mcpClient.connect();
+      const instance = getMockClientInstance();
+      instance.callTool.mockResolvedValueOnce({
+        content: [{ type: 'text', text: '{"login": "octocat"}' }],
+        isError: false,
+      });
+
+      const result = await mcpClient.checkAuth();
+      expect(result).toBe(true);
+    });
+
+    it('returns false when callTool throws', async () => {
+      const mcpClient = new GitHubMCPClient(serverConfig, makeLogger());
+      await mcpClient.connect();
+      const instance = getMockClientInstance();
+      instance.callTool.mockRejectedValueOnce(new Error('unauthorized'));
+
+      const result = await mcpClient.checkAuth();
+      expect(result).toBe(false);
+    });
+
+    it('logs the authenticated username on success', async () => {
+      const logger = makeLogger();
+      const mcpClient = new GitHubMCPClient(serverConfig, logger);
+      await mcpClient.connect();
+      const instance = getMockClientInstance();
+      instance.callTool.mockResolvedValueOnce({
+        content: [{ type: 'text', text: '{"login": "my-bot"}' }],
+        isError: false,
+      });
+
+      await mcpClient.checkAuth();
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('my-bot'));
+    });
+  });
+});

--- a/tests/prompts-collect.test.ts
+++ b/tests/prompts-collect.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@inquirer/prompts', () => ({
+  input: vi.fn(),
+  select: vi.fn(),
+  confirm: vi.fn(),
+}));
+
+vi.mock('../src/util/fs.js', () => ({
+  exists: vi.fn().mockResolvedValue(true),
+}));
+
+import { input, select, confirm } from '@inquirer/prompts';
+import {
+  collectAnswers,
+  validateAzureDevOpsRepository,
+} from '../src/cli/prompts.js';
+
+const mockInput = vi.mocked(input);
+const mockSelect = vi.mocked(select);
+const mockConfirm = vi.mocked(confirm);
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+/** Set up mocks for the yes=true fast path. */
+function setupYesTrue(platform: 'github' | 'azure-devops' = 'github') {
+  mockInput
+    .mockResolvedValueOnce('my-project') // projectName
+    .mockResolvedValueOnce('owner/repo'); // repository
+  mockSelect.mockResolvedValueOnce(platform); // platform
+}
+
+/**
+ * Set up mocks for the yes=false, GitHub, ids mode, token auth, no-commands path.
+ * Returns the token that was configured.
+ */
+function setupNoYesGitHubIdsToken(token = 'ghp_secret') {
+  mockInput
+    .mockResolvedValueOnce('my-project') // projectName
+    .mockResolvedValueOnce('owner/repo') // repository
+    .mockResolvedValueOnce('/tmp/repo') // repoPath
+    .mockResolvedValueOnce('main') // baseBranch
+    .mockResolvedValueOnce(token); // token (in promptGitHubAuth)
+  mockSelect
+    .mockResolvedValueOnce('github') // platform
+    .mockResolvedValueOnce('ids') // issueMode
+    .mockResolvedValueOnce('token'); // auth method
+  mockConfirm.mockResolvedValueOnce(false); // wantsCommands
+}
+
+describe('collectAnswers – yes=true fast path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns issueMode { mode: "query", state: "open", limit: 10 }', async () => {
+    setupYesTrue();
+    const result = await collectAnswers(true);
+    expect(result.issueMode).toEqual({ mode: 'query', state: 'open', limit: 10 });
+  });
+
+  it('sets baseBranch to "main"', async () => {
+    setupYesTrue();
+    const result = await collectAnswers(true);
+    expect(result.baseBranch).toBe('main');
+  });
+
+  it('sets repoPath to repoPathOverride when provided', async () => {
+    setupYesTrue();
+    const result = await collectAnswers(true, '/custom/path');
+    expect(result.repoPath).toBe('/custom/path');
+  });
+
+  it('sets repoPath to process.cwd() when no override', async () => {
+    setupYesTrue();
+    const result = await collectAnswers(true);
+    expect(result.repoPath).toBe(process.cwd());
+  });
+
+  it('calls input only for projectName and repository', async () => {
+    setupYesTrue();
+    await collectAnswers(true);
+    expect(mockInput).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls select only for platform', async () => {
+    setupYesTrue();
+    await collectAnswers(true);
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns githubAuth: undefined', async () => {
+    setupYesTrue();
+    const result = await collectAnswers(true);
+    expect(result.githubAuth).toBeUndefined();
+  });
+
+  it('returns commands as empty object', async () => {
+    setupYesTrue();
+    const result = await collectAnswers(true);
+    expect(result.commands).toEqual({});
+  });
+
+  it('returns the projectName from input', async () => {
+    setupYesTrue();
+    const result = await collectAnswers(true);
+    expect(result.projectName).toBe('my-project');
+  });
+});
+
+describe('collectAnswers – yes=false, GitHub platform, token auth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns { method: "token", token } when token auth selected', async () => {
+    setupNoYesGitHubIdsToken('ghp_mytoken');
+    const result = await collectAnswers(false);
+    expect(result.githubAuth).toEqual({ method: 'token', token: 'ghp_mytoken' });
+  });
+
+  it('returns issueMode { mode: "ids" } when ids selected', async () => {
+    setupNoYesGitHubIdsToken();
+    const result = await collectAnswers(false);
+    expect(result.issueMode).toEqual({ mode: 'ids' });
+  });
+
+  it('returns issueMode { mode: "query", state, limit: 10 } when query selected', async () => {
+    vi.clearAllMocks();
+    mockInput
+      .mockResolvedValueOnce('my-project') // projectName
+      .mockResolvedValueOnce('owner/repo') // repository
+      .mockResolvedValueOnce('/tmp/repo') // repoPath
+      .mockResolvedValueOnce('main') // baseBranch
+      .mockResolvedValueOnce('ghp_token'); // token
+    mockSelect
+      .mockResolvedValueOnce('github') // platform
+      .mockResolvedValueOnce('query') // issueMode
+      .mockResolvedValueOnce('open') // state
+      .mockResolvedValueOnce('token'); // auth method
+    mockConfirm.mockResolvedValueOnce(false);
+
+    const result = await collectAnswers(false);
+    expect(result.issueMode).toEqual({ mode: 'query', state: 'open', limit: 10 });
+  });
+
+  it('returns { method: "app", appId, installationId, privateKeyFile } when app auth selected', async () => {
+    vi.clearAllMocks();
+    mockInput
+      .mockResolvedValueOnce('my-project') // projectName
+      .mockResolvedValueOnce('owner/repo') // repository
+      .mockResolvedValueOnce('/tmp/repo') // repoPath
+      .mockResolvedValueOnce('main') // baseBranch
+      .mockResolvedValueOnce('12345') // appId
+      .mockResolvedValueOnce('67890') // installationId
+      .mockResolvedValueOnce('/path/key.pem'); // privateKeyFile
+    mockSelect
+      .mockResolvedValueOnce('github') // platform
+      .mockResolvedValueOnce('ids') // issueMode
+      .mockResolvedValueOnce('app'); // auth method
+    mockConfirm.mockResolvedValueOnce(false);
+
+    const result = await collectAnswers(false);
+    expect(result.githubAuth).toEqual({
+      method: 'app',
+      appId: '12345',
+      installationId: '67890',
+      privateKeyFile: '/path/key.pem',
+    });
+  });
+
+  it('returns commands {} when user declines (confirm → false)', async () => {
+    setupNoYesGitHubIdsToken();
+    const result = await collectAnswers(false);
+    expect(result.commands).toEqual({});
+  });
+
+  it('returns commands object with fields when user confirms', async () => {
+    vi.clearAllMocks();
+    mockInput
+      .mockResolvedValueOnce('my-project') // projectName
+      .mockResolvedValueOnce('owner/repo') // repository
+      .mockResolvedValueOnce('/tmp/repo') // repoPath
+      .mockResolvedValueOnce('main') // baseBranch
+      .mockResolvedValueOnce('ghp_token') // token (auth)
+      .mockResolvedValueOnce('npm install') // install
+      .mockResolvedValueOnce('npm run build') // build
+      .mockResolvedValueOnce('npm test') // test
+      .mockResolvedValueOnce('npm run lint'); // lint
+    mockSelect
+      .mockResolvedValueOnce('github') // platform
+      .mockResolvedValueOnce('ids') // issueMode
+      .mockResolvedValueOnce('token'); // auth method
+    mockConfirm.mockResolvedValueOnce(true); // wantsCommands
+
+    const result = await collectAnswers(false);
+    expect(result.commands).toMatchObject({
+      install: 'npm install',
+      build: 'npm run build',
+      test: 'npm test',
+      lint: 'npm run lint',
+    });
+  });
+});
+
+describe('collectAnswers – yes=false, azure-devops platform', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does NOT call GitHub auth prompts', async () => {
+    mockInput
+      .mockResolvedValueOnce('my-project') // projectName
+      .mockResolvedValueOnce('my-repo') // repository
+      .mockResolvedValueOnce('/tmp/repo') // repoPath
+      .mockResolvedValueOnce('main'); // baseBranch
+    mockSelect
+      .mockResolvedValueOnce('azure-devops') // platform
+      .mockResolvedValueOnce('ids'); // issueMode
+    mockConfirm.mockResolvedValueOnce(false);
+
+    const result = await collectAnswers(false);
+    expect(result.githubAuth).toBeUndefined();
+  });
+
+  it('returns platform azure-devops in the result', async () => {
+    mockInput
+      .mockResolvedValueOnce('my-project') // projectName
+      .mockResolvedValueOnce('my-repo') // repository
+      .mockResolvedValueOnce('/tmp/repo') // repoPath
+      .mockResolvedValueOnce('main'); // baseBranch
+    mockSelect
+      .mockResolvedValueOnce('azure-devops') // platform
+      .mockResolvedValueOnce('ids'); // issueMode
+    mockConfirm.mockResolvedValueOnce(false);
+
+    const result = await collectAnswers(false);
+    expect(result.platform).toBe('azure-devops');
+  });
+
+  it('uses validateAzureDevOpsRepository as the validate function for the repository input', async () => {
+    mockInput
+      .mockResolvedValueOnce('my-project') // projectName
+      .mockResolvedValueOnce('my-repo') // repository
+      .mockResolvedValueOnce('/tmp/repo') // repoPath
+      .mockResolvedValueOnce('main'); // baseBranch
+    mockSelect
+      .mockResolvedValueOnce('azure-devops') // platform
+      .mockResolvedValueOnce('ids'); // issueMode
+    mockConfirm.mockResolvedValueOnce(false);
+
+    await collectAnswers(false);
+
+    // The repository input is the 2nd call to input
+    const repositoryCall = mockInput.mock.calls[1][0] as { validate?: unknown };
+    expect(repositoryCall.validate).toBe(validateAzureDevOpsRepository);
+  });
+});


### PR DESCRIPTION
## Summary

Closes 5 of the highest-priority coverage gaps identified in the coverage-improvement tracking doc.

## Changes

| File | Tests added | Source gap closed |
|------|-------------|-------------------|
| `tests/github-mcp-client.test.ts` *(new)* | 23 | `src/github/mcp-client.ts` 17% → full |
| `tests/prompts-collect.test.ts` *(new)* | 18 | `src/cli/prompts.ts` lines 84–232 |
| `tests/config-loader-paths.test.ts` *(new)* | 14 | `src/config/loader.ts` branch coverage |
| `tests/parallel-executor.test.ts` *(extended)* | 8 | `src/execution/parallel-executor.ts` lines 41–42, 66–93 |
| `tests/azure-devops-provider.test.ts` *(extended)* | 34 | `src/platform/azure-devops-provider.ts` lines 306–408, 453–498 |

**Also:** `cadre.config.json` — increase copilot `timeout` from 300 s to 600 s.

## Detail

### `github-mcp-client.test.ts`
Mocks `@modelcontextprotocol/sdk` so no subprocess is spawned. Covers `connect` (idempotent), `disconnect` (idempotent, swallows close errors), `callTool` (JSON parsing, error flag, empty content, plain text fallback), `isConnected`, and `checkAuth`.

### `prompts-collect.test.ts`
Mocks `@inquirer/prompts` input/select/confirm. Covers `collectAnswers()` for the `yes=true` fast path (skips non-essential prompts, fixed defaults), GitHub token auth, GitHub App auth, both issue modes (ids / query), command prompts, and azure-devops platform wiring (correct validator attached to repository input, no GitHub auth prompts).

### `config-loader-paths.test.ts`
Covers all five `resolveAgentDir()` branches: absolute, `.cadre/`-prefixed, `.claude/`-prefixed, bare name (→ stateDir), and repo-relative (→ repoPath). Also covers `stateDir` defaulting to `~/.cadre/<projectName>` and relative resolution, and `worktreeRoot` defaulting and relative resolution.

### `parallel-executor.test.ts`
Adds `execute()` with `delayMs` (fake timers verify no delay for index 0, delay for later indices) and `executeSettled()` (all results returned even on throw, agent name preserved on synthetic failure, error field populated, order preserved).

### `azure-devops-provider.test.ts`
Adds `listIssues()` tests for WIQL query construction (state NOT IN / IN, Tags Contains per label, IterationPath UNDER, AssignedTo), empty result short-circuit, batch fetch, and `$top` limit. Adds `getPullRequest()`, `listPullRequests()` (state mapping, head filter), `updatePullRequest()`, and the `listPRComments()` / `listPRReviews()` stubs.