### PR TITLE
fix: use unique ephemeral worktree per dag-resolver run

### DIFF
--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -170,7 +170,7 @@ export class CadreRuntime {
     let dag: IssueDag | undefined;
     if (this.config.dag?.enabled) {
       this.logger.info('DAG mode enabled — resolving issue dependency graph');
-      const resolver = new DependencyResolver(this.config, launcher, this.logger);
+      const resolver = new DependencyResolver(this.config, launcher, this.logger, worktreeManager);
       try {
         dag = await resolver.resolve(issues, this.config.repoPath);
         this.logger.info(`DAG resolved: ${dag.getWaves().length} wave(s)`);


### PR DESCRIPTION
## Problem

`DependencyResolver` previously ran the dependency-analyst agent inside a shared `dag-resolver` worktree. Two issues:

1. **Concurrent runs race** — a second `cadre run` with DAG mode would find the same worktree directory already checked out and potentially in an inconsistent state.
2. **Stale state** — a worktree left over from a prior run could have outdated agent files (`.github/agents/` or `.claude/agents/`) or be pointing at an old commit.

## Fix

- **`WorktreeManager.provisionForDependencyAnalyst(runId)`** — always creates a fresh detached worktree at `dag-resolver-<runId>`, syncs agent files into it, and returns its path. Each run gets its own isolated directory.
- **`WorktreeManager.removeWorktreeAtPath(path)`** — removes an ephemeral worktree by path. Non-fatal on failure (logs a warning).
- **`DependencyResolver.resolve()`** — provisions the worktree once upfront (shared across retries), wraps the retry loop in `try/finally` so cleanup always runs even on failure.
- **`invokeAgent()`** — receives the pre-provisioned `agentCwd` instead of provisioning on each attempt.

## Tests

Updated `dependency-resolver.test.ts` to verify:
- `provisionForDependencyAnalyst` is called once with a non-empty run ID
- `removeWorktreeAtPath` is called with the provisioned path after resolution completes