### PR TITLE
fix: cadre-json regex and resetPhases task clearing for review-response

### DIFF
--- a/src/core/checkpoint.ts
+++ b/src/core/checkpoint.ts
@@ -296,6 +296,19 @@ export class CheckpointManager {
     this.state.completedPhases = this.state.completedPhases.filter(
       (p) => !phaseIds.includes(p),
     );
+    // Tasks, gate results, and phase outputs have no phase-ID association in
+    // the checkpoint, so clearing them all is the only correct approach when
+    // rewinding phases for a review-response re-run.
+    this.state.completedTasks = [];
+    this.state.failedTasks = [];
+    this.state.blockedTasks = [];
+    this.state.currentTask = null;
+    for (const phaseId of phaseIds) {
+      delete this.state.phaseOutputs[phaseId];
+      if (this.state.gateResults) {
+        delete this.state.gateResults[phaseId];
+      }
+    }
     await this.save();
   }
 

--- a/src/util/cadre-json.ts
+++ b/src/util/cadre-json.ts
@@ -1,9 +1,13 @@
 /**
  * Extract and JSON-parse the first ```cadre-json``` fenced block from content.
  * Returns the parsed value, or null if no such block exists or the JSON is invalid.
+ *
+ * The closing fence must appear at the start of a line (preceded by a real newline).
+ * This prevents false matches against ``` sequences embedded inside JSON string values
+ * as escape sequences (e.g. `\n```ts` stored as two chars `\n` + backtick-backtick-backtick).
  */
 export function extractCadreJson(content: string): unknown | null {
-  const match = content.match(/```cadre-json\s*\n([\s\S]*?)```/);
+  const match = content.match(/```cadre-json[ \t]*\n([\s\S]*?)\n```[ \t]*(\n|$)/);
   if (!match) return null;
   try {
     return JSON.parse(match[1].trim());


### PR DESCRIPTION
Two bugs that caused the `--respond-to-reviews` pipeline to silently fail when resuming from a checkpoint.

## Bug 1: `extractCadreJson` regex terminated too early

**File:** `src/util/cadre-json.ts`

The regex `` /```cadre-json\s*\n([\s\S]*?)```/ `` matched the first ` ``` ` sequence inside the JSON body — including escaped code fences like `\n```ts` that appear as literal characters inside JSON string values. This caused `JSON.parse` to receive a truncated, invalid fragment and return `null`, making the pipeline report the file as missing a `cadre-json` block even though it was valid.

**Fix:** Require the closing fence to be preceded by a real newline (`` \n``` ``), so it only matches a fence at the start of a line and ignores embedded backtick sequences inside string values.

## Bug 2: `resetPhases()` didn't clear task state

**File:** `src/core/checkpoint.ts`

`resetPhases()` filtered `completedPhases` but left `completedTasks`, `failedTasks`, `blockedTasks`, `currentTask`, `phaseOutputs`, and `gateResults` untouched. On a review-response re-run, all prior task IDs were still marked complete so the implementation phase found 1/1 tasks done, produced no diff, and failed the gate.

**Fix:** Also clear `completedTasks`, `failedTasks`, `blockedTasks`, `currentTask`, and delete the `phaseOutputs`/`gateResults` entries for the reset phases.