### PR TITLE
fix: dependency-analyst outputs cadre-json block instead of raw JSON

### DIFF
--- a/src/agents/templates/dependency-analyst.md
+++ b/src/agents/templates/dependency-analyst.md
@@ -22,20 +22,18 @@ Produce a dependency map indicating which issues must be completed before others
 - An issue with no dependencies should map to an empty array `[]`.
 
 ### Schema
-The output is a JSON object where:
-- Each **key** is an issue number (as a string).
-- Each **value** is an array of issue numbers (integers) that the key issue depends on.
 
-Example:
 ```json
 {
-  "101": [],
-  "102": [101],
-  "103": [101, 102]
+  "$schema": "dependency-map",
+  "type": "object",
+  "description": "Maps each issue number (string key) to an array of issue numbers it depends on.",
+  "additionalProperties": {
+    "type": "array",
+    "items": { "type": "integer" }
+  }
 }
 ```
-
-In this example, issue 103 depends on both 101 and 102; issue 102 depends on 101; issue 101 has no dependencies.
 
 ## Instructions
 
@@ -48,17 +46,17 @@ In this example, issue 103 depends on both 101 and 102; issue 102 depends on 101
 
 ## Machine-readable output (MANDATORY)
 
-After any analysis prose, you MUST append a `cadre-json` fenced block containing the dependency map. **cadre does not read the markdown prose — it reads only this block.**
+Read the `outputPath` field from your context file. Write your output to that file as a markdown document containing a `cadre-json` fenced block with the dependency map.
+
+**CADRE parses the `cadre-json` block from the file at `outputPath`. The `cadre-json` block is required — output without it will fail.**
+
+Example — issue 103 depends on 101 and 102; issue 102 depends on 101; issue 101 has no dependencies:
 
 ```cadre-json
 {
-  "$schema": "dependency-map",
-  "type": "object",
-  "description": "Maps each issue number (string key) to an array of issue numbers it depends on.",
-  "additionalProperties": {
-    "type": "array",
-    "items": { "type": "integer" }
-  }
+  "101": [],
+  "102": [101],
+  "103": [101, 102]
 }
 ```
 
@@ -66,3 +64,4 @@ After any analysis prose, you MUST append a `cadre-json` fenced block containing
 
 - **GitHub issue read**: Fetch issue details and comments.
 - **File read**: Examine source files to understand module relationships.
+- **File write**: Write the output markdown file (containing the `cadre-json` block) to `outputPath`.

--- a/tests/dependency-resolver.test.ts
+++ b/tests/dependency-resolver.test.ts
@@ -80,6 +80,10 @@ function makeAgentResult(outputPath: string, overrides: Partial<AgentResult> = {
   };
 }
 
+function cadreJson(obj: unknown): string {
+  return `\`\`\`cadre-json\n${JSON.stringify(obj)}\n\`\`\`\n`;
+}
+
 describe('DependencyResolver', () => {
   let config: RuntimeConfig;
   let logger: Logger;
@@ -99,7 +103,7 @@ describe('DependencyResolver', () => {
     const depMap = { '2': [1], '3': [1] };
 
     mockLaunchAgent.mockImplementationOnce(async (invocation: { outputPath: string }) => {
-      await writeFile(invocation.outputPath, JSON.stringify(depMap), 'utf-8');
+      await writeFile(invocation.outputPath, cadreJson(depMap), 'utf-8');
       return makeAgentResult(invocation.outputPath);
     });
 
@@ -122,7 +126,7 @@ describe('DependencyResolver', () => {
     const depMap = { '1': [], '2': [1], '999': [1] };
 
     mockLaunchAgent.mockImplementationOnce(async (invocation: { outputPath: string }) => {
-      await writeFile(invocation.outputPath, JSON.stringify(depMap), 'utf-8');
+      await writeFile(invocation.outputPath, cadreJson(depMap), 'utf-8');
       return makeAgentResult(invocation.outputPath);
     });
 
@@ -146,9 +150,9 @@ describe('DependencyResolver', () => {
       await writeFile(invocation.outputPath, 'not valid json!!!', 'utf-8');
       return makeAgentResult(invocation.outputPath);
     });
-    // Second call (retry): write valid JSON
+    // Second call (retry): write valid cadre-json
     mockLaunchAgent.mockImplementationOnce(async (invocation: { outputPath: string }) => {
-      await writeFile(invocation.outputPath, JSON.stringify(validDepMap), 'utf-8');
+      await writeFile(invocation.outputPath, cadreJson(validDepMap), 'utf-8');
       return makeAgentResult(invocation.outputPath);
     });
 
@@ -167,11 +171,11 @@ describe('DependencyResolver', () => {
     const validDepMap = { '2': [1] };
 
     mockLaunchAgent.mockImplementationOnce(async (invocation: { outputPath: string }) => {
-      await writeFile(invocation.outputPath, JSON.stringify(cyclicDepMap), 'utf-8');
+      await writeFile(invocation.outputPath, cadreJson(cyclicDepMap), 'utf-8');
       return makeAgentResult(invocation.outputPath);
     });
     mockLaunchAgent.mockImplementationOnce(async (invocation: { outputPath: string }) => {
-      await writeFile(invocation.outputPath, JSON.stringify(validDepMap), 'utf-8');
+      await writeFile(invocation.outputPath, cadreJson(validDepMap), 'utf-8');
       return makeAgentResult(invocation.outputPath);
     });
 
@@ -204,7 +208,7 @@ describe('DependencyResolver', () => {
     const cyclicDepMap = { '1': [2], '2': [1] };
 
     mockLaunchAgent.mockImplementation(async (invocation: { outputPath: string }) => {
-      await writeFile(invocation.outputPath, JSON.stringify(cyclicDepMap), 'utf-8');
+      await writeFile(invocation.outputPath, cadreJson(cyclicDepMap), 'utf-8');
       return makeAgentResult(invocation.outputPath);
     });
 
@@ -237,7 +241,7 @@ describe('DependencyResolver', () => {
     } as unknown as WorktreeManager;
 
     mockLaunchAgent.mockImplementationOnce(async (invocation: { outputPath: string }, cwd: string) => {
-      await writeFile(invocation.outputPath, JSON.stringify(depMap), 'utf-8');
+      await writeFile(invocation.outputPath, cadreJson(depMap), 'utf-8');
       expect(cwd).toBe(dagWorktreePath);
       return makeAgentResult(invocation.outputPath);
     });


### PR DESCRIPTION
## Summary

Makes the `dependency-analyst` agent consistent with all other cadre agents: its output artifact is now a markdown file containing a `cadre-json` fenced block, rather than a raw JSON file.

## Changes

### `src/agents/templates/dependency-analyst.md`
- **Schema section**: now shows the formal JSON Schema structure (type, additionalProperties) so agents understand the shape of the output.
- **Machine-readable output section**: moved the concrete `101`/`102`/`103` example here, immediately beneath the MANDATORY instructions, so agents see a real usage example in context.
- Added `File write` to Tool Permissions (agents need to write `outputPath`).

### `src/core/dependency-resolver.ts`
- Switches from `JSON.parse(rawOutput)` → `extractCadreJson(rawOutput)` to correctly parse the `cadre-json` block from the markdown file.
- Renames the output artifact `dep-map.json` → `dep-map.md`.
- Adds a guard: if `extractCadreJson` returns `null`, treats the attempt as a malformed-output failure (with retry).

### `tests/dependency-resolver.test.ts`
- Adds a `cadreJson()` helper that wraps an object in the expected fenced block.
- Updates all `writeFile` calls to produce `cadre-json` blocks instead of raw JSON strings.
- All 8 tests pass.

## Test Results

```
✓ tests/dependency-resolver.test.ts (8 tests) 12ms
Test Files  1 passed (1)
     Tests  8 passed (8)
```