### PR TITLE
Add dead-property and singleton lifecycle checks (#194)

### DIFF
--- a/tests/integration-checker-template.test.ts
+++ b/tests/integration-checker-template.test.ts
@@ -116,6 +116,34 @@ describe('integration-checker.md template', () => {
     });
   });
 
+  describe('dead-property detection', () => {
+    it('should have a Dead-property Detection section heading', () => {
+      expect(content).toMatch(/## Dead-property Detection/);
+    });
+
+    it('should instruct verifying properties on this or returned objects have read call-sites', () => {
+      expect(content).toMatch(/properties assigned on `this` or on a returned/i);
+    });
+
+    it('should instruct flagging properties with no readers', () => {
+      expect(content).toMatch(/flag.*property.*never read|written but.*never read/i);
+    });
+  });
+
+  describe('singleton lifecycle check', () => {
+    it('should have a Singleton Lifecycle Check section heading', () => {
+      expect(content).toMatch(/## Singleton Lifecycle Check/);
+    });
+
+    it('should instruct verifying handles are used to serve requests', () => {
+      expect(content).toMatch(/used to.*serve requests/i);
+    });
+
+    it('should instruct checking consumers do not independently spawn equivalent instances', () => {
+      expect(content).toMatch(/consumers.*do.*not.*independently spawn/i);
+    });
+  });
+
   describe('baseline comparison', () => {
     it('should reference baseline-results.json', () => {
       expect(content).toMatch(/baseline-results\.json/);
@@ -137,6 +165,69 @@ describe('integration-checker.md template', () => {
   describe('tool permissions', () => {
     it('should mention bash as a permitted tool', () => {
       expect(content).toMatch(/\bbash\b/i);
+    });
+  });
+
+  describe('agent file parity', () => {
+    const AGENT_PATH = resolve(__dirname, '../.github/agents/integration-checker.agent.md');
+    let agentContent: string;
+
+    beforeAll(() => {
+      agentContent = readFileSync(AGENT_PATH, 'utf-8');
+    });
+
+    it('should have a Dead-property Detection section in the agent file', () => {
+      expect(agentContent).toMatch(/## Dead-property Detection/);
+    });
+
+    it('should have a Singleton Lifecycle Check section in the agent file', () => {
+      expect(agentContent).toMatch(/## Singleton Lifecycle Check/);
+    });
+
+    it('should have matching Dead-property Detection content between template and agent file', () => {
+      const extractSection = (text: string, heading: string): string => {
+        const regex = new RegExp(`## ${heading}\\n([\\s\\S]*?)(?=\\n## |$)`);
+        const match = text.match(regex);
+        return match ? match[1].trim() : '';
+      };
+      const templateSection = extractSection(content, 'Dead-property Detection');
+      const agentSection = extractSection(agentContent, 'Dead-property Detection');
+      expect(agentSection).toBe(templateSection);
+    });
+
+    it('should have matching Singleton Lifecycle Check content between template and agent file', () => {
+      const extractSection = (text: string, heading: string): string => {
+        const regex = new RegExp(`## ${heading}\\n([\\s\\S]*?)(?=\\n## |$)`);
+        const match = text.match(regex);
+        return match ? match[1].trim() : '';
+      };
+      const templateSection = extractSection(content, 'Singleton Lifecycle Check');
+      const agentSection = extractSection(agentContent, 'Singleton Lifecycle Check');
+      expect(agentSection).toBe(templateSection);
+    });
+  });
+
+  describe('section ordering', () => {
+    it('should place Dead-property Detection after Baseline Comparison', () => {
+      const baselineIdx = content.indexOf('## Baseline Comparison');
+      const deadPropIdx = content.indexOf('## Dead-property Detection');
+      expect(baselineIdx).toBeGreaterThan(-1);
+      expect(deadPropIdx).toBeGreaterThan(baselineIdx);
+    });
+
+    it('should place Singleton Lifecycle Check after Dead-property Detection', () => {
+      const deadPropIdx = content.indexOf('## Dead-property Detection');
+      const singletonIdx = content.indexOf('## Singleton Lifecycle Check');
+      expect(deadPropIdx).toBeGreaterThan(-1);
+      expect(singletonIdx).toBeGreaterThan(deadPropIdx);
+    });
+
+    it('should place both new sections before the Output section', () => {
+      const deadPropIdx = content.indexOf('## Dead-property Detection');
+      const singletonIdx = content.indexOf('## Singleton Lifecycle Check');
+      const outputIdx = content.indexOf('## Output');
+      expect(deadPropIdx).toBeLessThan(outputIdx);
+      expect(singletonIdx).toBeLessThan(outputIdx);
     });
   });
 });


### PR DESCRIPTION
## Summary

Extend the integration-checker template with two new static-analysis instruction sections: **Dead-property Detection** and **Singleton Lifecycle Check**. These instruct the agent to flag properties that are written but never read, and to detect singleton-vs-per-call resource lifecycle smells. Closes #194

## Changes

### Integration-checker template (`src/agents/templates/integration-checker.md`)
- Added **Dead-property Detection** section instructing the agent to scan for properties assigned on `this` or returned/exported objects with no read call-site outside the setter, and flag them as dead properties.
- Added **Singleton Lifecycle Check** section instructing the agent to verify stored subprocess/connection handles are used to serve requests (not just readiness probes) and that consumers don't independently spawn equivalent instances per-call.
- Both sections are placed after the Baseline Comparison section and before the Output section.

### Agent file (`.github/agents/integration-checker.agent.md`)
- Mirrored both new sections identically to keep the agent file in sync with the primary template.

### Tests (`tests/integration-checker-template.test.ts`)
- Added `dead-property detection` describe block verifying the section heading, property scanning instructions, and flagging instructions.
- Added `singleton lifecycle check` describe block verifying the section heading, handle utilization check, and redundant spawning check.
- Added `agent file parity` describe block verifying both new sections exist in the agent file with content matching the primary template.
- Added `section ordering` describe block verifying the new sections appear after Baseline Comparison and before Output.

### Reviewer agent improvements
- Updated `.github/agents/code-reviewer.agent.md` to accept `issueBody` in the payload as the authoritative source of requirements.
- Updated `.github/agents/whole-pr-reviewer.agent.md` to add completeness validation against the original issue body, flagging unimplemented requirements as errors.

## Testing

- All existing and new tests pass (`npx vitest run` exits 0).
- Build succeeds (`npm run build` exits 0).
- No regressions detected.

Closes #194