### PR TITLE
fix: refresh agent templates on run, fix getBaseCommit fork point, fix pr-composer output

### DIFF
--- a/src/agents/templates/pr-composer.md
+++ b/src/agents/templates/pr-composer.md
@@ -14,7 +14,7 @@ Read all task result summaries before composing the PR. Understand the full scop
 
 ## Output Contract
 
-Return a `PRContent` object in a `cadre-json` fenced block. **The fence language must be `cadre-json` exactly — cadre uses this marker to parse the output; a plain `json` block will not be detected.**
+Write a `pr-content.md` file at the path specified by `outputPath` in your context file. The file must contain a `cadre-json` fenced block with the PR content. **The fence language must be `cadre-json` exactly — cadre uses this marker to parse the output; a plain `json` block will not be detected.**
 
 ```cadre-json
 {
@@ -23,6 +23,8 @@ Return a `PRContent` object in a `cadre-json` fenced block. **The fence language
   "labels": ["array", "of", "label", "strings"]
 }
 ```
+
+**You MUST write this file before finishing.** If the file is not written, the pipeline will fail.
 
 ### PR Body Structure
 

--- a/src/cli/agents.ts
+++ b/src/cli/agents.ts
@@ -42,6 +42,35 @@ export function agentFileName(name: string): string {
 }
 
 /**
+ * Refresh all agent instruction files in `agentDir` from the bundled templates,
+ * always overwriting existing files. Called on every `run` so that updates to
+ * bundled templates are picked up without requiring a manual scaffold.
+ *
+ * Returns the count of files written.
+ */
+export async function refreshAgentsFromTemplates(
+  agentDir: string,
+  templateDir?: string,
+): Promise<number> {
+  const resolvedTemplateDir = templateDir ?? getTemplateDir();
+  let written = 0;
+
+  for (const agent of AGENT_DEFINITIONS) {
+    const srcPath = join(resolvedTemplateDir, agent.templateFile);
+    const destPath = join(agentDir, agentFileName(agent.name));
+
+    if (!(await exists(srcPath))) continue;
+
+    const content = await readFile(srcPath, 'utf-8');
+    await mkdir(dirname(destPath), { recursive: true });
+    await writeFile(destPath, content, 'utf-8');
+    written++;
+  }
+
+  return written;
+}
+
+/**
  * Scaffold agent instruction files that are currently missing from `agentDir`.
  * Skips files that already exist; returns the count of files written.
  *

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -608,6 +608,13 @@ export class WorktreeManager {
   private async getBaseCommit(worktreePath: string): Promise<string> {
     try {
       const worktreeGit = simpleGit(worktreePath);
+      // Use merge-base with origin/baseBranch (or local baseBranch as fallback) so
+      // this always returns the fork point, not the latest implementation commit.
+      for (const ref of [`origin/${this.baseBranch}`, this.baseBranch]) {
+        const result = await worktreeGit.raw(['merge-base', 'HEAD', ref]).catch(() => '');
+        if (result.trim()) return result.trim();
+      }
+      // Fall back to HEAD for newly created worktrees that have no commits yet
       const head = await worktreeGit.revparse(['HEAD']);
       return head.trim();
     } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { runInit } from './cli/init.js';
 import { loadConfig, applyOverrides } from './config/loader.js';
 import { CadreRuntime } from './core/runtime.js';
 import { AgentLauncher } from './core/agent-launcher.js';
-import { registerAgentsCommand, scaffoldMissingAgents } from './cli/agents.js';
+import { registerAgentsCommand, scaffoldMissingAgents, refreshAgentsFromTemplates } from './cli/agents.js';
 
 const program = new Command();
 
@@ -54,6 +54,11 @@ program
           backend === 'claude'
             ? config.agent.claude.agentDir
             : config.agent.copilot.agentDir;
+
+        // Always refresh agentDir from bundled templates so worktree syncs pick
+        // up template changes without requiring a manual `cadre agents scaffold`.
+        await refreshAgentsFromTemplates(agentDir);
+
         let issues = await AgentLauncher.validateAgentFiles(agentDir);
 
         if (issues.length > 0) {

--- a/tests/cli-index.test.ts
+++ b/tests/cli-index.test.ts
@@ -24,6 +24,7 @@ vi.mock('../src/cli/agents.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/cli/agents.js')>();
   return {
     ...actual,
+    refreshAgentsFromTemplates: vi.fn().mockResolvedValue(10),
     scaffoldMissingAgents: vi.fn().mockResolvedValue(1),
   };
 });
@@ -299,6 +300,7 @@ describe('cadre run autoscaffold behavior', () => {
     }));
     vi.doMock('../src/cli/agents.js', () => ({
       registerAgentsCommand: vi.fn(),
+      refreshAgentsFromTemplates: vi.fn().mockResolvedValue(10),
       scaffoldMissingAgents: scaffoldMissingAgentsMock,
     }));
     await import('../src/index.js').catch(() => {});

--- a/tests/pr-composer-template.test.ts
+++ b/tests/pr-composer-template.test.ts
@@ -37,8 +37,8 @@ describe('pr-composer.md template', () => {
   });
 
   describe('output contract', () => {
-    it('should describe a PRContent output object', () => {
-      expect(content).toMatch(/PRContent/);
+    it('should describe writing pr-content.md at the outputPath', () => {
+      expect(content).toMatch(/pr-content\.md/);
     });
 
     it('should describe a title field', () => {

--- a/tests/worktree.test.ts
+++ b/tests/worktree.test.ts
@@ -414,7 +414,9 @@ describe('WorktreeManager', () => {
       const result = await manager.provisionFromBranch(42, 'cadre/issue-42');
 
       expect(mockGit.fetch).not.toHaveBeenCalled();
-      expect(mockGit.raw).not.toHaveBeenCalled();
+      // raw IS called for merge-base (to find the fork point), but not for worktree add
+      const rawCalls = (mockGit.raw as ReturnType<typeof vi.fn>).mock.calls;
+      expect(rawCalls.every((args: string[][]) => !args[0].includes('worktree'))).toBe(true);
       expect(result).toMatchObject({
         issueNumber: 42,
         path: '/tmp/worktrees/issue-42',


### PR DESCRIPTION
Three bugs discovered while running issue #142.

## 1. Agent templates never refreshed after initial scaffold

`agentDir` templates were scaffolded once and never updated when source templates changed. Added `refreshAgentsFromTemplates()` to `src/cli/agents.ts` — called unconditionally on every `run` so bundled template changes are picked up immediately without requiring `cadre agents scaffold`.

## 2. `getBaseCommit()` returned HEAD instead of the fork point

When a worktree already existed on resume, `getBaseCommit` called `git revparse HEAD`, returning the latest implementation commit. `getDiff(baseCommit)` then produced an empty patch (diff of HEAD..HEAD), causing the pr-composer to receive no diff context.

Fixed to use `git merge-base HEAD origin/baseBranch` so the original fork point is always returned regardless of how many commits have been made on the branch.

## 3. pr-composer template said "Return" instead of "Write file"

The Output Contract section said *"Return a `PRContent` object in a `cadre-json` block"* — the agent interpreted this as conversational output and never wrote `pr-content.md`. Fixed to explicitly say to write the file at `outputPath`.