### PR TITLE
fix: per-pattern git restore and worktree-rooted git-dir in initCadreDir

### DIFF
--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -223,9 +223,14 @@ export class WorktreeManager {
   }
 
   /**
-   * Bootstrap the worktree's `.cadre/` directory and add it to the worktree's
-   * private git exclude file (`{git-dir}/info/exclude`) so it is never tracked
-   * or accidentally committed — without touching the repo's `.gitignore`.
+   * Bootstrap the worktree's `.cadre/` directory and add both `.cadre/` and
+   * the backend-specific agent directory to the worktree's private git exclude
+   * file (`{git-dir}/info/exclude`) so they are never tracked or accidentally
+   * committed — without touching the repo's `.gitignore`.
+   *
+   * The agent directory (`.github/agents/` for Copilot, `.claude/agents/` for
+   * Claude) is added as a primary defence; `CommitManager.unstageArtifacts`
+   * is the belt-and-suspenders secondary defence.
    */
   private async initCadreDir(worktreePath: string, issueNumber: number): Promise<void> {
     const cadreDir = join(worktreePath, '.cadre');
@@ -234,10 +239,15 @@ export class WorktreeManager {
     // Ensure cadre's tasks scratch dir exists too so agents can write there
     await ensureDir(join(cadreDir, 'tasks'));
 
-    // Write `.cadre/` to the worktree-local git exclude instead of .gitignore
-    // so the exclusion is never staged or committed.
+    // Write exclusions to the worktree-local git exclude instead of .gitignore
+    // so the exclusions are never staged or committed.
     try {
-      const gitDir = (await this.git.raw(['rev-parse', '--git-dir'])).trim();
+      // Use a git instance rooted at the *worktree* so that
+      // `git rev-parse --git-dir` returns the worktree's own git-dir path
+      // (e.g. /path/to/repo/.git/worktrees/issue-N), not the main repo's `.git`.
+      const { simpleGit: makeGit } = await import('simple-git');
+      const worktreeGit = makeGit(worktreePath);
+      const gitDir = (await worktreeGit.raw(['rev-parse', '--git-dir'])).trim();
       const excludePath = join(
         gitDir.startsWith('/') ? gitDir : join(worktreePath, gitDir),
         'info',
@@ -246,16 +256,29 @@ export class WorktreeManager {
       await ensureDir(join(excludePath, '..'));
       const { readFile: readFileNode, writeFile } = await import('node:fs/promises');
       const existing = await readFileNode(excludePath, 'utf-8').catch(() => '');
-      if (!existing.split('\n').some((line) => line.trim() === '.cadre/')) {
+      const existingLines = existing.split('\n').map((l) => l.trim());
+
+      // Entries to protect: cadre state dir + backend-specific agent directory.
+      const agentExcludeDir =
+        this.backend === 'claude' ? '.claude/agents/' : '.github/agents/';
+      const entriesToAdd = ['.cadre/', agentExcludeDir].filter(
+        (entry) => !existingLines.some((l) => l === entry),
+      );
+
+      if (entriesToAdd.length > 0) {
+        const suffix = entriesToAdd.join('\n') + '\n';
         const updated =
           existing === '' || existing.endsWith('\n')
-            ? `${existing}.cadre/\n`
-            : `${existing}\n.cadre/\n`;
+            ? existing + suffix
+            : `${existing}\n${suffix}`;
         await writeFile(excludePath, updated, 'utf-8');
-        this.logger.debug('Added .cadre/ to worktree git exclude', { issueNumber });
+        this.logger.debug(
+          `Added ${entriesToAdd.join(', ')} to worktree git exclude`,
+          { issueNumber },
+        );
       }
-    } catch (err) {
-      // Non-fatal: belt-and-suspenders; CommitManager.unstageArtifacts also guards .cadre/
+    } catch {
+      // Non-fatal: CommitManager.unstageArtifacts provides the secondary guard.
       this.logger.debug('Could not write worktree git exclude; relying on unstageArtifacts', { issueNumber });
     }
   }


### PR DESCRIPTION
## Root cause

Two bugs caused cadre artifact files (`.github/agents/*.agent.md`) to slip into commits and the worktree git exclude to be silently skipped.

---

### Bug 1 — `commit.ts`: bulk `git restore --staged` aborted on pathspec miss

All artifact patterns were passed in a single invocation:

```
git restore --staged -- .cadre/ task-*.md .github/agents/adjudicator.agent.md ...
```

When `task-*.md` matched nothing staged, git returned a pathspec error (exit 128) and **aborted the entire command**. The surrounding `catch {}` swallowed the error, but because it was one atomic command none of the `.github/agents/*.agent.md` files were unstaged — they stayed staged and were committed. The same bug existed in `stripCadreFiles`.

**Fix:** loop over patterns individually, each with its own `.catch(() => {})`, so a miss on one pattern cannot abort the restore of the rest.

---

### Bug 2 — `worktree.ts`: `initCadreDir` used the main-repo `this.git` for `rev-parse --git-dir`

`this.git` is rooted at `repoPath` (the main repo). In a linked worktree, `git rev-parse --git-dir` run from the main repo root returns `.git` — which is a **file** (the gitfile pointer), not a directory. `ensureDir` threw on that path, the `try/catch` caught it silently, and the git exclude was **never written**. So `.github/agents/` had no primary gitignore-level protection.

**Fix:** create a local `simpleGit(worktreePath)` instance for the `rev-parse` so it returns the worktree-specific git-dir (e.g. `/repo/.git/worktrees/issue-N`).

**Secondary improvement:** also write the backend-specific agent directory (`.github/agents/` for Copilot, `.claude/agents/` for Claude) to the exclude file alongside `.cadre/`, making git-level exclusion the primary defence with `unstageArtifacts` as belt-and-suspenders.

---

## Files changed

| File | Change |
|------|--------|
| `src/git/commit.ts` | Per-pattern restore loop in `unstageArtifacts` and `stripCadreFiles` |
| `src/git/worktree.ts` | Worktree-rooted git instance in `initCadreDir`; add agent dir to exclude |
| `tests/git-commit.test.ts` | Updated assertions to collect patterns across per-call restore invocations |