### PR TITLE
config: increase copilot timeout from 1200000 to 1800000ms

### DIFF
--- a/cadre.config.json
+++ b/cadre.config.json
@@ -44,7 +44,7 @@
   "copilot": {
     "cliCommand": "copilot",
     "model": "claude-sonnet-4.6",
-    "timeout": 1200000
+    "timeout": 1800000
   },
   "environment": {
     "inheritShellPath": true,


### PR DESCRIPTION
Increases the copilot `timeout` from 20 minutes (1200000ms) to 30 minutes (1800000ms) to give longer-running agent sessions more headroom before timing out.