### PR TITLE
feat: log DAG wave ordering at start of wave-based execution

### DIFF
--- a/src/core/fleet-orchestrator.ts
+++ b/src/core/fleet-orchestrator.ts
@@ -466,6 +466,9 @@ export class FleetOrchestrator {
   private async runWithDag(dag: IssueDag): Promise<PromiseSettledResult<IssueResult>[]> {
     const waves = dag.getWaves();
     const waveNumbers = waves.map((w) => w.map((i) => i.number));
+    this.logger.info(
+      `DAG wave plan: ${waveNumbers.map((w, i) => `Wave ${i} → [${w.map((n) => `#${n}`).join(', ')}]`).join(' | ')}`,
+    );
     await this.fleetCheckpoint.setDag(this.dagDepMap ?? {}, waveNumbers);
 
     const checkpoint = this.fleetCheckpoint.getState();


### PR DESCRIPTION
When running in DAG mode, the fleet orchestrator now logs the computed wave plan before executing any waves. Example output:

```
DAG wave plan: Wave 0 → [#10, #12] | Wave 1 → [#15] | Wave 2 → [#20, #22]
```

This makes it easy to verify the dependency resolution and execution order from logs without inspecting the fleet checkpoint file.

**Changes:**
- Added `logger.info()` call in `runWithDag()` after computing `waveNumbers`
- Added test: `logs the DAG wave plan before executing`