### PR TITLE
fix: review-response pipeline always starts at phase 3

### DIFF
--- a/cadre.config.json
+++ b/cadre.config.json
@@ -44,7 +44,7 @@
   "copilot": {
     "cliCommand": "copilot",
     "model": "claude-sonnet-4.6",
-    "timeout": 600000
+    "timeout": 1200000
   },
   "environment": {
     "inheritShellPath": true,

--- a/src/core/review-response-orchestrator.ts
+++ b/src/core/review-response-orchestrator.ts
@@ -320,6 +320,11 @@ export class ReviewResponseOrchestrator {
         // implementation plan.  Without this, IssueOrchestrator sees them as
         // already completed and skips them entirely.
         await checkpoint.resetPhases(REVIEW_RESPONSE_PHASES);
+        // Ensure phases 1 and 2 are marked completed so IssueOrchestrator starts
+        // at phase 3.  On a fresh worktree the checkpoint has no completed phases,
+        // which would cause the orchestrator to fall back to phase 1.
+        await checkpoint.completePhase(1, '');
+        await checkpoint.completePhase(2, join(progressDir, 'implementation-plan.md'));
         await checkpoint.setWorktreeInfo(worktree.path, worktree.branch, worktree.baseCommit);
 
         const issueOrchestrator = new IssueOrchestrator(

--- a/tests/review-response-orchestrator.test.ts
+++ b/tests/review-response-orchestrator.test.ts
@@ -27,6 +27,7 @@ vi.mock('../src/core/checkpoint.js', () => ({
   CheckpointManager: vi.fn().mockImplementation(() => ({
     load: vi.fn().mockResolvedValue(undefined),
     resetPhases: vi.fn().mockResolvedValue(undefined),
+    completePhase: vi.fn().mockResolvedValue(undefined),
     setWorktreeInfo: vi.fn().mockResolvedValue(undefined),
   })),
 }));


### PR DESCRIPTION
## Problem

When `--respond-to-reviews` was used on a fresh worktree (or any worktree whose checkpoint had no completed phases), `IssueOrchestrator.getResumePoint()` returned phase 1. The full analysis and planning phases ran before reaching the reduced phases 3–5 that review-response is supposed to execute.

Root cause: `ReviewResponseOrchestrator` called `checkpoint.resetPhases([3,4,5])` (to force re-execution of those phases) but never ensured phases 1 and 2 were marked complete first. On a brand-new checkpoint, `completedPhases` is empty, so the orchestrator fell back to `{ phase: 1, task: null }`.

## Fix

After loading the checkpoint and resetting phases 3–5, explicitly mark phases 1 and 2 as completed so `getResumePoint()` always returns phase 3.

## Other changes

- Bump copilot agent `timeout` from 600 000 ms (10 min) to 1 200 000 ms (20 min) in `cadre.config.json`.