### PR TITLE
feat: per-dependency DAG scheduling instead of wave-blocking

### DIFF
--- a/src/core/issue-dag.ts
+++ b/src/core/issue-dag.ts
@@ -89,6 +89,19 @@ export class IssueDag {
     return this.waves;
   }
 
+  /** Returns all issues in the DAG. */
+  getAllIssues(): IssueDetail[] {
+    return [...this.issues.values()];
+  }
+
+  /**
+   * Returns the direct dependency issue numbers for the given issue
+   * (only those present in the DAG's issue set).
+   */
+  getDirectDeps(issueNumber: number): number[] {
+    return (this.depMap[issueNumber] ?? []).filter((n) => this.issues.has(n));
+  }
+
   /**
    * Returns all transitive dependencies of the given issue in topological order
    * (deepest/earliest dependencies first).

--- a/tests/issue-dag.test.ts
+++ b/tests/issue-dag.test.ts
@@ -153,4 +153,30 @@ describe('IssueDag', () => {
       expect(waves[0][0].number).toBe(1);
     });
   });
+
+  describe('getDirectDeps', () => {
+    it('returns direct dep numbers filtered to the issue set', () => {
+      const issues = [makeIssue(1), makeIssue(2), makeIssue(3)];
+      const depMap = { 1: [2, 999], 2: [3] }; // 999 not in set
+      const dag = new IssueDag(issues, depMap);
+      expect(dag.getDirectDeps(1)).toEqual([2]);
+      expect(dag.getDirectDeps(2)).toEqual([3]);
+      expect(dag.getDirectDeps(3)).toEqual([]);
+    });
+
+    it('returns empty array for issue with no deps', () => {
+      const issues = [makeIssue(5)];
+      const dag = new IssueDag(issues, {});
+      expect(dag.getDirectDeps(5)).toEqual([]);
+    });
+  });
+
+  describe('getAllIssues', () => {
+    it('returns all issues in the DAG', () => {
+      const issues = [makeIssue(1), makeIssue(2), makeIssue(3)];
+      const dag = new IssueDag(issues, {});
+      const all = dag.getAllIssues();
+      expect(all.map((i) => i.number).sort()).toEqual([1, 2, 3]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Replace the wave-based DAG scheduler with a per-dependency scheduler that launches each issue as soon as all its direct dependencies have completed, rather than waiting for the entire wave to finish.

Previously, `runWithDag` iterated waves sequentially — all issues in wave N had to complete before any issue in wave N+1 could start. This meant an issue whose only dependency finished early still waited for unrelated siblings in the same wave.

Now, each issue launches as soon as its direct deps are all satisfied, maximizing concurrency and reducing total wall-clock time.

## Changes

**`src/core/issue-dag.ts`**
- Add `getDirectDeps(issueNumber)` — returns direct dep numbers within the DAG's issue set
- Add `getAllIssues()` — returns all issues in the DAG

**`src/core/fleet-orchestrator.ts`**
- Rewrite `runWithDag` as a concurrent readiness-based scheduler:
  - Maintains `completed`, `failed`, `blocked`, and `inFlight` sets
  - Issues with no deps launch immediately
  - When any issue finishes, `scheduleReady()` scans pending issues and launches any whose deps are now satisfied
  - If any dep has failed/blocked, the dependent is immediately marked `dep-blocked`
- autoMerge happens per-issue immediately after success (before releasing dependents), not batched at wave boundaries
- Remove `propagateDepBlocked` helper (propagation is now implicit via `depsFailed()` checks)

**Tests**
- Update all DAG mock objects to provide `getDirectDeps` and `getAllIssues`
- Replace wave-based resume test with per-issue resume test
- Add unit tests for `getDirectDeps` and `getAllIssues` on `IssueDag`
- All 2866 tests pass