### PR TITLE
fix: whole-PR review exits after one successful fix round

### DIFF
--- a/src/executors/implementation-phase-executor.ts
+++ b/src/executors/implementation-phase-executor.ts
@@ -443,16 +443,18 @@ export class ImplementationPhaseExecutor implements PhaseExecutor {
         return;
       }
 
-      // Commit fix-surgeon output so the next review sees an updated diff.
+      // Commit fix-surgeon output and exit — one successful fix round is sufficient.
       await ctx.io.commitManager.commit(
         `fix: whole-PR review fixes (round ${attempt + 1})`,
         ctx.issue.number,
         'fix',
       );
 
-      // Refresh diff for re-review.
-      const updatedRawDiff = await ctx.io.commitManager.getDiff(ctx.worktree.baseCommit);
-      await writeFile(diffPath, truncateDiff(updatedRawDiff, 200_000), 'utf-8');
+      ctx.services.logger.info('[Whole-PR review] Fix applied successfully; continuing to phase 4', {
+        issueNumber: ctx.issue.number,
+        phase: 3,
+      });
+      return;
     }
   }
 


### PR DESCRIPTION
## Problem

The whole-PR review loop would re-run `whole-pr-reviewer` after every successful `fix-surgeon` pass. Because the reviewer gets no memory of what prior rounds addressed, an LLM re-examining a large diff will reliably find new (increasingly trivial) issues each time, causing the loop to burn through all `maxWholePrReviewRetries` attempts without ever producing a clean sign-off.

## Change

**One review, one fix, done.** If `fix-surgeon` succeeds, the fixes are committed and the loop exits immediately — no re-review. The loop only retries (up to `maxWholePrReviewRetries`) when `fix-surgeon` itself fails, which is the only case where looping is actually useful.

```
Before: review → needs-fixes → fix → re-review → needs-fixes → fix → ... → max retries → continue
After:  review → needs-fixes → fix ✓ → continue
        review → needs-fixes → fix ✗ → retry (up to maxWholePrReviewRetries)
```

## Files changed

- `src/executors/implementation-phase-executor.ts` — return after a successful fix instead of refreshing the diff and looping
- `tests/implementation-phase-executor.test.ts` — updated three tests to match the single-pass contract; the "max retries" test now uses `maxWholePrReviewRetries: 0` to reach that path