### PR TITLE
fix(dag): sync agent files into deps worktree for conflict resolver

### DIFF
--- a/src/git/dependency-branch-merger.ts
+++ b/src/git/dependency-branch-merger.ts
@@ -42,6 +42,7 @@ export class DependencyBranchMerger {
     baseCommit: string,
     worktreeRoot: string,
     resolveMergeConflict?: (context: DependencyMergeConflictContext) => Promise<boolean>,
+    prepareDepsWorktree?: (worktreePath: string, issueNumber: number) => Promise<void>,
   ): Promise<string> {
     const depsBranch = `cadre/deps-${issueNumber}`;
 
@@ -55,6 +56,11 @@ export class DependencyBranchMerger {
     const depsWorktreePath = join(worktreeRoot, `deps-${issueNumber}`);
     await ensureDir(worktreeRoot);
     await this.git.raw(['worktree', 'add', depsWorktreePath, depsBranch]);
+
+    if (prepareDepsWorktree) {
+      await prepareDepsWorktree(depsWorktreePath, issueNumber);
+    }
+
     const depsGit = simpleGit(depsWorktreePath);
 
     let mergeSucceeded = false;

--- a/src/git/worktree-provisioner.ts
+++ b/src/git/worktree-provisioner.ts
@@ -206,6 +206,10 @@ export class WorktreeProvisioner {
       baseCommit,
       this.worktreeRoot,
       resolveMergeConflict,
+      async (depsWorktreePath, depsIssueNumber) => {
+        await this.agentFileSync.initCadreDir(depsWorktreePath, depsIssueNumber);
+        await this.agentFileSync.syncAgentFiles(depsWorktreePath, depsIssueNumber);
+      },
     );
 
     // Create the issue branch from the HEAD of the deps branch

--- a/tests/dependency-branch-merger.test.ts
+++ b/tests/dependency-branch-merger.test.ts
@@ -80,6 +80,22 @@ describe('DependencyBranchMerger', () => {
   });
 
   describe('successful multi-dep merge', () => {
+    it('should call deps worktree preparation callback after creating worktree', async () => {
+      const prepareDepsWorktree = vi.fn().mockResolvedValue(undefined);
+
+      await merger.mergeDependencies(
+        42,
+        [],
+        'basesha',
+        '/tmp/worktrees',
+        undefined,
+        prepareDepsWorktree,
+      );
+
+      expect(prepareDepsWorktree).toHaveBeenCalledOnce();
+      expect(prepareDepsWorktree).toHaveBeenCalledWith('/tmp/worktrees/deps-42', 42);
+    });
+
     it('should create deps branch from baseCommit when it does not exist', async () => {
       await merger.mergeDependencies(42, [], 'basesha', '/tmp/worktrees');
 


### PR DESCRIPTION
## Summary
Fixes DAG dependency conflict resolution failures where `dep-conflict-resolver` could not be launched because deps worktrees were missing synced agent files.

## Root Cause
`DependencyBranchMerger` creates a temporary deps worktree (`cadre/deps-{issue}`) and launches `dep-conflict-resolver` on merge conflicts. Unlike normal issue worktrees, deps worktrees were not initialized via `AgentFileSync`, so `.github/agents/*.agent.md` was absent and Copilot CLI returned `No such agent`.

## Changes
- Add optional `prepareDepsWorktree` hook to `DependencyBranchMerger.mergeDependencies(...)`.
- Invoke the hook immediately after deps worktree creation.
- Wire `WorktreeProvisioner.provisionWithDeps(...)` to pass a hook that:
  - bootstraps `.cadre/` exclusions via `initCadreDir(...)`
  - syncs agent files via `syncAgentFiles(...)`
- Add unit test verifying the deps worktree preparation callback is called with expected path and issue number.

## Validation
- Ran focused tests:
  - `npx vitest run tests/dependency-branch-merger.test.ts`
  - Result: 20 passed.

## Impact
DAG runs using `onDependencyMergeConflict: "resolve"` can now actually invoke `dep-conflict-resolver` in deps worktrees, instead of immediately failing with missing-agent errors.