### PR TITLE
refactor(config): remove legacy copilot config path

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -116,29 +116,15 @@ Shell commands executed inside the issue worktree.
 
 ---
 
-## `copilot`
-
-Controls the GitHub Copilot CLI backend.
-
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `cliCommand` | `string` | `"copilot"` | Executable name for the Copilot CLI. |
-| `model` | `string` | `"claude-sonnet-4.6"` | Model identifier passed to the Copilot CLI. |
-| `agentDir` | `string` | `".github/agents"` | Directory containing `.md` agent files. |
-| `timeout` | `number` | `300000` | Timeout in milliseconds for a single agent invocation. |
-| `costOverrides` | `Record<string, { input: number, output: number }>` | — | Per-model cost overrides ($/1K tokens) for token budget accounting. Keys are model names. |
-
----
-
 ## `agent`
 
-Advanced agent backend configuration. When omitted cadre uses the `copilot` backend with defaults.
+Advanced agent backend configuration.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `backend` | `"copilot" \| "claude"` | `"copilot"` | AI backend for agent invocations. |
-| `model` | `string` | — | Model identifier override (takes precedence over backend-specific default). |
-| `timeout` | `number` | — | Timeout in ms override for all agents. |
+| `model` | `string` | `"claude-sonnet-4.6"` | Model identifier override (takes precedence over backend-specific default). |
+| `timeout` | `number` | `300000` | Timeout in ms override for all agents. |
 | `copilot.cliCommand` | `string` | `"copilot"` | Copilot CLI executable. |
 | `copilot.agentDir` | `string` | `".github/agents"` | Agent file directory. |
 | `copilot.costOverrides` | `Record<string, { input, output }>` | — | Per-model cost overrides. |

--- a/src/agents/backend.ts
+++ b/src/agents/backend.ts
@@ -226,10 +226,9 @@ export class CopilotBackend implements AgentBackend {
     private readonly config: RuntimeConfig,
     private readonly logger: Logger,
   ) {
-    // Prefer config.agent.copilot settings, fall back to legacy config.copilot
     this.cliCommand = config.agent.copilot.cliCommand;
     this.agentDir = config.agent.copilot.agentDir;
-    this.defaultTimeout = config.agent.timeout ?? config.copilot.timeout;
+    this.defaultTimeout = config.agent.timeout;
     this.defaultModel = config.agent.model;
   }
 
@@ -292,7 +291,7 @@ export class ClaudeBackend implements AgentBackend {
     private readonly logger: Logger,
   ) {
     this.cliCommand = config.agent.claude.cliCommand || 'claude';
-    this.defaultTimeout = config.agent.timeout ?? config.copilot.timeout;
+    this.defaultTimeout = config.agent.timeout;
     this.defaultModel = config.agent.model;
   }
 

--- a/src/budget/cost-estimator.ts
+++ b/src/budget/cost-estimator.ts
@@ -18,7 +18,7 @@ const DEFAULT_COSTS: Record<string, { input: number; output: number }> = {
 export class CostEstimator {
   private readonly costs: Record<string, { input: number; output: number }>;
 
-  constructor(config: CadreConfig['copilot']) {
+  constructor(config: NonNullable<CadreConfig['agent']>['copilot']) {
     this.costs = { ...DEFAULT_COSTS };
 
     // Apply config overrides

--- a/src/cli/status-renderer.ts
+++ b/src/cli/status-renderer.ts
@@ -39,14 +39,14 @@ export function formatElapsed(isoDate?: string): string {
 export function renderFleetStatus(
   state: FleetCheckpointState,
   model?: string,
-  copilotConfig?: CadreConfig['copilot'],
+  copilotConfig?: NonNullable<CadreConfig['agent']>['copilot'],
 ): string {
   const estimator = new CostEstimator(
-    copilotConfig ?? { cliCommand: 'copilot', model: 'claude-sonnet-4.6', agentDir: '.github/agents', timeout: 300_000 },
+    copilotConfig ?? { cliCommand: 'copilot', agentDir: '.github/agents' },
   );
 
   const totalTokens = state.tokenUsage.total;
-  const totalCostEst = estimator.estimate(totalTokens, model ?? copilotConfig?.model);
+  const totalCostEst = estimator.estimate(totalTokens, model);
   const totalCostStr = totalTokens > 0 ? `$${totalCostEst.totalCost.toFixed(4)}` : '$0.0000';
   const header = [
     `Project: ${state.projectName}`,
@@ -59,7 +59,7 @@ export function renderFleetStatus(
   for (const [issueNumStr, issue] of Object.entries(state.issues)) {
     const issueNum = Number(issueNumStr);
     const tokens = state.tokenUsage.byIssue[issueNum] ?? 0;
-    const costEst = estimator.estimate(tokens, model ?? copilotConfig?.model);
+    const costEst = estimator.estimate(tokens, model);
     const costStr = tokens > 0 ? `$${costEst.totalCost.toFixed(4)}` : '—';
     const phaseIdx = Math.max(0, issue.lastPhase - 1);
     const phaseName = phaseIdx >= 0 && phaseIdx < phaseNames.length ? phaseNames[phaseIdx] : `Phase ${issue.lastPhase}`;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -30,9 +30,9 @@ export const AgentConfigSchema = z.object({
   /** Which AI backend to use for agent invocations. */
   backend: z.enum(['copilot', 'claude']).default('copilot'),
   /** Model identifier to pass to the backend (overrides backend-specific default). */
-  model: z.string().optional(),
+  model: z.string().default('claude-sonnet-4.6'),
   /** Timeout in milliseconds for agent invocations. */
-  timeout: z.number().int().optional(),
+  timeout: z.number().int().default(300_000),
   /** Copilot-backend-specific options. */
   copilot: z
     .object({
@@ -212,24 +212,6 @@ export const CadreConfigSchema = z.object({
     })
     .default({}),
 
-  copilot: z
-    .object({
-      cliCommand: z.string().default('copilot'),
-      model: z.string().default('claude-sonnet-4.6'),
-      agentDir: z.string().default('agents'),
-      timeout: z.number().int().default(300_000),
-      costOverrides: z
-        .record(
-          z.string(),
-          z.object({
-            input: z.number().min(0),
-            output: z.number().min(0),
-          }),
-        )
-        .optional(),
-    })
-    .default({}),
-
   environment: z
     .object({
       inheritShellPath: z.boolean().default(true),
@@ -340,8 +322,8 @@ export const CadreConfigSchema = z.object({
   /** Notification provider configuration. Optional; defaults to disabled. */
   notifications: NotificationsConfigSchema,
 
-  /** Agent backend configuration. Optional; uses copilot defaults when omitted. */
-  agent: AgentConfigSchema.optional(),
+  /** Agent backend configuration. */
+  agent: AgentConfigSchema.default({}),
 
   /** Review response configuration. */
   reviewResponse: z

--- a/src/core/fleet-orchestrator.ts
+++ b/src/core/fleet-orchestrator.ts
@@ -76,7 +76,7 @@ export class FleetOrchestrator {
     this.fleetCheckpoint = new FleetCheckpointManager(this.cadreDir, config.projectName, logger);
     this.fleetProgress = new FleetProgressWriter(this.cadreDir, logger);
     this.tokenTracker = new TokenTracker();
-    this.costEstimator = new CostEstimator(config.copilot);
+    this.costEstimator = new CostEstimator(config.agent.copilot);
     this.contextBuilder = new ContextBuilder(config, logger);
 
     const autoComplete = this.resolveAutoCompleteConfig();

--- a/src/core/fleet-reporter.ts
+++ b/src/core/fleet-reporter.ts
@@ -138,7 +138,7 @@ export class FleetReporter {
    */
   async writeReport(fleetResult: FleetResult, startTime: number): Promise<void> {
     try {
-      const reportWriter = new ReportWriter(this.config, new CostEstimator(this.config.copilot));
+      const reportWriter = new ReportWriter(this.config, new CostEstimator(this.config.agent.copilot));
       const report = reportWriter.buildReport(fleetResult, this.issues, startTime);
       const reportPath = await reportWriter.write(report);
       this.logger.info(`Run report written: ${reportPath}`);

--- a/src/core/report-service.ts
+++ b/src/core/report-service.ts
@@ -41,8 +41,8 @@ export class ReportService {
     }
 
     const duration = (run.duration / 1000).toFixed(1);
-    const estimator = new CostEstimator(this.config.copilot);
-    const costStr = estimator.format(estimator.estimate(run.totalTokens, this.config.copilot.model));
+    const estimator = new CostEstimator(this.config.agent.copilot);
+    const costStr = estimator.format(estimator.estimate(run.totalTokens, this.config.agent.model));
 
     console.log('\n=== CADRE Run Report ===\n');
     console.log(`  Run ID:   ${run.runId}`);

--- a/src/core/run-coordinator.ts
+++ b/src/core/run-coordinator.ts
@@ -304,8 +304,8 @@ export class RunCoordinator {
     console.log('');
 
     // Cost estimate
-    const estimator = new CostEstimator(this.config.copilot);
-    const estimate = estimator.estimate(result.tokenUsage.total, this.config.copilot.model);
+    const estimator = new CostEstimator(this.config.agent.copilot);
+    const estimate = estimator.estimate(result.tokenUsage.total, this.config.agent.model);
     console.log(`  Estimated cost: ${estimator.format(estimate)}`);
     console.log('');
   }

--- a/src/core/status-service.ts
+++ b/src/core/status-service.ts
@@ -54,7 +54,7 @@ export class StatusService {
         console.log(`No per-issue checkpoint found for issue #${issueNumber}`);
       }
     } else {
-      console.log(renderFleetStatus(state, this.config.copilot.model, this.config.copilot));
+      console.log(renderFleetStatus(state, this.config.agent.model, this.config.agent.copilot));
     }
   }
 }

--- a/src/reporting/report-writer.ts
+++ b/src/reporting/report-writer.ts
@@ -54,7 +54,7 @@ export class ReportWriter {
     const byPhase = result.tokenUsage.byPhase;
     const phases: RunPhaseSummary[] = ISSUE_PHASES.map((phase) => {
       const tokens = byPhase[phase.id] ?? 0;
-      const costEstimate = this.costEstimator.estimate(tokens, this.config.copilot.model);
+      const costEstimate = this.costEstimator.estimate(tokens, this.config.agent.model);
       return {
         id: String(phase.id),
         name: phase.name,
@@ -66,7 +66,7 @@ export class ReportWriter {
 
     const totalCostEstimate = this.costEstimator.estimate(
       result.tokenUsage.total,
-      this.config.copilot.model,
+      this.config.agent.model,
     );
 
     const prsCreated = result.prsCreated.length;

--- a/src/validation/agent-backend-validator.ts
+++ b/src/validation/agent-backend-validator.ts
@@ -10,7 +10,7 @@ export const agentBackendValidator: PreRunValidator = {
     const errors: string[] = [];
     const warnings: string[] = [];
 
-    // loadConfig always synthesizes config.agent before returning
+    // loadConfig always returns config.agent with defaults applied
     const agent = config.agent;
     const isClaudeBackend = agent.backend === 'claude';
 

--- a/tests/config-schema.test.ts
+++ b/tests/config-schema.test.ts
@@ -34,9 +34,10 @@ describe('CadreConfigSchema', () => {
     expect(result.pullRequest.autoComplete).toBe(false);
     expect(result.pullRequest.draft).toBe(true);
     expect(result.pullRequest.labels).toEqual(['cadre-generated']);
-    expect(result.copilot.cliCommand).toBe('copilot');
-    expect(result.copilot.agentDir).toBe('agents');
-    expect(result.copilot.timeout).toBe(300_000);
+    expect(result.agent.backend).toBe('copilot');
+    expect(result.agent.copilot.cliCommand).toBe('copilot');
+    expect(result.agent.copilot.agentDir).toBe('agents');
+    expect(result.agent.timeout).toBe(300_000);
     expect(result.github?.mcpServer.command).toBe('github-mcp-server');
     expect(result.github?.mcpServer.args).toEqual(['stdio']);
     // Auth is a union — the validConfig uses App auth
@@ -779,11 +780,12 @@ describe('CadreConfigSchema', () => {
   });
 
   describe('agent field', () => {
-    it('should accept a config without an agent field (backward compat)', () => {
+    it('should apply default agent config when agent field is omitted', () => {
       const result = CadreConfigSchema.safeParse(validConfig);
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.agent).toBeUndefined();
+        expect(result.data.agent).toBeDefined();
+        expect(result.data.agent.backend).toBe('copilot');
       }
     });
 
@@ -976,14 +978,14 @@ describe('AgentConfigSchema', () => {
     expect(result.claude.cliCommand).toBe('claude');
   });
 
-  it('should leave model undefined by default', () => {
+  it('should default model to claude-sonnet-4.6', () => {
     const result = AgentConfigSchema.parse({});
-    expect(result.model).toBeUndefined();
+    expect(result.model).toBe('claude-sonnet-4.6');
   });
 
-  it('should leave timeout undefined by default', () => {
+  it('should default timeout to 300000', () => {
     const result = AgentConfigSchema.parse({});
-    expect(result.timeout).toBeUndefined();
+    expect(result.timeout).toBe(300_000);
   });
 
   it('should accept backend claude with custom cliCommand', () => {

--- a/tests/core/report-service.test.ts
+++ b/tests/core/report-service.test.ts
@@ -27,7 +27,13 @@ function makeConfig(): RuntimeConfig {
   return {
     stateDir: '/tmp/cadre-state',
     projectName: 'test-project',
-    copilot: { model: 'claude-sonnet-4.6', cliCommand: 'copilot', agentDir: '.agents', timeout: 300000 },
+    agent: {
+      backend: 'copilot',
+      model: 'claude-sonnet-4.6',
+      timeout: 300000,
+      copilot: { cliCommand: 'copilot', agentDir: '.agents' },
+      claude: { cliCommand: 'claude', agentDir: '.agents' },
+    },
   } as unknown as RuntimeConfig;
 }
 

--- a/tests/core/status-service.test.ts
+++ b/tests/core/status-service.test.ts
@@ -58,7 +58,13 @@ function makeConfig(): RuntimeConfig {
   return {
     stateDir: '/tmp/cadre-state',
     projectName: 'test-project',
-    copilot: { model: 'claude-sonnet-4.6', cliCommand: 'copilot', agentDir: '.agents', timeout: 300000 },
+    agent: {
+      backend: 'copilot',
+      model: 'claude-sonnet-4.6',
+      timeout: 300000,
+      copilot: { cliCommand: 'copilot', agentDir: '.agents' },
+      claude: { cliCommand: 'claude', agentDir: '.agents' },
+    },
   } as unknown as RuntimeConfig;
 }
 
@@ -137,12 +143,16 @@ describe('StatusService', () => {
       }));
     });
 
-    it('should call renderFleetStatus with fleet state and copilot config', async () => {
+    it('should call renderFleetStatus with fleet state and agent copilot config', async () => {
       const config = makeConfig();
       const service = new StatusService(config, makeLogger());
       await service.status();
 
-      expect(mockRenderFleetStatus).toHaveBeenCalledWith(fleetState, config.copilot.model, config.copilot);
+      expect(mockRenderFleetStatus).toHaveBeenCalledWith(
+        fleetState,
+        config.agent.model,
+        config.agent.copilot,
+      );
     });
 
     it('should print the rendered fleet status', async () => {

--- a/tests/fleet-reporter.test.ts
+++ b/tests/fleet-reporter.test.ts
@@ -37,7 +37,13 @@ function makeIssue(number: number): IssueDetail {
 function makeConfig() {
   return {
     options: { tokenBudget: 100000 },
-    copilot: { cliCommand: 'copilot', model: 'gpt-4', agentDir: '/tmp', timeout: 300000 },
+    agent: {
+      backend: 'copilot',
+      model: 'gpt-4',
+      timeout: 300000,
+      copilot: { cliCommand: 'copilot', agentDir: '/tmp' },
+      claude: { cliCommand: 'claude', agentDir: '/tmp' },
+    },
   } as any;
 }
 

--- a/tests/helpers/make-runtime-config.ts
+++ b/tests/helpers/make-runtime-config.ts
@@ -39,15 +39,11 @@ export function makeRuntimeConfig(overrides: Partial<RuntimeConfig> = {}): Runti
       postCostComment: false,
     },
     commands: {},
-    copilot: {
-      cliCommand: 'copilot',
-      model: 'claude-sonnet-4.6',
-      agentDir: '/tmp/.cadre/test-project/agents',
-      timeout: 300_000,
-    },
     environment: { inheritShellPath: true, extraPath: [] },
     agent: {
       backend: 'copilot',
+      model: 'claude-sonnet-4.6',
+      timeout: 300_000,
       copilot: {
         cliCommand: 'copilot',
         agentDir: '/tmp/.cadre/test-project/agents',

--- a/tests/runtime-status.test.ts
+++ b/tests/runtime-status.test.ts
@@ -219,12 +219,16 @@ describe('CadreRuntime.status() — fleet checkpoint exists, no issue filter', (
     consoleSpy.mockRestore();
   });
 
-  it('calls renderFleetStatus with the loaded fleet state and copilot config', async () => {
+  it('calls renderFleetStatus with the loaded fleet state and agent copilot config', async () => {
     const config = makeConfig();
     const runtime = new CadreRuntime(config);
     await runtime.status();
 
-    expect(mockRenderFleetStatus).toHaveBeenCalledWith(fleetState, config.copilot.model, config.copilot);
+    expect(mockRenderFleetStatus).toHaveBeenCalledWith(
+      fleetState,
+      config.agent.model,
+      config.agent.copilot,
+    );
   });
 
   it('prints the rendered fleet status table', async () => {


### PR DESCRIPTION
## Summary
- remove legacy top-level `copilot` schema path and make `agent` canonical
- remove loader fallback that synthesized `agent` from top-level `copilot`
- migrate runtime model/timeout/cost usage from `config.copilot` to `config.agent`
- update config docs and tests to reflect agent-only defaults and behavior

## Validation
- pnpm -s tsc --noEmit
- pnpm -s vitest run

## Notes
- this is an intentional breaking config change: top-level `copilot` is no longer consumed by runtime config