### PR TITLE
feat: redesign implementation-planner output as two-level agent-session schema (#139)

### DIFF
--- a/src/agents/backend.ts
+++ b/src/agents/backend.ts
@@ -31,8 +31,8 @@ function buildEnv(
   env['CADRE_ISSUE_NUMBER'] = String(invocation.issueNumber);
   env['CADRE_WORKTREE_PATH'] = worktreePath;
   env['CADRE_PHASE'] = String(invocation.phase);
-  if (invocation.taskId) {
-    env['CADRE_TASK_ID'] = invocation.taskId;
+  if (invocation.sessionId) {
+    env['CADRE_SESSION_ID'] = invocation.sessionId;
   }
 
   if (config.environment.extraPath.length > 0) {
@@ -97,7 +97,7 @@ async function writeAgentLog(
       `=== Agent: ${invocation.agent} ===`,
       `=== Issue: #${invocation.issueNumber} ===`,
       `=== Phase: ${invocation.phase} ===`,
-      invocation.taskId ? `=== Task: ${invocation.taskId} ===` : '',
+      invocation.sessionId ? `=== Session: ${invocation.sessionId} ===` : '',
       `=== Started: ${new Date(startTime).toISOString()} ===`,
       `=== Duration: ${Date.now() - startTime}ms ===`,
       `=== Exit Code: ${processResult.exitCode} ===`,
@@ -149,13 +149,13 @@ export class CopilotBackend implements AgentBackend {
     await ensureDir(logDir);
 
     const timestamp = Date.now();
-    const taskSuffix = invocation.taskId ? `-${invocation.taskId}` : '';
-    const logFile = join(logDir, `${invocation.agent}${taskSuffix}-${timestamp}.log`);
+    const sessionSuffix = invocation.sessionId ? `-${invocation.sessionId}` : '';
+    const logFile = join(logDir, `${invocation.agent}${sessionSuffix}-${timestamp}.log`);
 
     this.logger.info(`Launching agent (copilot): ${invocation.agent}`, {
       issueNumber: invocation.issueNumber,
       phase: invocation.phase,
-      taskId: invocation.taskId,
+      sessionId: invocation.sessionId,
     });
 
     const prompt = `Read your context file at: ${invocation.contextPath}`;
@@ -200,7 +200,7 @@ export class CopilotBackend implements AgentBackend {
       this.logger.info(`Agent ${invocation.agent} completed in ${duration}ms`, {
         issueNumber: invocation.issueNumber,
         phase: invocation.phase,
-        taskId: invocation.taskId,
+        sessionId: invocation.sessionId,
         data: { tokenUsage, outputExists },
       });
     } else {
@@ -211,7 +211,7 @@ export class CopilotBackend implements AgentBackend {
         {
           issueNumber: invocation.issueNumber,
           phase: invocation.phase,
-          taskId: invocation.taskId,
+          sessionId: invocation.sessionId,
           data: { stderr: processResult.stderr.slice(0, 500) },
         },
       );
@@ -266,13 +266,13 @@ export class ClaudeBackend implements AgentBackend {
     await ensureDir(logDir);
 
     const timestamp = Date.now();
-    const taskSuffix = invocation.taskId ? `-${invocation.taskId}` : '';
-    const logFile = join(logDir, `${invocation.agent}${taskSuffix}-${timestamp}.log`);
+    const sessionSuffix = invocation.sessionId ? `-${invocation.sessionId}` : '';
+    const logFile = join(logDir, `${invocation.agent}${sessionSuffix}-${timestamp}.log`);
 
     this.logger.info(`Launching agent (claude): ${invocation.agent}`, {
       issueNumber: invocation.issueNumber,
       phase: invocation.phase,
-      taskId: invocation.taskId,
+      sessionId: invocation.sessionId,
     });
 
     const prompt = `Read your context file at: ${invocation.contextPath}`;
@@ -309,14 +309,14 @@ export class ClaudeBackend implements AgentBackend {
       this.logger.info(`Agent ${invocation.agent} completed in ${duration}ms`, {
         issueNumber: invocation.issueNumber,
         phase: invocation.phase,
-        taskId: invocation.taskId,
+        sessionId: invocation.sessionId,
         data: { tokenUsage, outputExists },
       });
     } else {
       this.logger.error(`Agent ${invocation.agent} failed (exit: ${processResult.exitCode}, timeout: ${processResult.timedOut})`, {
         issueNumber: invocation.issueNumber,
         phase: invocation.phase,
-        taskId: invocation.taskId,
+        sessionId: invocation.sessionId,
         data: { stderr: processResult.stderr.slice(0, 500) },
       });
     }

--- a/src/agents/result-parser.ts
+++ b/src/agents/result-parser.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { extractCadreJson } from '../util/cadre-json.js';
 import type {
-  ImplementationTask,
+  AgentSession,
   AnalysisResult,
   ScoutReport,
   ReviewResult,
@@ -39,9 +39,9 @@ export class ResultParser {
   }
 
   /**
-   * Parse an implementation plan markdown into a list of ImplementationTasks.
+   * Parse an implementation plan markdown into a list of AgentSessions.
    */
-  async parseImplementationPlan(planPath: string): Promise<ImplementationTask[]> {
+  async parseImplementationPlan(planPath: string): Promise<AgentSession[]> {
     const content = await readFile(planPath, 'utf-8');
 
     const parsed = extractCadreJson(content);

--- a/src/agents/schemas/implementation-plan.schema.ts
+++ b/src/agents/schemas/implementation-plan.schema.ts
@@ -1,16 +1,30 @@
 import { z } from 'zod';
 
-export const implementationTaskSchema = z.object({
+export const agentStepSchema = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string(),
   files: z.array(z.string()),
-  dependencies: z.array(z.string()),
   complexity: z.enum(['simple', 'moderate', 'complex']),
   acceptanceCriteria: z.array(z.string()),
 });
 
-export const implementationPlanSchema = z.array(implementationTaskSchema);
+export const agentSessionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  rationale: z.string(),
+  dependencies: z.array(z.string()),
+  steps: z.array(agentStepSchema),
+});
 
-export type ImplementationTask = z.infer<typeof implementationTaskSchema>;
+export const implementationPlanSchema = z.array(agentSessionSchema);
+
+export type AgentStep = z.infer<typeof agentStepSchema>;
+export type AgentSession = z.infer<typeof agentSessionSchema>;
 export type ImplementationPlan = z.infer<typeof implementationPlanSchema>;
+
+// Backward-compatibility aliases (deprecated — use AgentSession / AgentStep)
+/** @deprecated Use AgentSession */
+export type ImplementationTask = AgentSession;
+/** @deprecated Use agentSessionSchema */
+export const implementationTaskSchema = agentSessionSchema;

--- a/src/agents/schemas/index.ts
+++ b/src/agents/schemas/index.ts
@@ -4,8 +4,8 @@ export type { AnalysisResult } from './analysis.schema.js';
 export { scoutReportSchema } from './scout-report.schema.js';
 export type { ScoutReport } from './scout-report.schema.js';
 
-export { implementationTaskSchema, implementationPlanSchema } from './implementation-plan.schema.js';
-export type { ImplementationTask, ImplementationPlan } from './implementation-plan.schema.js';
+export { agentStepSchema, agentSessionSchema, implementationTaskSchema, implementationPlanSchema } from './implementation-plan.schema.js';
+export type { AgentStep, AgentSession, ImplementationTask, ImplementationPlan } from './implementation-plan.schema.js';
 
 export { reviewIssueSchema, reviewSchema } from './review.schema.js';
 export type { ReviewIssue, ReviewResult } from './review.schema.js';

--- a/src/agents/templates/implementation-planner.md
+++ b/src/agents/templates/implementation-planner.md
@@ -1,7 +1,7 @@
 # Implementation Planner
 
 ## Role
-Break a GitHub issue into a set of discrete implementation tasks with dependencies, ordering, and acceptance criteria.
+Break a GitHub issue into a set of **agent sessions**, each containing an ordered list of **steps**. One session = one code-writer agent invocation.
 
 ## Input Contract
 
@@ -9,31 +9,15 @@ You will receive:
 - **analysis.md**: Structured output from the issue-analyst agent, containing requirements, change type, scope estimate, affected areas, and ambiguities.
 - **scout-report.md**: Structured output from the codebase-scout agent, containing relevant files, dependency map, test files, and entry points.
 
-Read both files carefully before producing the plan. Use the affected areas and relevant files to determine which source files each task should touch.
+Read both files carefully before producing the plan. Use the affected areas and relevant files to determine which source files each step should touch.
 
 ## Output Contract
 
-Produce an **implementation-plan.md** file. You MUST include **two sections** in your output:
+Produce an **implementation-plan.md** file containing a machine-readable `cadre-json` block. CADRE parses only the `cadre-json` block — human-readable prose outside that block is optional.
 
-### 1. Human-readable task list (required for reviewability)
+### Machine-readable cadre-json block (MANDATORY — cadre cannot parse the plan without this)
 
-First write each task as a markdown section:
-
-```
-## task-XXX – {Task Name}
-
-**Description:** {One or two sentences describing what needs to change and why.}
-**Files:** {comma-separated list of source files to modify or create}
-**Dependencies:** {comma-separated list of task IDs that must complete first, or "none"}
-**Complexity:** {simple | moderate | complex}
-**Acceptance Criteria:**
-- {Specific, testable criterion}
-- {Specific, testable criterion}
-```
-
-### 2. Machine-readable cadre-json block (MANDATORY — cadre cannot parse the plan without this)
-
-At the very end of the file, after all task sections, you MUST append a fenced `cadre-json` block containing the complete task list as a JSON array. cadre reads this block to execute the plan. **If this block is missing or malformed, the entire run will fail.**
+At the end of the file you MUST include a fenced `cadre-json` block with the complete session array. **If this block is missing or malformed, the entire run will fail.**
 
 The block must match this exact schema:
 
@@ -41,14 +25,21 @@ The block must match this exact schema:
 ```cadre-json
 [
   {
-    "id": "task-001",
-    "name": "Short task name",
-    "description": "One or two sentences.",
-    "files": ["src/example.ts", "tests/example.test.ts"],
+    "id": "session-001",
+    "name": "Short session name",
+    "rationale": "Why these steps are grouped together.",
     "dependencies": [],
-    "complexity": "simple",
-    "acceptanceCriteria": [
-      "Specific verifiable criterion"
+    "steps": [
+      {
+        "id": "session-001-step-001",
+        "name": "Short step name",
+        "description": "One or two sentences describing what changes and why.",
+        "files": ["src/example.ts", "tests/example.test.ts"],
+        "complexity": "simple",
+        "acceptanceCriteria": [
+          "Specific verifiable criterion"
+        ]
+      }
     ]
   }
 ]
@@ -56,25 +47,48 @@ The block must match this exact schema:
 ````
 
 **Schema rules for the cadre-json block:**
-- The top-level value is a JSON **array** of task objects — not an object with a `tasks` key.
-- `id`: string, sequential, e.g. `"task-001"`, `"task-002"`.
-- `name`: short descriptive string.
-- `description`: one or two sentences.
-- `files`: JSON array of strings (file paths relative to repo root).
-- `dependencies`: JSON array of task ID strings (empty array `[]` when none).
-- `complexity`: one of `"simple"`, `"moderate"`, `"complex"`.
-- `acceptanceCriteria`: JSON array of strings; each entry is a single testable criterion.
+- The top-level value is a JSON **array** of session objects — not an object with a `sessions` key.
+- **Session fields:**
+  - `id`: string, sequential, e.g. `"session-001"`, `"session-002"`.
+  - `name`: short descriptive string.
+  - `rationale`: one sentence explaining why these steps are grouped in one agent invocation.
+  - `dependencies`: JSON array of session ID strings that must complete before this session starts (empty array `[]` when none).
+  - `steps`: non-empty JSON array of step objects (ordered).
+- **Step fields:**
+  - `id`: string formatted as `"<sessionId>-step-<NNN>"`, e.g. `"session-001-step-001"`.
+  - `name`: short step name.
+  - `description`: one or two sentences.
+  - `files`: JSON array of file paths relative to repo root. Must include test files the step creates or modifies.
+  - `complexity`: one of `"simple"`, `"moderate"`, `"complex"`.
+  - `acceptanceCriteria`: non-empty JSON array of strings; each entry is a single testable criterion.
 - All string values must be valid JSON (escape quotes, no trailing commas).
 
-### Rules
+---
+
+## Session Sizing Guidance
+
+**Session sizing:** Each session you define is a single agent invocation. Group steps into a session when they are logically cohesive and the agent benefits from seeing its prior step output before doing the next step (e.g., add a helper → update its caller → update the test). Only split into a new session when the work is truly independent and large enough to warrant a separate focused invocation.
+
+**Step granularity:** Steps within a session should be fine-grained enough to be individually verifiable. A step should touch a coherent set of files (typically one source file and its test file). Each step has a `complexity` field (`simple` / `moderate` / `complex`) describing that step's scope of change.
+
+**Grouping heuristics:**
+- Prefer fewer sessions over many. A session with several steps is better than several single-step sessions for related work.
+- Group steps into the same session when they share a logical dependency chain (e.g., step A produces a type that step B consumes).
+- Split into a new session when the work touches a completely different concern and there is no benefit to shared in-session context.
+- Avoid creating one session per step — that defeats the purpose of the grouping.
+
+---
+
+## Rules
 - You MUST read every source file you intend to reference before making any claims about its contents or structure.
-- Task IDs must be sequential: `task-001`, `task-002`, etc.
-- Every task must list explicit file paths relative to the repository root.
-- The `files` list must include every test file the task creates or modifies (e.g., `tests/*.test.ts`), not just source files.
-- Dependencies must only reference task IDs defined earlier in the same plan.
+- Session IDs must be sequential: `session-001`, `session-002`, etc.
+- Step IDs must follow the pattern `<sessionId>-step-<NNN>`, e.g. `session-001-step-001`.
+- Every step must list explicit file paths relative to the repository root.
+- The `files` list on a step must include every test file that step creates or modifies.
+- Session `dependencies` must only reference `id` values of other sessions in the same plan.
+- Steps within a session do **not** have dependencies on each other — they are always executed in order.
 - Acceptance criteria must be concrete and verifiable (not vague goals).
-- Order tasks so that no task depends on one that appears later.
-- Do not include tasks for changes outside the scope identified in analysis.md.
+- Do not include sessions for changes outside the scope identified in analysis.md.
 - **The cadre-json block must be the last thing in the file.**
 
 ## Tool Permissions
@@ -83,54 +97,57 @@ The block must match this exact schema:
 
 ## Example Output
 
-```
-## task-001 – Add timeout configuration constant
-
-**Description:** Define a DEFAULT_TIMEOUT constant in the shared config module so all components can reference a single source of truth for the default timeout value.
-**Files:** src/config.ts
-**Dependencies:** none
-**Complexity:** simple
-**Acceptance Criteria:**
-- `DEFAULT_TIMEOUT` is exported from `src/config.ts`
-- Value is `30` (seconds)
-
-## task-002 – Accept timeout parameter in login handler
-
-**Description:** Update the loginHandler function to accept an optional `timeout` parameter, falling back to `DEFAULT_TIMEOUT` when not provided.
-**Files:** src/auth/login.ts, tests/auth/login.test.ts
-**Dependencies:** task-001
-**Complexity:** moderate
-**Acceptance Criteria:**
-- `loginHandler` accepts an optional `timeout?: number` parameter
-- When `timeout` is omitted, the handler uses `DEFAULT_TIMEOUT`
-- Existing tests continue to pass without modification
-```
-
 ```cadre-json
 [
   {
-    "id": "task-001",
-    "name": "Add timeout configuration constant",
-    "description": "Define a DEFAULT_TIMEOUT constant in the shared config module so all components can reference a single source of truth for the default timeout value.",
-    "files": ["src/config.ts"],
+    "id": "session-001",
+    "name": "Add timeout constant and update login handler",
+    "rationale": "These steps share a tight dependency — the constant is defined in step 1 and consumed in step 2, so the agent benefits from seeing step 1's output before step 2.",
     "dependencies": [],
-    "complexity": "simple",
-    "acceptanceCriteria": [
-      "`DEFAULT_TIMEOUT` is exported from `src/config.ts`",
-      "Value is `30` (seconds)"
+    "steps": [
+      {
+        "id": "session-001-step-001",
+        "name": "Add timeout configuration constant",
+        "description": "Define a DEFAULT_TIMEOUT constant in the shared config module so all components can reference a single source of truth for the default timeout value.",
+        "files": ["src/config.ts"],
+        "complexity": "simple",
+        "acceptanceCriteria": [
+          "`DEFAULT_TIMEOUT` is exported from `src/config.ts`",
+          "Value is `30` (seconds)"
+        ]
+      },
+      {
+        "id": "session-001-step-002",
+        "name": "Accept timeout parameter in login handler",
+        "description": "Update the loginHandler function to accept an optional `timeout` parameter, falling back to `DEFAULT_TIMEOUT` when not provided.",
+        "files": ["src/auth/login.ts", "tests/auth/login.test.ts"],
+        "complexity": "moderate",
+        "acceptanceCriteria": [
+          "`loginHandler` accepts an optional `timeout?: number` parameter",
+          "When `timeout` is omitted, the handler uses `DEFAULT_TIMEOUT`",
+          "Existing tests continue to pass without modification"
+        ]
+      }
     ]
   },
   {
-    "id": "task-002",
-    "name": "Accept timeout parameter in login handler",
-    "description": "Update the loginHandler function to accept an optional `timeout` parameter, falling back to `DEFAULT_TIMEOUT` when not provided.",
-    "files": ["src/auth/login.ts", "tests/auth/login.test.ts"],
-    "dependencies": ["task-001"],
-    "complexity": "moderate",
-    "acceptanceCriteria": [
-      "`loginHandler` accepts an optional `timeout?: number` parameter",
-      "When `timeout` is omitted, the handler uses `DEFAULT_TIMEOUT`",
-      "Existing tests continue to pass without modification"
+    "id": "session-002",
+    "name": "Update API route to pass timeout",
+    "rationale": "Independent of session-001's internal implementation — the route only needs session-001 to complete first so the loginHandler signature is stable.",
+    "dependencies": ["session-001"],
+    "steps": [
+      {
+        "id": "session-002-step-001",
+        "name": "Thread timeout from API route to login handler",
+        "description": "Update the /login API route to read an optional `timeout` query parameter and pass it to loginHandler.",
+        "files": ["src/routes/login.route.ts", "tests/routes/login.route.test.ts"],
+        "complexity": "simple",
+        "acceptanceCriteria": [
+          "Route reads optional `timeout` query param (integer, seconds)",
+          "Timeout is forwarded to `loginHandler`",
+          "Route handler tests cover both timeout-provided and timeout-omitted cases"
+        ]
+      }
     ]
   }
 ]

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -126,8 +126,8 @@ export interface AgentInvocation {
   issueNumber: number;
   /** Current pipeline phase. */
   phase: number;
-  /** Optional task ID (for Implementation phase). */
-  taskId?: string;
+  /** Optional session ID (for Implementation phase). */
+  sessionId?: string;
   /** Path to the context JSON file the agent should read. */
   contextPath: string;
   /** Expected output path(s). */
@@ -162,23 +162,38 @@ export interface AgentResult {
   error?: string;
 }
 
-/** An implementation task parsed from the planner's output. */
-export interface ImplementationTask {
-  /** Unique task ID (e.g. "task-001"). */
+/** A discrete unit of work within an agent session. */
+export interface AgentStep {
+  /** Unique step ID (e.g. "session-001-step-001"). */
   id: string;
-  /** Human-readable task name. */
+  /** Human-readable step name. */
   name: string;
-  /** Description of what needs to change. */
+  /** Description of what this step changes and why. */
   description: string;
   /** Source files to modify or create. */
   files: string[];
-  /** IDs of tasks that must complete before this one. */
-  dependencies: string[];
-  /** Complexity estimate. */
+  /** Complexity estimate for this step. */
   complexity: 'simple' | 'moderate' | 'complex';
-  /** Acceptance criteria. */
+  /** Testable acceptance criteria. */
   acceptanceCriteria: string[];
 }
+
+/** A single code-writer agent invocation, containing an ordered list of steps. */
+export interface AgentSession {
+  /** Unique session ID (e.g. "session-001"). */
+  id: string;
+  /** Short human-readable label. */
+  name: string;
+  /** Why these steps are grouped together. */
+  rationale: string;
+  /** Session IDs that must complete before this session starts. */
+  dependencies: string[];
+  /** Ordered steps to execute within this session. */
+  steps: AgentStep[];
+}
+
+/** @deprecated Use AgentSession */
+export type ImplementationTask = AgentSession;
 
 /** Parsed analysis output. */
 export interface AnalysisResult {
@@ -261,7 +276,7 @@ export interface AgentContext {
   repository: string;
   worktreePath: string;
   phase: number;
-  taskId?: string;
+  sessionId?: string;
   config: {
     commands: {
       install?: string;

--- a/src/core/review-response-orchestrator.ts
+++ b/src/core/review-response-orchestrator.ts
@@ -257,49 +257,67 @@ export class ReviewResponseOrchestrator {
         const threadTasks = activeThreads.map((thread, idx) => {
           const files = [...new Set(thread.comments.map((c) => c.path).filter(Boolean))];
           const description = thread.comments.map((c) => c.body).join('\n\n');
+          const sessionId = `session-${String(idx + 1).padStart(3, '0')}`;
           return {
-            id: `task-${String(idx + 1).padStart(3, '0')}`,
+            id: sessionId,
             name: `Address review comment${files.length ? ` in ${files[0]}` : ''}`,
-            description,
-            files: files.length ? files : [],
+            rationale: 'Address code review thread',
             dependencies: [] as string[],
-            complexity: 'simple' as const,
-            acceptanceCriteria: [
-              'Review comment addressed as described',
-              'Existing tests continue to pass',
-            ],
+            steps: [{
+              id: `${sessionId}-step-001`,
+              name: `Address review comment${files.length ? ` in ${files[0]}` : ''}`,
+              description,
+              files: files.length ? files : [],
+              complexity: 'simple' as const,
+              acceptanceCriteria: [
+                'Review comment addressed as described',
+                'Existing tests continue to pass',
+              ],
+            }],
           };
         });
 
         const commentTasks = actionableComments.map((comment, idx) => {
-          const taskIdx = activeThreads.length + idx + 1;
+          const sessionIdx = activeThreads.length + idx + 1;
+          const sessionId = `session-${String(sessionIdx).padStart(3, '0')}`;
           return {
-            id: `task-${String(taskIdx).padStart(3, '0')}`,
+            id: sessionId,
             name: `Address PR comment from ${comment.author}`,
-            description: comment.body,
-            files: [] as string[],
+            rationale: 'Address PR comment',
             dependencies: [] as string[],
-            complexity: 'simple' as const,
-            acceptanceCriteria: [
-              'PR comment addressed as described',
-              'Existing tests continue to pass',
-            ],
+            steps: [{
+              id: `${sessionId}-step-001`,
+              name: `Address PR comment from ${comment.author}`,
+              description: comment.body,
+              files: [] as string[],
+              complexity: 'simple' as const,
+              acceptanceCriteria: [
+                'PR comment addressed as described',
+                'Existing tests continue to pass',
+              ],
+            }],
           };
         });
 
         const reviewBodyTasks = actionableReviews.map((review, idx) => {
-          const taskIdx = activeThreads.length + actionableComments.length + idx + 1;
+          const sessionIdx = activeThreads.length + actionableComments.length + idx + 1;
+          const sessionId = `session-${String(sessionIdx).padStart(3, '0')}`;
           return {
-            id: `task-${String(taskIdx).padStart(3, '0')}`,
+            id: sessionId,
             name: `Address PR review from ${review.author}`,
-            description: review.body,
-            files: [] as string[],
+            rationale: 'Address PR review feedback',
             dependencies: [] as string[],
-            complexity: 'simple' as const,
-            acceptanceCriteria: [
-              'PR review feedback addressed as described',
-              'Existing tests continue to pass',
-            ],
+            steps: [{
+              id: `${sessionId}-step-001`,
+              name: `Address PR review from ${review.author}`,
+              description: review.body,
+              files: [] as string[],
+              complexity: 'simple' as const,
+              acceptanceCriteria: [
+                'PR review feedback addressed as described',
+                'Existing tests continue to pass',
+              ],
+            }],
           };
         });
 

--- a/src/execution/parallel-executor.ts
+++ b/src/execution/parallel-executor.ts
@@ -43,7 +43,7 @@ export class ParallelExecutor {
 
           this.logger.debug(`Parallel executor: launching ${invocation.agent}`, {
             issueNumber: invocation.issueNumber,
-            taskId: invocation.taskId,
+            sessionId: invocation.sessionId,
           });
 
           return this.launcher.launchAgent(invocation, worktreePath);

--- a/src/execution/serial-executor.ts
+++ b/src/execution/serial-executor.ts
@@ -29,7 +29,7 @@ export class SerialExecutor {
 
       this.logger.debug(`Serial executor: launching ${invocation.agent} (${i + 1}/${invocations.length})`, {
         issueNumber: invocation.issueNumber,
-        taskId: invocation.taskId,
+        sessionId: invocation.sessionId,
       });
 
       const result = await this.launcher.launchAgent(invocation, worktreePath);

--- a/src/execution/task-queue.ts
+++ b/src/execution/task-queue.ts
@@ -1,30 +1,47 @@
-import type { ImplementationTask } from '../agents/types.js';
+import type { AgentSession } from '../agents/types.js';
 
 /**
- * Dependency-aware task queue with topological ordering.
- * Tasks are released when all their dependencies are satisfied.
+ * Returns the union of all file paths covered by a session (across all its steps).
  */
-export class TaskQueue {
-  private readonly tasks: Map<string, ImplementationTask>;
+function sessionFiles(session: AgentSession): string[] {
+  const seen = new Set<string>();
+  const files: string[] = [];
+  for (const step of session.steps) {
+    for (const f of step.files) {
+      if (!seen.has(f)) {
+        seen.add(f);
+        files.push(f);
+      }
+    }
+  }
+  return files;
+}
+
+/**
+ * Dependency-aware session queue with topological ordering.
+ * Sessions are released when all their dependencies are satisfied.
+ */
+export class SessionQueue {
+  private readonly sessions: Map<string, AgentSession>;
   private readonly completed: Set<string> = new Set();
   private readonly blocked: Set<string> = new Set();
   private readonly inProgress: Set<string> = new Set();
 
-  constructor(tasks: ImplementationTask[]) {
-    this.tasks = new Map(tasks.map((t) => [t.id, t]));
+  constructor(sessions: AgentSession[]) {
+    this.sessions = new Map(sessions.map((s) => [s.id, s]));
     this.validate();
   }
 
   /**
-   * Validate the task graph: check for missing dependencies and cycles.
+   * Validate the session graph: check for missing dependencies and cycles.
    */
   private validate(): void {
     // Check all dependencies exist
-    for (const task of this.tasks.values()) {
-      for (const dep of task.dependencies) {
-        if (!this.tasks.has(dep)) {
+    for (const session of this.sessions.values()) {
+      for (const dep of session.dependencies) {
+        if (!this.sessions.has(dep)) {
           throw new Error(
-            `Task ${task.id} depends on ${dep}, which does not exist`,
+            `Session ${session.id} depends on ${dep}, which does not exist`,
           );
         }
       }
@@ -35,21 +52,21 @@ export class TaskQueue {
   }
 
   /**
-   * Get tasks that are ready to execute (all dependencies satisfied).
+   * Get sessions that are ready to execute (all dependencies satisfied).
    */
-  getReady(): ImplementationTask[] {
-    const ready: ImplementationTask[] = [];
+  getReady(): AgentSession[] {
+    const ready: AgentSession[] = [];
 
-    for (const task of this.tasks.values()) {
-      if (this.completed.has(task.id)) continue;
-      if (this.blocked.has(task.id)) continue;
-      if (this.inProgress.has(task.id)) continue;
+    for (const session of this.sessions.values()) {
+      if (this.completed.has(session.id)) continue;
+      if (this.blocked.has(session.id)) continue;
+      if (this.inProgress.has(session.id)) continue;
 
-      const depsOk = task.dependencies.every(
+      const depsOk = session.dependencies.every(
         (dep) => this.completed.has(dep) || this.blocked.has(dep),
       );
       if (depsOk) {
-        ready.push(task);
+        ready.push(session);
       }
     }
 
@@ -57,43 +74,43 @@ export class TaskQueue {
   }
 
   /**
-   * Mark a task as in-progress.
+   * Mark a session as in-progress.
    */
-  start(taskId: string): void {
-    if (!this.tasks.has(taskId)) {
-      throw new Error(`Unknown task: ${taskId}`);
+  start(sessionId: string): void {
+    if (!this.sessions.has(sessionId)) {
+      throw new Error(`Unknown session: ${sessionId}`);
     }
-    this.inProgress.add(taskId);
+    this.inProgress.add(sessionId);
   }
 
   /**
-   * Mark a task as completed.
+   * Mark a session as completed.
    */
-  complete(taskId: string): void {
-    if (!this.tasks.has(taskId)) {
-      throw new Error(`Unknown task: ${taskId}`);
+  complete(sessionId: string): void {
+    if (!this.sessions.has(sessionId)) {
+      throw new Error(`Unknown session: ${sessionId}`);
     }
-    this.inProgress.delete(taskId);
-    this.completed.add(taskId);
+    this.inProgress.delete(sessionId);
+    this.completed.add(sessionId);
   }
 
   /**
-   * Mark a task as blocked (max retries exceeded).
+   * Mark a session as blocked (max retries exceeded).
    */
-  markBlocked(taskId: string): void {
-    if (!this.tasks.has(taskId)) {
-      throw new Error(`Unknown task: ${taskId}`);
+  markBlocked(sessionId: string): void {
+    if (!this.sessions.has(sessionId)) {
+      throw new Error(`Unknown session: ${sessionId}`);
     }
-    this.inProgress.delete(taskId);
-    this.blocked.add(taskId);
+    this.inProgress.delete(sessionId);
+    this.blocked.add(sessionId);
   }
 
   /**
-   * Check if all tasks are done (completed or blocked).
+   * Check if all sessions are done (completed or blocked).
    */
   isComplete(): boolean {
-    for (const task of this.tasks.values()) {
-      if (!this.completed.has(task.id) && !this.blocked.has(task.id)) {
+    for (const session of this.sessions.values()) {
+      if (!this.completed.has(session.id) && !this.blocked.has(session.id)) {
         return false;
       }
     }
@@ -101,17 +118,17 @@ export class TaskQueue {
   }
 
   /**
-   * Get a task by ID.
+   * Get a session by ID.
    */
-  getTask(taskId: string): ImplementationTask | undefined {
-    return this.tasks.get(taskId);
+  getSession(sessionId: string): AgentSession | undefined {
+    return this.sessions.get(sessionId);
   }
 
   /**
-   * Get all tasks.
+   * Get all sessions.
    */
-  getAllTasks(): ImplementationTask[] {
-    return Array.from(this.tasks.values());
+  getAllSessions(): AgentSession[] {
+    return Array.from(this.sessions.values());
   }
 
   /**
@@ -124,7 +141,7 @@ export class TaskQueue {
     inProgress: number;
     pending: number;
   } {
-    const total = this.tasks.size;
+    const total = this.sessions.size;
     return {
       total,
       completed: this.completed.size,
@@ -135,10 +152,10 @@ export class TaskQueue {
   }
 
   /**
-   * Check if a specific task is completed.
+   * Check if a specific session is completed.
    */
-  isTaskCompleted(taskId: string): boolean {
-    return this.completed.has(taskId);
+  isTaskCompleted(sessionId: string): boolean {
+    return this.completed.has(sessionId);
   }
 
   /**
@@ -146,46 +163,46 @@ export class TaskQueue {
    */
   restoreState(completedTasks: string[], blockedTasks: string[]): void {
     for (const id of completedTasks) {
-      if (this.tasks.has(id)) {
+      if (this.sessions.has(id)) {
         this.completed.add(id);
       }
     }
     for (const id of blockedTasks) {
-      if (this.tasks.has(id)) {
+      if (this.sessions.has(id)) {
         this.blocked.add(id);
       }
     }
   }
 
   /**
-   * Topological sort of all tasks. Throws if a cycle is detected.
+   * Topological sort of all sessions. Throws if a cycle is detected.
    */
-  topologicalSort(): ImplementationTask[] {
-    const sorted: ImplementationTask[] = [];
+  topologicalSort(): AgentSession[] {
+    const sorted: AgentSession[] = [];
     const visited = new Set<string>();
     const visiting = new Set<string>();
 
-    const visit = (taskId: string): void => {
-      if (visited.has(taskId)) return;
-      if (visiting.has(taskId)) {
-        throw new Error(`Cycle detected in task dependencies involving: ${taskId}`);
+    const visit = (sessionId: string): void => {
+      if (visited.has(sessionId)) return;
+      if (visiting.has(sessionId)) {
+        throw new Error(`Cycle detected in session dependencies involving: ${sessionId}`);
       }
 
-      visiting.add(taskId);
-      const task = this.tasks.get(taskId);
-      if (!task) return;
+      visiting.add(sessionId);
+      const session = this.sessions.get(sessionId);
+      if (!session) return;
 
-      for (const dep of task.dependencies) {
+      for (const dep of session.dependencies) {
         visit(dep);
       }
 
-      visiting.delete(taskId);
-      visited.add(taskId);
-      sorted.push(task);
+      visiting.delete(sessionId);
+      visited.add(sessionId);
+      sorted.push(session);
     };
 
-    for (const taskId of this.tasks.keys()) {
-      visit(taskId);
+    for (const sessionId of this.sessions.keys()) {
+      visit(sessionId);
     }
 
     return sorted;
@@ -193,22 +210,22 @@ export class TaskQueue {
 
   /**
    * Detect file-path collisions across a completed batch.
-   * Returns one description per colliding pair, e.g.
-   *   "File src/foo.ts claimed by both task-001 and task-003"
+   * Uses the union of all step files within each session.
+   * Returns one description per colliding pair.
    */
-  static detectBatchCollisions(tasks: ImplementationTask[]): string[] {
-    const fileToTasks = new Map<string, string[]>();
+  static detectBatchCollisions(sessions: AgentSession[]): string[] {
+    const fileToSessions = new Map<string, string[]>();
 
-    for (const task of tasks) {
-      for (const file of task.files) {
-        const owners = fileToTasks.get(file) ?? [];
-        owners.push(task.id);
-        fileToTasks.set(file, owners);
+    for (const session of sessions) {
+      for (const file of sessionFiles(session)) {
+        const owners = fileToSessions.get(file) ?? [];
+        owners.push(session.id);
+        fileToSessions.set(file, owners);
       }
     }
 
     const collisions: string[] = [];
-    for (const [file, owners] of fileToTasks) {
+    for (const [file, owners] of fileToSessions) {
       if (owners.length < 2) continue;
       for (let i = 0; i < owners.length - 1; i++) {
         for (let j = i + 1; j < owners.length; j++) {
@@ -223,22 +240,23 @@ export class TaskQueue {
   }
 
   /**
-   * Select a batch of non-overlapping ready tasks.
-   * Tasks that modify the same files cannot run in the same batch.
+   * Select a batch of non-overlapping ready sessions.
+   * Sessions that share files (across all their steps) cannot run in the same batch.
    */
   static selectNonOverlappingBatch(
-    readyTasks: ImplementationTask[],
+    readySessions: AgentSession[],
     maxBatchSize: number,
-  ): ImplementationTask[] {
-    const batch: ImplementationTask[] = [];
+  ): AgentSession[] {
+    const batch: AgentSession[] = [];
     const claimedFiles = new Set<string>();
 
-    for (const task of readyTasks) {
+    for (const session of readySessions) {
       if (batch.length >= maxBatchSize) break;
-      const hasOverlap = task.files.some((f) => claimedFiles.has(f));
+      const files = sessionFiles(session);
+      const hasOverlap = files.some((f) => claimedFiles.has(f));
       if (!hasOverlap) {
-        batch.push(task);
-        for (const f of task.files) {
+        batch.push(session);
+        for (const f of files) {
           claimedFiles.add(f);
         }
       }
@@ -247,3 +265,8 @@ export class TaskQueue {
     return batch;
   }
 }
+
+/**
+ * @deprecated Use SessionQueue. TaskQueue is an alias kept for backward compatibility.
+ */
+export const TaskQueue = SessionQueue;

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -87,7 +87,7 @@ export class Logger {
   private buildEntry(
     level: LogLevel,
     message: string,
-    context?: { issueNumber?: number; phase?: number; taskId?: string; data?: Record<string, unknown> },
+    context?: { issueNumber?: number; phase?: number; taskId?: string; sessionId?: string; data?: Record<string, unknown> },
   ): LogEntry {
     return {
       timestamp: new Date().toISOString(),
@@ -98,19 +98,19 @@ export class Logger {
     };
   }
 
-  debug(message: string, context?: { issueNumber?: number; phase?: number; taskId?: string; data?: Record<string, unknown> }): void {
+  debug(message: string, context?: { issueNumber?: number; phase?: number; taskId?: string; sessionId?: string; data?: Record<string, unknown> }): void {
     void this.writeEntry(this.buildEntry('debug', message, context));
   }
 
-  info(message: string, context?: { issueNumber?: number; phase?: number; taskId?: string; data?: Record<string, unknown> }): void {
+  info(message: string, context?: { issueNumber?: number; phase?: number; taskId?: string; sessionId?: string; data?: Record<string, unknown> }): void {
     void this.writeEntry(this.buildEntry('info', message, context));
   }
 
-  warn(message: string, context?: { issueNumber?: number; phase?: number; taskId?: string; data?: Record<string, unknown> }): void {
+  warn(message: string, context?: { issueNumber?: number; phase?: number; taskId?: string; sessionId?: string; data?: Record<string, unknown> }): void {
     void this.writeEntry(this.buildEntry('warn', message, context));
   }
 
-  error(message: string, context?: { issueNumber?: number; phase?: number; taskId?: string; data?: Record<string, unknown> }): void {
+  error(message: string, context?: { issueNumber?: number; phase?: number; taskId?: string; sessionId?: string; data?: Record<string, unknown> }): void {
     void this.writeEntry(this.buildEntry('error', message, context));
   }
 

--- a/tests/agent-backend.test.ts
+++ b/tests/agent-backend.test.ts
@@ -92,7 +92,7 @@ function makeInvocation(overrides: Partial<AgentInvocation> = {}): AgentInvocati
     agent: 'code-writer',
     issueNumber: 42,
     phase: 3,
-    taskId: 'task-001',
+    sessionId: 'session-001',
     contextPath: '/tmp/worktree/.cadre/issues/42/contexts/ctx.json',
     outputPath: '/tmp/worktree/.cadre/issues/42/outputs/result.md',
     ...overrides,
@@ -299,21 +299,21 @@ describe('CopilotBackend', () => {
     expect(opts.env?.['CADRE_PHASE']).toBe('3');
   });
 
-  it('should set CADRE_TASK_ID env var when taskId is provided', async () => {
+  it('should set CADRE_SESSION_ID env var when taskId is provided', async () => {
     const backend = new CopilotBackend(config, logger as never);
     setupSpawn(makeProcessResult());
-    await backend.invoke(makeInvocation({ taskId: 'task-007' }), '/tmp/worktree');
+    await backend.invoke(makeInvocation({ sessionId: 'session-007' }), '/tmp/worktree');
     const [, , opts] = mockSpawnProcess.mock.calls[0];
-    expect(opts.env?.['CADRE_TASK_ID']).toBe('task-007');
+    expect(opts.env?.['CADRE_SESSION_ID']).toBe('session-007');
   });
 
-  it('should not set CADRE_TASK_ID env var when taskId is absent', async () => {
-    vi.stubEnv('CADRE_TASK_ID', undefined as unknown as string);
+  it('should not set CADRE_SESSION_ID env var when taskId is absent', async () => {
+    vi.stubEnv('CADRE_SESSION_ID', undefined as unknown as string);
     const backend = new CopilotBackend(config, logger as never);
     setupSpawn(makeProcessResult());
-    await backend.invoke(makeInvocation({ taskId: undefined }), '/tmp/worktree');
+    await backend.invoke(makeInvocation({ sessionId: undefined }), '/tmp/worktree');
     const [, , opts] = mockSpawnProcess.mock.calls[0];
-    expect(opts.env?.['CADRE_TASK_ID']).toBeUndefined();
+    expect(opts.env?.['CADRE_SESSION_ID']).toBeUndefined();
     vi.unstubAllEnvs();
   });
 
@@ -529,12 +529,12 @@ describe('ClaudeBackend', () => {
     expect(opts.env?.['CADRE_PHASE']).toBe('4');
   });
 
-  it('should set CADRE_TASK_ID env var when taskId is provided', async () => {
+  it('should set CADRE_SESSION_ID env var when taskId is provided', async () => {
     const backend = new ClaudeBackend(config, logger as never);
     setupSpawn(makeProcessResult());
-    await backend.invoke(makeInvocation({ taskId: 'task-abc' }), '/tmp/worktree');
+    await backend.invoke(makeInvocation({ sessionId: 'session-abc' }), '/tmp/worktree');
     const [, , opts] = mockSpawnProcess.mock.calls[0];
-    expect(opts.env?.['CADRE_TASK_ID']).toBe('task-abc');
+    expect(opts.env?.['CADRE_SESSION_ID']).toBe('session-abc');
   });
 
   it('should call trackProcess on the spawned process', async () => {

--- a/tests/agent-backends.test.ts
+++ b/tests/agent-backends.test.ts
@@ -92,7 +92,7 @@ function makeInvocation(overrides: Partial<AgentInvocation> = {}): AgentInvocati
     agent: 'code-writer',
     issueNumber: 42,
     phase: 3,
-    taskId: 'task-001',
+    sessionId: 'session-001',
     contextPath: '/tmp/worktree/.cadre/issues/42/contexts/ctx.json',
     outputPath: '/tmp/worktree/.cadre/issues/42/outputs/result.md',
     ...overrides,
@@ -280,21 +280,21 @@ describe('CopilotBackend', () => {
     expect(opts.env?.['CADRE_PHASE']).toBe('3');
   });
 
-  it('should set CADRE_TASK_ID env var when taskId is provided', async () => {
+  it('should set CADRE_SESSION_ID env var when taskId is provided', async () => {
     const backend = new CopilotBackend(config, logger as never);
     setupSpawn(makeProcessResult());
-    await backend.invoke(makeInvocation({ taskId: 'task-007' }), '/tmp/worktree');
+    await backend.invoke(makeInvocation({ sessionId: 'session-007' }), '/tmp/worktree');
     const [, , opts] = mockSpawnProcess.mock.calls[0];
-    expect(opts.env?.['CADRE_TASK_ID']).toBe('task-007');
+    expect(opts.env?.['CADRE_SESSION_ID']).toBe('session-007');
   });
 
-  it('should not set CADRE_TASK_ID env var when taskId is absent', async () => {
-    vi.stubEnv('CADRE_TASK_ID', undefined as unknown as string);
+  it('should not set CADRE_SESSION_ID env var when taskId is absent', async () => {
+    vi.stubEnv('CADRE_SESSION_ID', undefined as unknown as string);
     const backend = new CopilotBackend(config, logger as never);
     setupSpawn(makeProcessResult());
-    await backend.invoke(makeInvocation({ taskId: undefined }), '/tmp/worktree');
+    await backend.invoke(makeInvocation({ sessionId: undefined }), '/tmp/worktree');
     const [, , opts] = mockSpawnProcess.mock.calls[0];
-    expect(opts.env?.['CADRE_TASK_ID']).toBeUndefined();
+    expect(opts.env?.['CADRE_SESSION_ID']).toBeUndefined();
     vi.unstubAllEnvs();
   });
 
@@ -510,12 +510,12 @@ describe('ClaudeBackend', () => {
     expect(opts.env?.['CADRE_PHASE']).toBe('4');
   });
 
-  it('should set CADRE_TASK_ID env var when taskId is provided', async () => {
+  it('should set CADRE_SESSION_ID env var when taskId is provided', async () => {
     const backend = new ClaudeBackend(config, logger as never);
     setupSpawn(makeProcessResult());
-    await backend.invoke(makeInvocation({ taskId: 'task-abc' }), '/tmp/worktree');
+    await backend.invoke(makeInvocation({ sessionId: 'session-abc' }), '/tmp/worktree');
     const [, , opts] = mockSpawnProcess.mock.calls[0];
-    expect(opts.env?.['CADRE_TASK_ID']).toBe('task-abc');
+    expect(opts.env?.['CADRE_SESSION_ID']).toBe('session-abc');
   });
 
   it('should call trackProcess on the spawned process', async () => {

--- a/tests/context-builder.test.ts
+++ b/tests/context-builder.test.ts
@@ -3,6 +3,7 @@ import { ContextBuilder } from '../src/agents/context-builder.js';
 import type { CadreConfig } from '../src/config/schema.js';
 import type { IssueDetail } from '../src/github/issues.js';
 import type { ReviewThread } from '../src/platform/provider.js';
+import type { AgentSession } from '../src/agents/types.js';
 import { Logger } from '../src/logging/logger.js';
 import { readFile, writeFile, mkdir, rename } from 'node:fs/promises';
 
@@ -111,20 +112,25 @@ describe('ContextBuilder', () => {
   });
 
   it('should build context for code-writer', async () => {
-    const task = {
-      id: 'task-001',
+    const session: AgentSession = {
+      id: 'session-001',
       name: 'Fix login',
-      description: 'Fix the login handler',
-      files: ['src/auth/login.ts'],
+      rationale: 'Fix the login handler',
       dependencies: [],
-      complexity: 'simple' as const,
-      acceptanceCriteria: ['Login works'],
+      steps: [{
+        id: 'session-001-step-001',
+        name: 'Fix login handler',
+        description: 'Fix the login handler',
+        files: ['src/auth/login.ts'],
+        complexity: 'simple' as const,
+        acceptanceCriteria: ['Login works'],
+      }],
     };
 
     const ctx = await builder.buildForCodeWriter(
       42,
       '/tmp/worktree',
-      task,
+      session,
       '/tmp/task-plan.md',
       ['src/auth/login.ts'],
       '/tmp/progress',
@@ -135,20 +141,25 @@ describe('ContextBuilder', () => {
   });
 
   it('should build context for code-reviewer', async () => {
-    const task = {
-      id: 'task-001',
+    const session: AgentSession = {
+      id: 'session-001',
       name: 'Fix login',
-      description: 'Fix the login handler',
-      files: ['src/auth/login.ts'],
+      rationale: 'Fix the login handler',
       dependencies: [],
-      complexity: 'simple' as const,
-      acceptanceCriteria: ['Login works'],
+      steps: [{
+        id: 'session-001-step-001',
+        name: 'Fix login handler',
+        description: 'Fix the login handler',
+        files: ['src/auth/login.ts'],
+        complexity: 'simple' as const,
+        acceptanceCriteria: ['Login works'],
+      }],
     };
 
     const ctx = await builder.buildForCodeReviewer(
       42,
       '/tmp/worktree',
-      task,
+      session,
       '/tmp/diff.patch',
       '/tmp/task-plan.md',
       '/tmp/progress',
@@ -175,14 +186,19 @@ describe('ContextBuilder', () => {
   });
 
   describe('outputSchema inclusion', () => {
-    const task = {
-      id: 'task-001',
+    const task: AgentSession = {
+      id: 'session-001',
       name: 'Fix login',
-      description: 'Fix the login handler',
-      files: ['src/auth/login.ts'],
+      rationale: 'Fix the login handler',
       dependencies: [],
-      complexity: 'simple' as const,
-      acceptanceCriteria: ['Login works'],
+      steps: [{
+        id: 'session-001-step-001',
+        name: 'Fix login handler',
+        description: 'Fix the login handler',
+        files: ['src/auth/login.ts'],
+        complexity: 'simple' as const,
+        acceptanceCriteria: ['Login works'],
+      }],
     };
 
     it('should include outputSchema for issue-analyst', async () => {
@@ -242,14 +258,19 @@ describe('ContextBuilder', () => {
   });
 
   describe('buildForCodeWriter siblingFiles', () => {
-    const task = {
-      id: 'task-001',
+    const task: AgentSession = {
+      id: 'session-001',
       name: 'Fix login',
-      description: 'Fix the login handler',
-      files: ['src/auth/login.ts'],
+      rationale: 'Fix the login handler',
       dependencies: [],
-      complexity: 'simple' as const,
-      acceptanceCriteria: ['Login works'],
+      steps: [{
+        id: 'session-001-step-001',
+        name: 'Fix login handler',
+        description: 'Fix the login handler',
+        files: ['src/auth/login.ts'],
+        complexity: 'simple' as const,
+        acceptanceCriteria: ['Login works'],
+      }],
     };
 
     it('should include siblingFiles in payload when provided and non-empty', async () => {
@@ -274,25 +295,29 @@ describe('ContextBuilder', () => {
       expect(payload.siblingFiles).toBeUndefined();
     });
 
-    it('should always include taskId, files, and acceptanceCriteria in payload regardless of siblingFiles', async () => {
+    it('should always include sessionId and steps in payload regardless of siblingFiles', async () => {
       await builder.buildForCodeWriter(42, '/tmp/worktree', task, '/tmp/task-plan.md', [], '/tmp/progress', ['src/other.ts']);
       const ctx = captureWrittenContext();
       const payload = ctx.payload as Record<string, unknown>;
-      expect(payload.taskId).toBe(task.id);
-      expect(payload.files).toEqual(task.files);
-      expect(payload.acceptanceCriteria).toEqual(task.acceptanceCriteria);
+      expect(payload.sessionId).toBe(task.id);
+      expect(Array.isArray(payload.steps)).toBe(true);
     });
   });
 
   describe('outputSchema exclusions', () => {
-    const task = {
-      id: 'task-001',
+    const task: AgentSession = {
+      id: 'session-001',
       name: 'Fix login',
-      description: 'Fix the login handler',
-      files: ['src/auth/login.ts'],
+      rationale: 'Fix the login handler',
       dependencies: [],
-      complexity: 'simple' as const,
-      acceptanceCriteria: ['Login works'],
+      steps: [{
+        id: 'session-001-step-001',
+        name: 'Fix login handler',
+        description: 'Fix the login handler',
+        files: ['src/auth/login.ts'],
+        complexity: 'simple' as const,
+        acceptanceCriteria: ['Login works'],
+      }],
     };
 
     it('should NOT include outputSchema for test-writer', async () => {

--- a/tests/e2e-pipeline.test.ts
+++ b/tests/e2e-pipeline.test.ts
@@ -79,8 +79,8 @@ const SYNTHETIC_IMPLEMENTATION_PLAN = `# Implementation Plan: Issue
 
 \`\`\`cadre-json
 ${JSON.stringify([
-  { id: 'task-001', name: 'Implement core changes', description: 'Make the primary code changes required by the issue.', files: ['src/core/issue-orchestrator.ts'], dependencies: [], complexity: 'moderate', acceptanceCriteria: ['Core changes implemented correctly'] },
-  { id: 'task-002', name: 'Add tests', description: 'Write tests for the changes.', files: ['tests/issue-orchestrator.test.ts'], dependencies: ['task-001'], complexity: 'simple', acceptanceCriteria: ['Tests cover new functionality'] },
+  { id: 'session-001', name: 'Implement core changes', rationale: 'Make the primary code changes required by the issue.', dependencies: [], steps: [{ id: 'session-001-step-001', name: 'Core implementation', description: 'Make the primary code changes.', files: ['src/core/issue-orchestrator.ts'], complexity: 'moderate', acceptanceCriteria: ['Core changes implemented correctly'] }] },
+  { id: 'session-002', name: 'Add tests', rationale: 'Write tests for the changes.', dependencies: ['session-001'], steps: [{ id: 'session-002-step-001', name: 'Write tests', description: 'Write tests for the changes.', files: ['tests/issue-orchestrator.test.ts'], complexity: 'simple', acceptanceCriteria: ['Tests cover new functionality'] }] },
 ])}
 \`\`\`
 `;
@@ -110,9 +110,9 @@ const THREE_TASK_PLAN = `# Implementation Plan: Issue
 
 \`\`\`cadre-json
 ${JSON.stringify([
-  { id: 'task-001', name: 'Implement core changes', description: 'Make the primary code changes.', files: ['src/core/issue-orchestrator.ts'], dependencies: [], complexity: 'moderate', acceptanceCriteria: ['Core changes implemented'] },
-  { id: 'task-002', name: 'Add tests', description: 'Write tests for the changes.', files: ['tests/issue-orchestrator.test.ts'], dependencies: [], complexity: 'simple', acceptanceCriteria: ['Tests pass'] },
-  { id: 'task-003', name: 'Always blocked task', description: 'This task is configured to always fail in the test.', files: ['src/blocked.ts'], dependencies: [], complexity: 'simple', acceptanceCriteria: ['Will never pass (for testing blocked-task behavior)'] },
+  { id: 'session-001', name: 'Implement core changes', rationale: 'Make the primary code changes.', dependencies: [], steps: [{ id: 'session-001-step-001', name: 'Core implementation', description: 'Make the primary code changes.', files: ['src/core/issue-orchestrator.ts'], complexity: 'moderate', acceptanceCriteria: ['Core changes implemented'] }] },
+  { id: 'session-002', name: 'Add tests', rationale: 'Write tests for the changes.', dependencies: [], steps: [{ id: 'session-002-step-001', name: 'Write tests', description: 'Write tests for the changes.', files: ['tests/issue-orchestrator.test.ts'], complexity: 'simple', acceptanceCriteria: ['Tests pass'] }] },
+  { id: 'session-003', name: 'Always blocked task', rationale: 'This task is configured to always fail in the test.', dependencies: [], steps: [{ id: 'session-003-step-001', name: 'Blocked step', description: 'This task is configured to always fail in the test.', files: ['src/blocked.ts'], complexity: 'simple', acceptanceCriteria: ['Will never pass (for testing blocked-task behavior)'] }] },
 ])}
 \`\`\`
 `;
@@ -341,7 +341,7 @@ describe('e2e pipeline', () => {
     let task001Calls = 0;
 
     launcher.addOverride(async (inv) => {
-      if (inv.agent === 'code-writer' && inv.taskId === 'task-001') {
+      if (inv.agent === 'code-writer' && inv.sessionId === 'session-001') {
         task001Calls++;
         if (task001Calls === 1) {
           return E2ELauncher.failResult(inv, 'Simulated first-attempt failure');
@@ -381,7 +381,7 @@ describe('e2e pipeline', () => {
         };
       }
       // task-003 code-writer always fails
-      if (inv.agent === 'code-writer' && inv.taskId === 'task-003') {
+      if (inv.agent === 'code-writer' && inv.sessionId === 'session-003') {
         return E2ELauncher.failResult(inv, 'Blocked task always fails');
       }
       return null;
@@ -395,7 +395,7 @@ describe('e2e pipeline', () => {
     // At least task-003 should be blocked in checkpoint state
     const cpState = checkpoint.getState();
     expect(cpState.blockedTasks.length).toBeGreaterThanOrEqual(1);
-    expect(cpState.blockedTasks).toContain('task-003');
+    expect(cpState.blockedTasks).toContain('session-003');
   });
 
   it('resume: phases 1 and 2 are skipped on second run with tokenUsage === 0', async () => {

--- a/tests/implementation-planner-template.test.ts
+++ b/tests/implementation-planner-template.test.ts
@@ -37,8 +37,8 @@ describe('implementation-planner.md template', () => {
       expect(content).toMatch(/implementation-plan\.md/i);
     });
 
-    it('should describe task IDs with task-XXX pattern', () => {
-      expect(content).toMatch(/task-\d{3}|task-XXX/i);
+    it('should describe session IDs with session-XXX pattern', () => {
+      expect(content).toMatch(/session-\d{3}|session-XXX/i);
     });
 
     it('should describe dependencies field', () => {
@@ -53,11 +53,10 @@ describe('implementation-planner.md template', () => {
       expect(content).toMatch(/[Aa]cceptance [Cc]riteria/);
     });
 
-    it('should specify the exact ImplementationTask interface fields', () => {
-      expect(content).toMatch(/\*\*Description:\*\*|\*\*Description\*\*:|\bDescription:/);
-      expect(content).toMatch(/\*\*Files:\*\*|\*\*Files\*\*:|\bFiles:/);
-      expect(content).toMatch(/\*\*Dependencies:\*\*|\*\*Dependencies\*\*:|\bDependencies:/);
-      expect(content).toMatch(/\*\*Complexity:\*\*|\*\*Complexity\*\*:|\bComplexity:/);
+    it('should specify session and step schema fields', () => {
+      expect(content).toMatch(/rationale/i);
+      expect(content).toMatch(/steps/i);
+      expect(content).toMatch(/sessionId|session-001/i);
     });
   });
 
@@ -94,19 +93,18 @@ describe('implementation-planner.md template', () => {
       expect(content).toMatch(/[Ee]xample/);
     });
 
-    it('example should contain a task-001 heading', () => {
-      expect(content).toMatch(/task-001/);
+    it('example should contain a session-001 id', () => {
+      expect(content).toMatch(/session-001/);
     });
 
-    it('example should include Description, Files, Dependencies, Complexity, and Acceptance Criteria', () => {
-      expect(content).toMatch(/\*\*Description:\*\*|\*\*Description\*\*:/);
-      expect(content).toMatch(/\*\*Files:\*\*|\*\*Files\*\*:/);
-      expect(content).toMatch(/\*\*Dependencies:\*\*|\*\*Dependencies\*\*:/);
-      expect(content).toMatch(/\*\*Complexity:\*\*|\*\*Complexity\*\*:/);
-      expect(content).toMatch(/\*\*Acceptance Criteria:\*\*|\*\*Acceptance Criteria\*\*:/);
+    it('example should include rationale, steps, complexity, and acceptanceCriteria fields', () => {
+      expect(content).toMatch(/"rationale"/);
+      expect(content).toMatch(/"steps"/);
+      expect(content).toMatch(/"complexity"/);
+      expect(content).toMatch(/"acceptanceCriteria"/);
     });
 
-    it('example should include at least one test file path in a Files list', () => {
+    it('example should include at least one test file path in a files list', () => {
       expect(content).toMatch(/tests\/[^\s,]+\.test\.ts/);
     });
   });

--- a/tests/issue-orchestrator-gates.test.ts
+++ b/tests/issue-orchestrator-gates.test.ts
@@ -150,14 +150,17 @@ vi.mock('../src/execution/retry.js', () => ({
   })),
 }));
 
+const mockSessionQueueInstance = {
+  topologicalSort: vi.fn().mockReturnValue([]),
+  isComplete: vi.fn().mockReturnValue(true),
+  getReady: vi.fn().mockReturnValue([]),
+  getCounts: vi.fn().mockReturnValue({ total: 0, completed: 0, blocked: 0 }),
+  restoreState: vi.fn(),
+};
+
 vi.mock('../src/execution/task-queue.js', () => ({
-  TaskQueue: vi.fn(() => ({
-    topologicalSort: vi.fn().mockReturnValue([]),
-    isComplete: vi.fn().mockReturnValue(true),
-    getReady: vi.fn().mockReturnValue([]),
-    getCounts: vi.fn().mockReturnValue({ total: 0, completed: 0, blocked: 0 }),
-    restoreState: vi.fn(),
-  })),
+  TaskQueue: vi.fn(() => mockSessionQueueInstance),
+  SessionQueue: vi.fn(() => mockSessionQueueInstance),
   // static method:
   selectNonOverlappingBatch: vi.fn().mockReturnValue([]),
 }));
@@ -404,13 +407,18 @@ describe('IssueOrchestrator – Gate Validation (runGate)', () => {
     // Phase 2 (executePlanning) validates the plan and requires at least one task
     mockResultParserParsePlan.mockResolvedValue([
       {
-        id: 'task-001',
-        name: 'Task 1',
-        description: 'Do something',
-        files: ['src/foo.ts'],
+        id: 'session-001',
+        name: 'Session 1',
+        rationale: 'Do something',
         dependencies: [],
-        complexity: 'simple',
-        acceptanceCriteria: ['It works'],
+        steps: [{
+          id: 'session-001-step-001',
+          name: 'Step 1',
+          description: 'Do something',
+          files: ['src/foo.ts'],
+          complexity: 'simple',
+          acceptanceCriteria: ['It works'],
+        }],
       },
     ]);
 

--- a/tests/phase-gate.test.ts
+++ b/tests/phase-gate.test.ts
@@ -39,7 +39,7 @@ const VALID_SCOUT = `# Scout Report
 const VALID_PLAN = `# Implementation Plan
 
 \`\`\`cadre-json
-[{"id":"task-001","name":"First Task","description":"Do the first thing.","files":["src/core/first.ts"],"dependencies":[],"acceptanceCriteria":["It works"]}]
+[{"id":"session-001","name":"First Session","rationale":"Initial implementation","dependencies":[],"steps":[{"id":"session-001-step-001","name":"First Step","description":"Do the first thing.","files":["src/core/first.ts"],"complexity":"simple","acceptanceCriteria":["It works"]}]}]
 \`\`\`
 `;
 
@@ -186,12 +186,12 @@ describe('PlanningToImplementationGate', () => {
 
     const result = await gate.validate(makeContext(tempDir));
     expect(result.status).toBe('fail');
-    expect(result.errors.some((e) => e.includes('no tasks'))).toBe(true);
+    expect(result.errors.some((e) => e.includes('no sessions'))).toBe(true);
   });
 
   it('should fail when a task is missing a description', async () => {
-    const task = { id: 'task-001', name: 'My Task', description: '', files: ['src/foo.ts'], dependencies: [], acceptanceCriteria: ['Works'] };
-    const plan = `\`\`\`cadre-json\n${JSON.stringify([task])}\n\`\`\``;
+    const session = { id: 'session-001', name: 'My Session', rationale: 'Test', dependencies: [], steps: [{ id: 'session-001-step-001', name: 'Step 1', description: '', files: ['src/foo.ts'], complexity: 'simple', acceptanceCriteria: ['Works'] }] };
+    const plan = `\`\`\`cadre-json\n${JSON.stringify([session])}\n\`\`\``;
     await writeFile(join(tempDir, 'implementation-plan.md'), plan);
 
     const result = await gate.validate(makeContext(tempDir));
@@ -200,8 +200,8 @@ describe('PlanningToImplementationGate', () => {
   });
 
   it('should fail when a task has no files', async () => {
-    const task = { id: 'task-001', name: 'My Task', description: 'Do something.', files: [], dependencies: [], acceptanceCriteria: ['Works'] };
-    const plan = `\`\`\`cadre-json\n${JSON.stringify([task])}\n\`\`\``;
+    const session = { id: 'session-001', name: 'My Session', rationale: 'Test', dependencies: [], steps: [{ id: 'session-001-step-001', name: 'Step 1', description: 'Do something.', files: [], complexity: 'simple', acceptanceCriteria: ['Works'] }] };
+    const plan = `\`\`\`cadre-json\n${JSON.stringify([session])}\n\`\`\``;
     await writeFile(join(tempDir, 'implementation-plan.md'), plan);
 
     const result = await gate.validate(makeContext(tempDir));
@@ -210,8 +210,8 @@ describe('PlanningToImplementationGate', () => {
   });
 
   it('should fail when a task has no acceptance criteria', async () => {
-    const task = { id: 'task-001', name: 'My Task', description: 'Do something.', files: ['src/foo.ts'], dependencies: [], acceptanceCriteria: [] };
-    const plan = `\`\`\`cadre-json\n${JSON.stringify([task])}\n\`\`\``;
+    const session = { id: 'session-001', name: 'My Session', rationale: 'Test', dependencies: [], steps: [{ id: 'session-001-step-001', name: 'Step 1', description: 'Do something.', files: ['src/foo.ts'], complexity: 'simple', acceptanceCriteria: [] }] };
+    const plan = `\`\`\`cadre-json\n${JSON.stringify([session])}\n\`\`\``;
     await writeFile(join(tempDir, 'implementation-plan.md'), plan);
 
     const result = await gate.validate(makeContext(tempDir));
@@ -220,11 +220,11 @@ describe('PlanningToImplementationGate', () => {
   });
 
   it('should fail when tasks have a circular dependency', async () => {
-    const tasks = [
-      { id: 'task-001', name: 'First', description: 'Do first.', files: ['src/first.ts'], dependencies: ['task-002'], acceptanceCriteria: ['Works'] },
-      { id: 'task-002', name: 'Second', description: 'Do second.', files: ['src/second.ts'], dependencies: ['task-001'], acceptanceCriteria: ['Works'] },
+    const sessions = [
+      { id: 'session-001', name: 'First', rationale: 'First', dependencies: ['session-002'], steps: [{ id: 'session-001-step-001', name: 'Step 1', description: 'Do first.', files: ['src/first.ts'], complexity: 'simple', acceptanceCriteria: ['Works'] }] },
+      { id: 'session-002', name: 'Second', rationale: 'Second', dependencies: ['session-001'], steps: [{ id: 'session-002-step-001', name: 'Step 1', description: 'Do second.', files: ['src/second.ts'], complexity: 'simple', acceptanceCriteria: ['Works'] }] },
     ];
-    const plan = `\`\`\`cadre-json\n${JSON.stringify(tasks)}\n\`\`\``;
+    const plan = `\`\`\`cadre-json\n${JSON.stringify(sessions)}\n\`\`\``;
     await writeFile(join(tempDir, 'implementation-plan.md'), plan);
 
     const result = await gate.validate(makeContext(tempDir));
@@ -233,11 +233,11 @@ describe('PlanningToImplementationGate', () => {
   });
 
   it('should pass with multiple valid tasks and linear dependencies', async () => {
-    const tasks = [
-      { id: 'task-001', name: 'First', description: 'Do first.', files: ['src/first.ts'], dependencies: [], acceptanceCriteria: ['Works'] },
-      { id: 'task-002', name: 'Second', description: 'Do second.', files: ['src/second.ts'], dependencies: ['task-001'], acceptanceCriteria: ['Also works'] },
+    const sessions = [
+      { id: 'session-001', name: 'First', rationale: 'First session', dependencies: [], steps: [{ id: 'session-001-step-001', name: 'Step 1', description: 'Do first.', files: ['src/first.ts'], complexity: 'simple', acceptanceCriteria: ['Works'] }] },
+      { id: 'session-002', name: 'Second', rationale: 'Second session', dependencies: ['session-001'], steps: [{ id: 'session-002-step-001', name: 'Step 1', description: 'Do second.', files: ['src/second.ts'], complexity: 'simple', acceptanceCriteria: ['Also works'] }] },
     ];
-    const plan = `\`\`\`cadre-json\n${JSON.stringify(tasks)}\n\`\`\``;
+    const plan = `\`\`\`cadre-json\n${JSON.stringify(sessions)}\n\`\`\``;
     await writeFile(join(tempDir, 'implementation-plan.md'), plan);
     await mkdir(join(worktreeDir, 'src'), { recursive: true });
     await writeFile(join(worktreeDir, 'src/first.ts'), '');
@@ -255,31 +255,31 @@ describe('PlanningToImplementationGate', () => {
     const result = await gate.validate(makeContext(tempDir, worktreeDir));
     expect(result.status).toBe('warn');
     expect(result.errors).toHaveLength(0);
-    expect(result.warnings.some((w) => w.includes('task-001') && w.includes('src/core/first.ts'))).toBe(true);
+    expect(result.warnings.some((w) => w.includes('session-001') && w.includes('src/core/first.ts'))).toBe(true);
   });
 
   it('should warn for every missing file across all tasks', async () => {
-    const tasks = [
-      { id: 'task-001', name: 'First', description: 'Do first.', files: ['src/first.ts'], dependencies: [], acceptanceCriteria: ['Works'] },
-      { id: 'task-002', name: 'Second', description: 'Do second.', files: ['src/second.ts'], dependencies: ['task-001'], acceptanceCriteria: ['Also works'] },
+    const sessions = [
+      { id: 'session-001', name: 'First', rationale: 'First', dependencies: [], steps: [{ id: 'session-001-step-001', name: 'Step 1', description: 'Do first.', files: ['src/first.ts'], complexity: 'simple', acceptanceCriteria: ['Works'] }] },
+      { id: 'session-002', name: 'Second', rationale: 'Second', dependencies: ['session-001'], steps: [{ id: 'session-002-step-001', name: 'Step 1', description: 'Do second.', files: ['src/second.ts'], complexity: 'simple', acceptanceCriteria: ['Also works'] }] },
     ];
-    const plan = `\`\`\`cadre-json\n${JSON.stringify(tasks)}\n\`\`\``;
+    const plan = `\`\`\`cadre-json\n${JSON.stringify(sessions)}\n\`\`\``;
     await writeFile(join(tempDir, 'implementation-plan.md'), plan);
     // Create worktreeDir but no source files
 
     const result = await gate.validate(makeContext(tempDir, worktreeDir));
     expect(result.status).toBe('warn');
     expect(result.errors).toHaveLength(0);
-    expect(result.warnings.some((w) => w.includes('task-001') && w.includes('src/first.ts'))).toBe(true);
-    expect(result.warnings.some((w) => w.includes('task-002') && w.includes('src/second.ts'))).toBe(true);
+    expect(result.warnings.some((w) => w.includes('session-001') && w.includes('src/first.ts'))).toBe(true);
+    expect(result.warnings.some((w) => w.includes('session-002') && w.includes('src/second.ts'))).toBe(true);
   });
 
   it('should warn only for missing files when some exist and some do not', async () => {
-    const tasks = [
-      { id: 'task-001', name: 'First', description: 'Do first.', files: ['src/exists.ts'], dependencies: [], acceptanceCriteria: ['Works'] },
-      { id: 'task-002', name: 'Second', description: 'Do second.', files: ['src/missing.ts'], dependencies: ['task-001'], acceptanceCriteria: ['Also works'] },
+    const sessions = [
+      { id: 'session-001', name: 'First', rationale: 'First', dependencies: [], steps: [{ id: 'session-001-step-001', name: 'Step 1', description: 'Do first.', files: ['src/exists.ts'], complexity: 'simple', acceptanceCriteria: ['Works'] }] },
+      { id: 'session-002', name: 'Second', rationale: 'Second', dependencies: ['session-001'], steps: [{ id: 'session-002-step-001', name: 'Step 1', description: 'Do second.', files: ['src/missing.ts'], complexity: 'simple', acceptanceCriteria: ['Also works'] }] },
     ];
-    const plan = `\`\`\`cadre-json\n${JSON.stringify(tasks)}\n\`\`\``;
+    const plan = `\`\`\`cadre-json\n${JSON.stringify(sessions)}\n\`\`\``;
     await writeFile(join(tempDir, 'implementation-plan.md'), plan);
     await mkdir(join(worktreeDir, 'src'), { recursive: true });
     await writeFile(join(worktreeDir, 'src/exists.ts'), '');

--- a/tests/planning-phase-executor.test.ts
+++ b/tests/planning-phase-executor.test.ts
@@ -46,8 +46,8 @@ function makeCtx(overrides: Partial<PhaseContext> = {}): PhaseContext {
 
   const resultParser = {
     parseImplementationPlan: vi.fn().mockResolvedValue([
-      { id: 'task-001', name: 'Task 1', dependencies: [] },
-      { id: 'task-002', name: 'Task 2', dependencies: ['task-001'] },
+      { id: 'session-001', name: 'Session 1', rationale: 'r', dependencies: [], steps: [{ id: 'session-001-step-001', name: 'Step 1', description: 'd', files: ['src/a.ts'], complexity: 'simple', acceptanceCriteria: ['ok'] }] },
+      { id: 'session-002', name: 'Session 2', rationale: 'r', dependencies: ['session-001'], steps: [{ id: 'session-002-step-001', name: 'Step 1', description: 'd', files: ['src/b.ts'], complexity: 'simple', acceptanceCriteria: ['ok'] }] },
     ]),
   };
 
@@ -195,7 +195,7 @@ describe('PlanningPhaseExecutor', () => {
       expect(
         (ctx.services.logger as never as { info: ReturnType<typeof vi.fn> }).info,
       ).toHaveBeenCalledWith(
-        expect.stringContaining('2 tasks'),
+        expect.stringContaining('2 sessions'),
         expect.objectContaining({ issueNumber: 42, phase: 2 }),
       );
     });
@@ -227,14 +227,14 @@ describe('PlanningPhaseExecutor', () => {
         parseImplementationPlan: vi.fn().mockResolvedValue([]),
       };
       const ctx = makeCtx({ services: { resultParser: resultParser } as never });
-      await expect(executor.execute(ctx)).rejects.toThrow('Implementation plan produced zero tasks');
+      await expect(executor.execute(ctx)).rejects.toThrow('Implementation plan produced zero sessions');
     });
 
     it('should throw if the dependency graph has a cycle', async () => {
       const resultParser = {
         parseImplementationPlan: vi.fn().mockResolvedValue([
-          { id: 'task-001', name: 'Task 1', dependencies: ['task-002'] },
-          { id: 'task-002', name: 'Task 2', dependencies: ['task-001'] },
+          { id: 'session-001', name: 'Session 1', rationale: 'r', dependencies: ['session-002'], steps: [{ id: 'session-001-step-001', name: 'Step 1', description: 'd', files: ['src/a.ts'], complexity: 'simple', acceptanceCriteria: ['ok'] }] },
+          { id: 'session-002', name: 'Session 2', rationale: 'r', dependencies: ['session-001'], steps: [{ id: 'session-002-step-001', name: 'Step 1', description: 'd', files: ['src/b.ts'], complexity: 'simple', acceptanceCriteria: ['ok'] }] },
         ]),
       };
       const ctx = makeCtx({ services: { resultParser: resultParser } as never });

--- a/tests/result-parser.test.ts
+++ b/tests/result-parser.test.ts
@@ -14,26 +14,56 @@ describe('ResultParser', () => {
 
   describe('parseImplementationPlan', () => {
     it('should parse tasks from a cadre-json block', async () => {
-      const tasks = [
-        { id: 'task-001', name: 'Add timeout types', description: 'Add TypeScript types for timeout config', files: ['src/config/types.ts', 'src/config/schema.ts'], dependencies: [], complexity: 'simple', acceptanceCriteria: ['TimeoutConfig interface defined', 'Config validates positive integers'] },
-        { id: 'task-002', name: 'Implement middleware', description: 'Create timeout middleware', files: ['src/middleware/timeout.ts'], dependencies: ['task-001'], complexity: 'moderate', acceptanceCriteria: ['Middleware times out after configured duration', 'Returns 408 on timeout'] },
+      const sessions = [
+        {
+          id: 'session-001',
+          name: 'Add timeout types',
+          rationale: 'Required for type-safe config',
+          dependencies: [],
+          steps: [
+            {
+              id: 'session-001-step-001',
+              name: 'Add TypeScript types',
+              description: 'Add TypeScript types for timeout config',
+              files: ['src/config/types.ts', 'src/config/schema.ts'],
+              complexity: 'simple',
+              acceptanceCriteria: ['TimeoutConfig interface defined', 'Config validates positive integers'],
+            },
+          ],
+        },
+        {
+          id: 'session-002',
+          name: 'Implement middleware',
+          rationale: 'Add timeout handling',
+          dependencies: ['session-001'],
+          steps: [
+            {
+              id: 'session-002-step-001',
+              name: 'Create timeout middleware',
+              description: 'Create timeout middleware',
+              files: ['src/middleware/timeout.ts'],
+              complexity: 'moderate',
+              acceptanceCriteria: ['Middleware times out after configured duration', 'Returns 408 on timeout'],
+            },
+          ],
+        },
       ];
-      const content = `# Plan\n\n\`\`\`cadre-json\n${JSON.stringify(tasks)}\n\`\`\`\n`;
+      const content = `# Plan\n\n\`\`\`cadre-json\n${JSON.stringify(sessions)}\n\`\`\`\n`;
       vi.mocked(readFile).mockResolvedValue(content);
 
       const result = await parser.parseImplementationPlan('/tmp/plan.md');
 
       expect(result).toHaveLength(2);
-      expect(result[0].id).toBe('task-001');
+      expect(result[0].id).toBe('session-001');
       expect(result[0].name).toBe('Add timeout types');
-      expect(result[0].files).toContain('src/config/types.ts');
-      expect(result[0].files).toContain('src/config/schema.ts');
+      expect(result[0].steps[0].files).toContain('src/config/types.ts');
+      expect(result[0].steps[0].files).toContain('src/config/schema.ts');
       expect(result[0].dependencies).toEqual([]);
-      expect(result[0].complexity).toBe('simple');
-      expect(result[0].acceptanceCriteria).toHaveLength(2);
-      expect(result[1].id).toBe('task-002');
-      expect(result[1].dependencies).toEqual(['task-001']);
-      expect(result[1].complexity).toBe('moderate');
+      expect(result[0].steps[0].complexity).toBe('simple');
+      expect(result[0].steps[0].acceptanceCriteria).toHaveLength(2);
+      expect(result[1].id).toBe('session-002');
+      expect(result[1].dependencies).toEqual(['session-001']);
+      expect(result[1].steps[0].complexity).toBe('moderate');
     });
 
     it('should throw when cadre-json block is missing', async () => {

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -134,13 +134,18 @@ describe('scoutReportSchema', () => {
 // ---------------------------------------------------------------------------
 describe('implementationTaskSchema', () => {
   const validTask = {
-    id: 'task-001',
+    id: 'session-001',
     name: 'Add feature',
-    description: 'Detailed description',
-    files: ['src/feature.ts'],
+    rationale: 'Needed for productivity',
     dependencies: [],
-    complexity: 'simple' as const,
-    acceptanceCriteria: ['Should work'],
+    steps: [{
+      id: 'session-001-step-001',
+      name: 'Add feature step',
+      description: 'Detailed description',
+      files: ['src/feature.ts'],
+      complexity: 'simple' as const,
+      acceptanceCriteria: ['Should work'],
+    }],
   };
 
   it('should accept a valid ImplementationTask', () => {
@@ -149,7 +154,8 @@ describe('implementationTaskSchema', () => {
   });
 
   it('should reject an unknown complexity value', () => {
-    const result = implementationTaskSchema.safeParse({ ...validTask, complexity: 'extreme' });
+    const invalid = { ...validTask, steps: [{ ...validTask.steps[0], complexity: 'extreme' }] };
+    const result = implementationTaskSchema.safeParse(invalid);
     expect(result.success).toBe(false);
   });
 
@@ -160,15 +166,17 @@ describe('implementationTaskSchema', () => {
   });
 
   it('should reject when acceptanceCriteria field is missing', () => {
-    const { acceptanceCriteria: _a, ...without } = validTask;
-    const result = implementationTaskSchema.safeParse(without);
+    const { acceptanceCriteria: _a, ...withoutAc } = validTask.steps[0];
+    const invalid = { ...validTask, steps: [withoutAc] };
+    const result = implementationTaskSchema.safeParse(invalid);
     expect(result.success).toBe(false);
   });
 
   it('should accept all valid complexity values', () => {
     const complexities = ['simple', 'moderate', 'complex'] as const;
     for (const complexity of complexities) {
-      const result = implementationTaskSchema.safeParse({ ...validTask, complexity });
+      const invalid = { ...validTask, steps: [{ ...validTask.steps[0], complexity }] };
+      const result = implementationTaskSchema.safeParse(invalid);
       expect(result.success).toBe(true);
     }
   });
@@ -176,13 +184,18 @@ describe('implementationTaskSchema', () => {
 
 describe('implementationPlanSchema', () => {
   const validTask = {
-    id: 'task-001',
+    id: 'session-001',
     name: 'Add feature',
-    description: 'Detailed description',
-    files: ['src/feature.ts'],
+    rationale: 'Needed for productivity',
     dependencies: [],
-    complexity: 'simple' as const,
-    acceptanceCriteria: ['Should work'],
+    steps: [{
+      id: 'session-001-step-001',
+      name: 'Add feature step',
+      description: 'Detailed description',
+      files: ['src/feature.ts'],
+      complexity: 'simple' as const,
+      acceptanceCriteria: ['Should work'],
+    }],
   };
 
   it('should accept an empty plan array', () => {
@@ -193,13 +206,14 @@ describe('implementationPlanSchema', () => {
   it('should accept a plan with multiple valid tasks', () => {
     const result = implementationPlanSchema.safeParse([
       validTask,
-      { ...validTask, id: 'task-002', name: 'Second task' },
+      { ...validTask, id: 'session-002', name: 'Second session', steps: [{ ...validTask.steps[0], id: 'session-002-step-001' }] },
     ]);
     expect(result.success).toBe(true);
   });
 
   it('should reject a plan containing an invalid task', () => {
-    const result = implementationPlanSchema.safeParse([{ ...validTask, complexity: 'invalid' }]);
+    const invalid = { ...validTask, steps: [{ ...validTask.steps[0], complexity: 'invalid' }] };
+    const result = implementationPlanSchema.safeParse([invalid]);
     expect(result.success).toBe(false);
   });
 });

--- a/tests/task-queue.test.ts
+++ b/tests/task-queue.test.ts
@@ -1,29 +1,45 @@
 import { describe, it, expect } from 'vitest';
-import { TaskQueue } from '../src/execution/task-queue.js';
-import type { ImplementationTask } from '../src/agents/types.js';
+import { SessionQueue, TaskQueue } from '../src/execution/task-queue.js';
+import type { AgentSession } from '../src/agents/types.js';
 
-function makeTask(
+function makeSession(
   id: string,
   deps: string[] = [],
   files: string[] = [],
-): ImplementationTask {
+): AgentSession {
   return {
     id,
-    name: `Task ${id}`,
-    description: `Description for ${id}`,
-    files: files.length ? files : [`src/${id}.ts`],
+    name: `Session ${id}`,
+    rationale: `Rationale for ${id}`,
     dependencies: deps,
-    complexity: 'simple' as const,
-    acceptanceCriteria: ['criterion 1'],
+    steps: [
+      {
+        id: `${id}-step-001`,
+        name: `Step 1 of ${id}`,
+        description: `Description for ${id}`,
+        files: files.length ? files : [`src/${id}.ts`],
+        complexity: 'simple' as const,
+        acceptanceCriteria: ['criterion 1'],
+      },
+    ],
   };
 }
 
+// Alias for backward-compat tests — TaskQueue is SessionQueue
+const makeTask = makeSession;
+
+describe('SessionQueue (also exported as TaskQueue)', () => {
+  it('TaskQueue is an alias for SessionQueue', () => {
+    expect(TaskQueue).toBe(SessionQueue);
+  });
+});
+
 describe('TaskQueue', () => {
   describe('construction and validation', () => {
-    it('should accept a valid task list', () => {
+    it('should accept a valid session list', () => {
       const queue = new TaskQueue([
-        makeTask('task-001'),
-        makeTask('task-002', ['task-001']),
+        makeSession('session-001'),
+        makeSession('session-002', ['session-001']),
       ]);
       expect(queue.getCounts().total).toBe(2);
     });
@@ -31,7 +47,7 @@ describe('TaskQueue', () => {
     it('should throw on missing dependencies', () => {
       expect(() =>
         new TaskQueue([
-          makeTask('task-001', ['task-999']),
+          makeSession('session-001', ['session-999']),
         ]),
       ).toThrow('does not exist');
     });
@@ -39,8 +55,8 @@ describe('TaskQueue', () => {
     it('should throw on circular dependencies', () => {
       expect(() =>
         new TaskQueue([
-          makeTask('task-001', ['task-002']),
-          makeTask('task-002', ['task-001']),
+          makeSession('session-001', ['session-002']),
+          makeSession('session-002', ['session-001']),
         ]),
       ).toThrow('Cycle detected');
     });
@@ -48,224 +64,224 @@ describe('TaskQueue', () => {
     it('should detect transitive cycles', () => {
       expect(() =>
         new TaskQueue([
-          makeTask('task-001', ['task-003']),
-          makeTask('task-002', ['task-001']),
-          makeTask('task-003', ['task-002']),
+          makeSession('session-001', ['session-003']),
+          makeSession('session-002', ['session-001']),
+          makeSession('session-003', ['session-002']),
         ]),
       ).toThrow('Cycle detected');
     });
   });
 
   describe('getReady', () => {
-    it('should return tasks with no dependencies', () => {
+    it('should return sessions with no dependencies', () => {
       const queue = new TaskQueue([
-        makeTask('task-001'),
-        makeTask('task-002', ['task-001']),
-        makeTask('task-003'),
+        makeSession('session-001'),
+        makeSession('session-002', ['session-001']),
+        makeSession('session-003'),
       ]);
 
       const ready = queue.getReady();
       const readyIds = ready.map((t) => t.id);
-      expect(readyIds).toContain('task-001');
-      expect(readyIds).toContain('task-003');
-      expect(readyIds).not.toContain('task-002');
+      expect(readyIds).toContain('session-001');
+      expect(readyIds).toContain('session-003');
+      expect(readyIds).not.toContain('session-002');
     });
 
-    it('should release tasks when dependencies complete', () => {
+    it('should release sessions when dependencies complete', () => {
       const queue = new TaskQueue([
-        makeTask('task-001'),
-        makeTask('task-002', ['task-001']),
+        makeSession('session-001'),
+        makeSession('session-002', ['session-001']),
       ]);
 
-      queue.start('task-001');
-      queue.complete('task-001');
+      queue.start('session-001');
+      queue.complete('session-001');
 
       const ready = queue.getReady();
-      expect(ready.map((t) => t.id)).toContain('task-002');
+      expect(ready.map((t) => t.id)).toContain('session-002');
     });
 
-    it('should not include in-progress tasks', () => {
+    it('should not include in-progress sessions', () => {
       const queue = new TaskQueue([
-        makeTask('task-001'),
-        makeTask('task-002'),
+        makeSession('session-001'),
+        makeSession('session-002'),
       ]);
 
-      queue.start('task-001');
+      queue.start('session-001');
       const ready = queue.getReady();
-      expect(ready.map((t) => t.id)).not.toContain('task-001');
-      expect(ready.map((t) => t.id)).toContain('task-002');
+      expect(ready.map((t) => t.id)).not.toContain('session-001');
+      expect(ready.map((t) => t.id)).toContain('session-002');
     });
   });
 
   describe('state transitions', () => {
     it('should track completion correctly', () => {
       const queue = new TaskQueue([
-        makeTask('task-001'),
-        makeTask('task-002'),
+        makeSession('session-001'),
+        makeSession('session-002'),
       ]);
 
-      queue.start('task-001');
-      queue.complete('task-001');
+      queue.start('session-001');
+      queue.complete('session-001');
 
-      expect(queue.isTaskCompleted('task-001')).toBe(true);
+      expect(queue.isTaskCompleted('session-001')).toBe(true);
       expect(queue.getCounts().completed).toBe(1);
     });
 
-    it('should handle blocked tasks', () => {
+    it('should handle blocked sessions', () => {
       const queue = new TaskQueue([
-        makeTask('task-001'),
-        makeTask('task-002', ['task-001']),
+        makeSession('session-001'),
+        makeSession('session-002', ['session-001']),
       ]);
 
-      queue.start('task-001');
-      queue.markBlocked('task-001');
+      queue.start('session-001');
+      queue.markBlocked('session-001');
 
       expect(queue.getCounts().blocked).toBe(1);
-      // Blocked dep still releases downstream tasks
+      // Blocked dep still releases downstream sessions
       const ready = queue.getReady();
-      expect(ready.map((t) => t.id)).toContain('task-002');
+      expect(ready.map((t) => t.id)).toContain('session-002');
     });
 
     it('should report isComplete when all done', () => {
       const queue = new TaskQueue([
-        makeTask('task-001'),
-        makeTask('task-002'),
+        makeSession('session-001'),
+        makeSession('session-002'),
       ]);
 
       expect(queue.isComplete()).toBe(false);
 
-      queue.start('task-001');
-      queue.complete('task-001');
-      queue.start('task-002');
-      queue.complete('task-002');
+      queue.start('session-001');
+      queue.complete('session-001');
+      queue.start('session-002');
+      queue.complete('session-002');
 
       expect(queue.isComplete()).toBe(true);
     });
 
-    it('should throw on unknown task operations', () => {
-      const queue = new TaskQueue([makeTask('task-001')]);
-      expect(() => queue.start('task-999')).toThrow('Unknown task');
-      expect(() => queue.complete('task-999')).toThrow('Unknown task');
-      expect(() => queue.markBlocked('task-999')).toThrow('Unknown task');
+    it('should throw on unknown session operations', () => {
+      const queue = new TaskQueue([makeSession('session-001')]);
+      expect(() => queue.start('session-999')).toThrow('Unknown session');
+      expect(() => queue.complete('session-999')).toThrow('Unknown session');
+      expect(() => queue.markBlocked('session-999')).toThrow('Unknown session');
     });
   });
 
   describe('restoreState', () => {
-    it('should restore completed and blocked tasks', () => {
+    it('should restore completed and blocked sessions', () => {
       const queue = new TaskQueue([
-        makeTask('task-001'),
-        makeTask('task-002', ['task-001']),
-        makeTask('task-003', ['task-001']),
+        makeSession('session-001'),
+        makeSession('session-002', ['session-001']),
+        makeSession('session-003', ['session-001']),
       ]);
 
-      queue.restoreState(['task-001'], ['task-003']);
+      queue.restoreState(['session-001'], ['session-003']);
 
-      expect(queue.isTaskCompleted('task-001')).toBe(true);
+      expect(queue.isTaskCompleted('session-001')).toBe(true);
       expect(queue.getCounts().blocked).toBe(1);
       expect(queue.getCounts().completed).toBe(1);
 
       const ready = queue.getReady();
-      expect(ready.map((t) => t.id)).toContain('task-002');
+      expect(ready.map((t) => t.id)).toContain('session-002');
     });
   });
 
   describe('topologicalSort', () => {
-    it('should return tasks in dependency order', () => {
+    it('should return sessions in dependency order', () => {
       const queue = new TaskQueue([
-        makeTask('task-003', ['task-002']),
-        makeTask('task-001'),
-        makeTask('task-002', ['task-001']),
+        makeSession('session-003', ['session-002']),
+        makeSession('session-001'),
+        makeSession('session-002', ['session-001']),
       ]);
 
       const sorted = queue.topologicalSort();
       const ids = sorted.map((t) => t.id);
-      expect(ids.indexOf('task-001')).toBeLessThan(ids.indexOf('task-002'));
-      expect(ids.indexOf('task-002')).toBeLessThan(ids.indexOf('task-003'));
+      expect(ids.indexOf('session-001')).toBeLessThan(ids.indexOf('session-002'));
+      expect(ids.indexOf('session-002')).toBeLessThan(ids.indexOf('session-003'));
     });
   });
 
   describe('detectBatchCollisions', () => {
-    it('should return empty array when no tasks share a file', () => {
-      const tasks = [
-        makeTask('task-001', [], ['src/a.ts']),
-        makeTask('task-002', [], ['src/b.ts']),
-        makeTask('task-003', [], ['src/c.ts']),
+    it('should return empty array when no sessions share a file', () => {
+      const sessions = [
+        makeTask('session-001', [], ['src/a.ts']),
+        makeTask('session-002', [], ['src/b.ts']),
+        makeTask('session-003', [], ['src/c.ts']),
       ];
 
-      const collisions = TaskQueue.detectBatchCollisions(tasks);
+      const collisions = TaskQueue.detectBatchCollisions(sessions);
       expect(collisions).toEqual([]);
     });
 
     it('should return one collision entry for a pair sharing a file', () => {
-      const tasks = [
-        makeTask('task-001', [], ['src/a.ts']),
-        makeTask('task-002', [], ['src/a.ts']),
+      const sessions = [
+        makeTask('session-001', [], ['src/a.ts']),
+        makeTask('session-002', [], ['src/a.ts']),
       ];
 
-      const collisions = TaskQueue.detectBatchCollisions(tasks);
+      const collisions = TaskQueue.detectBatchCollisions(sessions);
       expect(collisions).toHaveLength(1);
       expect(collisions[0]).toContain('src/a.ts');
-      expect(collisions[0]).toContain('task-001');
-      expect(collisions[0]).toContain('task-002');
+      expect(collisions[0]).toContain('session-001');
+      expect(collisions[0]).toContain('session-002');
     });
 
     it('should return separate entries for multiple colliding pairs', () => {
-      const tasks = [
-        makeTask('task-001', [], ['src/a.ts', 'src/b.ts']),
-        makeTask('task-002', [], ['src/a.ts']),
-        makeTask('task-003', [], ['src/b.ts']),
+      const sessions = [
+        makeTask('session-001', [], ['src/a.ts', 'src/b.ts']),
+        makeTask('session-002', [], ['src/a.ts']),
+        makeTask('session-003', [], ['src/b.ts']),
       ];
 
-      const collisions = TaskQueue.detectBatchCollisions(tasks);
+      const collisions = TaskQueue.detectBatchCollisions(sessions);
       expect(collisions).toHaveLength(2);
       const combined = collisions.join('\n');
       expect(combined).toContain('src/a.ts');
       expect(combined).toContain('src/b.ts');
     });
 
-    it('should return three entries for three tasks sharing the same file', () => {
-      const tasks = [
-        makeTask('task-001', [], ['src/shared.ts']),
-        makeTask('task-002', [], ['src/shared.ts']),
-        makeTask('task-003', [], ['src/shared.ts']),
+    it('should return three entries for three sessions sharing the same file', () => {
+      const sessions = [
+        makeTask('session-001', [], ['src/shared.ts']),
+        makeTask('session-002', [], ['src/shared.ts']),
+        makeTask('session-003', [], ['src/shared.ts']),
       ];
 
-      const collisions = TaskQueue.detectBatchCollisions(tasks);
+      const collisions = TaskQueue.detectBatchCollisions(sessions);
       // Pairs: (001,002), (001,003), (002,003)
       expect(collisions).toHaveLength(3);
     });
 
-    it('should return empty array for an empty task list', () => {
+    it('should return empty array for an empty session list', () => {
       const collisions = TaskQueue.detectBatchCollisions([]);
       expect(collisions).toEqual([]);
     });
 
-    it('should return empty array for a single-task batch', () => {
-      const tasks = [makeTask('task-001', [], ['src/a.ts'])];
-      const collisions = TaskQueue.detectBatchCollisions(tasks);
+    it('should return empty array for a single-session batch', () => {
+      const sessions = [makeTask('session-001', [], ['src/a.ts'])];
+      const collisions = TaskQueue.detectBatchCollisions(sessions);
       expect(collisions).toEqual([]);
     });
 
-    it('should detect collision when two tasks share a test file', () => {
-      const tasks = [
-        makeTask('task-001', [], ['src/a.ts', 'tests/foo.test.ts']),
-        makeTask('task-002', [], ['src/b.ts', 'tests/foo.test.ts']),
+    it('should detect collision when two sessions share a test file', () => {
+      const sessions = [
+        makeTask('session-001', [], ['src/a.ts', 'tests/foo.test.ts']),
+        makeTask('session-002', [], ['src/b.ts', 'tests/foo.test.ts']),
       ];
 
-      const collisions = TaskQueue.detectBatchCollisions(tasks);
+      const collisions = TaskQueue.detectBatchCollisions(sessions);
       expect(collisions).toHaveLength(1);
       expect(collisions[0]).toContain('tests/foo.test.ts');
-      expect(collisions[0]).toContain('task-001');
-      expect(collisions[0]).toContain('task-002');
+      expect(collisions[0]).toContain('session-001');
+      expect(collisions[0]).toContain('session-002');
     });
 
-    it('should not report a collision for a task that owns a file exclusively', () => {
-      const tasks = [
-        makeTask('task-001', [], ['src/a.ts', 'src/b.ts']),
-        makeTask('task-002', [], ['src/b.ts']),
+    it('should not report a collision for a session that owns a file exclusively', () => {
+      const sessions = [
+        makeTask('session-001', [], ['src/a.ts', 'src/b.ts']),
+        makeTask('session-002', [], ['src/b.ts']),
       ];
 
-      const collisions = TaskQueue.detectBatchCollisions(tasks);
+      const collisions = TaskQueue.detectBatchCollisions(sessions);
       expect(collisions).toHaveLength(1);
       expect(collisions[0]).toContain('src/b.ts');
       expect(collisions[0]).not.toContain('src/a.ts');
@@ -273,29 +289,29 @@ describe('TaskQueue', () => {
   });
 
   describe('selectNonOverlappingBatch', () => {
-    it('should select tasks with non-overlapping files', () => {
-      const tasks = [
-        makeTask('task-001', [], ['src/a.ts']),
-        makeTask('task-002', [], ['src/b.ts']),
-        makeTask('task-003', [], ['src/a.ts']), // overlaps with task-001
+    it('should select sessions with non-overlapping files', () => {
+      const sessions = [
+        makeTask('session-001', [], ['src/a.ts']),
+        makeTask('session-002', [], ['src/b.ts']),
+        makeTask('session-003', [], ['src/a.ts']), // overlaps with session-001
       ];
 
-      const batch = TaskQueue.selectNonOverlappingBatch(tasks, 10);
+      const batch = TaskQueue.selectNonOverlappingBatch(sessions, 10);
       const batchIds = batch.map((t) => t.id);
 
-      expect(batchIds).toContain('task-001');
-      expect(batchIds).toContain('task-002');
-      expect(batchIds).not.toContain('task-003');
+      expect(batchIds).toContain('session-001');
+      expect(batchIds).toContain('session-002');
+      expect(batchIds).not.toContain('session-003');
     });
 
     it('should respect max batch size', () => {
-      const tasks = [
-        makeTask('task-001', [], ['src/a.ts']),
-        makeTask('task-002', [], ['src/b.ts']),
-        makeTask('task-003', [], ['src/c.ts']),
+      const sessions = [
+        makeTask('session-001', [], ['src/a.ts']),
+        makeTask('session-002', [], ['src/b.ts']),
+        makeTask('session-003', [], ['src/c.ts']),
       ];
 
-      const batch = TaskQueue.selectNonOverlappingBatch(tasks, 2);
+      const batch = TaskQueue.selectNonOverlappingBatch(sessions, 2);
       expect(batch.length).toBe(2);
     });
 
@@ -305,3 +321,4 @@ describe('TaskQueue', () => {
     });
   });
 });
+


### PR DESCRIPTION
## Summary

Implements #139 — redesigns the implementation-planner output from a flat list of tasks to a two-level **agent-session / agent-step** hierarchy.

## Schema Changes

**Before:**
```json
[{ "id": "task-001", "name": "...", "description": "...", "files": [...], "dependencies": [...], "complexity": "...", "acceptanceCriteria": [...] }]
```

**After:**
```json
[{
  "id": "session-001",
  "name": "...",
  "rationale": "...",
  "dependencies": [...],
  "steps": [{
    "id": "session-001-step-001",
    "name": "...",
    "description": "...",
    "files": [...],
    "complexity": "...",
    "acceptanceCriteria": [...]
  }]
}]
```

## Key Changes

### Types & Schema
- Added `AgentStep` and `AgentSession` interfaces (two-level hierarchy)
- Added `agentStepSchema` and `agentSessionSchema` Zod schemas
- Kept `ImplementationTask = AgentSession` and `implementationTaskSchema` as deprecated aliases

### Execution
- `TaskQueue` → `SessionQueue`; `TaskQueue` kept as deprecated alias
- `taskId` → `sessionId` in `AgentInvocation`, `AgentContext`, and `CADRE_SESSION_ID` env var
- Implementation-phase-executor now iterates sessions, then executes each step within a session
- File naming: `session-${id}.md`, `diff-${id}.patch`, `build-failure-${id}-${round}.txt`

### Other Source Files
- `planning-phase-executor`: validates against session schema, error message `'Implementation plan produced zero sessions'`
- `phase-gate`: validates `AgentSession`/`AgentStep` file existence
- `context-builder`: builds session payload with `sessionId` and `steps` array
- `result-parser`: returns `Promise<AgentSession[]>`
- `logger.ts`: added `sessionId` to log context type
- `parallel-executor` / `serial-executor`: use `sessionId` for log context
- `implementation-planner.md`: rewritten template with session/step schema

## Test Results

```
Test Files  114 passed (114)
Tests       2230 passed (2230)
```