### PR TITLE
fix(state): keep CADRE state under ~/.cadre and tighten path semantics

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -488,7 +488,7 @@ stateDiagram-v2
 
 ```mermaid
 graph TD
-    ROOT["~/.cadre/&lt;repo&gt;/"]
+    ROOT["~/.cadre/"]
 
     ROOT --> WT["worktrees/"]
     ROOT --> AG["agents/   (templates)"]

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { resolve, isAbsolute, join } from 'node:path';
+import { resolve, isAbsolute, join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { CadreConfigSchema, type CadreConfig } from './schema.js';
 import { exists } from '../util/fs.js';
@@ -33,6 +33,7 @@ export class ConfigLoadError extends Error {
  */
 export async function loadConfig(configPath: string): Promise<RuntimeConfig> {
   const absPath = isAbsolute(configPath) ? configPath : resolve(process.cwd(), configPath);
+  const configDir = dirname(absPath);
 
   // Check file exists
   if (!(await exists(absPath))) {
@@ -68,13 +69,13 @@ export async function loadConfig(configPath: string): Promise<RuntimeConfig> {
   const resolvedStateDir = config.stateDir
     ? isAbsolute(config.stateDir)
       ? config.stateDir
-      : resolve(process.cwd(), config.stateDir)
-    : join(homedir(), '.cadre', config.projectName);
+      : resolve(configDir, config.stateDir)
+    : join(homedir(), '.cadre');
 
   const resolvedWorktreeRoot = config.worktreeRoot
     ? isAbsolute(config.worktreeRoot)
       ? config.worktreeRoot
-      : resolve(resolvedRepoPath, config.worktreeRoot)
+      : resolve(resolvedStateDir, config.worktreeRoot)
     : join(resolvedStateDir, 'worktrees');
 
   /**

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -84,7 +84,7 @@ export const CadreConfigSchema = z.object({
 
   /**
    * Directory where all cadre state is stored (logs, checkpoints, reports, agents, worktrees).
-   * Defaults to `~/.cadre/{projectName}/` so cadre never writes inside the target repository.
+    * Defaults to `~/.cadre/` so cadre never writes inside the target repository.
    * Can be overridden to any absolute or relative path.
    */
   stateDir: z.string().optional(),

--- a/src/git/dependency-branch-merger.ts
+++ b/src/git/dependency-branch-merger.ts
@@ -1,5 +1,6 @@
 import { simpleGit, type SimpleGit } from 'simple-git';
 import { join } from 'node:path';
+import { homedir } from 'node:os';
 import { writeFile } from 'node:fs/promises';
 import { Logger } from '../logging/logger.js';
 import { ensureDir } from '../util/fs.js';
@@ -23,7 +24,7 @@ export class DependencyBranchMerger {
     private readonly repoPath: string,
     private readonly logger: Logger,
     private readonly resolveBranchName: (issueNumber: number, title: string) => string,
-    private readonly stateDir: string = join(repoPath, '.cadre'),
+    private readonly stateDir: string = join(homedir(), '.cadre'),
   ) {}
 
   /**

--- a/src/git/worktree-provisioner.ts
+++ b/src/git/worktree-provisioner.ts
@@ -1,6 +1,6 @@
 import { simpleGit, type SimpleGit } from 'simple-git';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { tmpdir, homedir } from 'node:os';
 import { Logger } from '../logging/logger.js';
 import { exists, ensureDir } from '../util/fs.js';
 import type { IssueDetail } from '../platform/provider.js';
@@ -53,7 +53,7 @@ export class WorktreeProvisioner {
     private readonly logger: Logger,
     private readonly agentDir?: string,
     private readonly backend: string = 'copilot',
-    private readonly stateDir: string = join(repoPath, '.cadre'),
+    private readonly stateDir: string = join(homedir(), '.cadre'),
   ) {
     this.git = simpleGit(repoPath);
     this.agentFileSync = new AgentFileSync(agentDir, backend, logger);

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,5 +1,6 @@
 import { appendFile, mkdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
 import { format } from 'date-fns';
 import type { LogLevel, LogEntry, CadreEvent } from './events.js';
 
@@ -28,7 +29,7 @@ export class Logger {
 
   constructor(opts: Partial<LoggerOptions> & { source: string }) {
     this.opts = {
-      logDir: opts.logDir ?? '.cadre/logs',
+      logDir: opts.logDir ?? join(homedir(), '.cadre', 'logs'),
       level: opts.level ?? 'info',
       console: opts.console ?? true,
       source: opts.source,

--- a/src/notifications/log-provider.ts
+++ b/src/notifications/log-provider.ts
@@ -1,5 +1,6 @@
 import { appendFile } from 'fs/promises';
 import path from 'path';
+import { homedir } from 'os';
 import type { NotificationProvider } from './types.js';
 import type { CadreEvent } from '../logging/events.js';
 
@@ -13,7 +14,7 @@ export class LogProvider implements NotificationProvider {
   private readonly events?: string[];
 
   constructor(config: LogProviderConfig = {}) {
-    this.logFile = config.logFile ?? path.join(process.cwd(), '.cadre', 'notifications.jsonl');
+    this.logFile = config.logFile ?? path.join(homedir(), '.cadre', 'notifications.jsonl');
     this.events = config.events;
   }
 

--- a/src/notifications/manager.ts
+++ b/src/notifications/manager.ts
@@ -11,7 +11,10 @@ function resolveLogFilePath(logFile: string | undefined, stateDir: string | unde
   if (!logFile) {
     return stateDir ? join(stateDir, 'notifications.jsonl') : undefined;
   }
-  if (isAbsolute(logFile) || !stateDir) {
+  if (isAbsolute(logFile)) {
+    return logFile;
+  }
+  if (!stateDir) {
     return logFile;
   }
   if (logFile.startsWith('.cadre/')) {

--- a/tests/config-loader-paths.test.ts
+++ b/tests/config-loader-paths.test.ts
@@ -175,14 +175,14 @@ describe('loadConfig – stateDir resolution', () => {
     vi.clearAllMocks();
   });
 
-  it('defaults stateDir to ~/.cadre/<projectName> when absent from config', async () => {
+  it('defaults stateDir to ~/.cadre when absent from config', async () => {
     const cfg = makeConfig();
     // Remove stateDir
     delete (cfg as Record<string, unknown>).stateDir;
     setupFs(cfg);
 
     const config = await loadConfig('/tmp/cadre.config.json');
-    const expected = join(homedir(), '.cadre', 'test-project');
+    const expected = join(homedir(), '.cadre');
     expect(config.stateDir).toBe(expected);
   });
 
@@ -193,11 +193,11 @@ describe('loadConfig – stateDir resolution', () => {
     expect(config.stateDir).toBe('/custom/absolute/state');
   });
 
-  it('resolves a relative stateDir against process.cwd()', async () => {
+  it('resolves a relative stateDir against the config file directory', async () => {
     setupFs(makeConfig({ stateDir: 'relative/state' }));
 
     const config = await loadConfig('/tmp/cadre.config.json');
-    expect(config.stateDir).toBe(resolve(process.cwd(), 'relative/state'));
+    expect(config.stateDir).toBe(resolve('/tmp', 'relative/state'));
   });
 });
 
@@ -223,12 +223,11 @@ describe('loadConfig – worktreeRoot resolution', () => {
     expect(config.worktreeRoot).toBe('/custom/worktrees');
   });
 
-  it('resolves a relative worktreeRoot against repoPath', async () => {
+  it('resolves a relative worktreeRoot against stateDir', async () => {
     setupFs(makeConfig({ worktreeRoot: 'relative/worktrees' }));
 
     const config = await loadConfig('/tmp/cadre.config.json');
-    // repoPath is /tmp/repo (absolute in fixture)
-    expect(config.worktreeRoot).toBe('/tmp/repo/relative/worktrees');
+    expect(config.worktreeRoot).toBe('/abs/state/relative/worktrees');
   });
 
   it('worktreeRoot defaults to stateDir/worktrees using the default stateDir when both are absent', async () => {
@@ -238,7 +237,7 @@ describe('loadConfig – worktreeRoot resolution', () => {
     setupFs(cfg);
 
     const config = await loadConfig('/tmp/cadre.config.json');
-    const expectedStateDir = join(homedir(), '.cadre', 'test-project');
+    const expectedStateDir = join(homedir(), '.cadre');
     expect(config.worktreeRoot).toBe(join(expectedStateDir, 'worktrees'));
   });
 });

--- a/tests/log-provider.test.ts
+++ b/tests/log-provider.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
 import { LogProvider } from '../src/notifications/log-provider.js';
 
 vi.mock('fs/promises', () => ({
@@ -19,7 +21,7 @@ describe('LogProvider', () => {
     await provider.notify({ type: 'fleet-started', issueCount: 1, maxParallel: 1 });
     expect(mockAppendFile).toHaveBeenCalledOnce();
     const [filePath, content] = mockAppendFile.mock.calls[0];
-    expect(filePath).toContain('.cadre/notifications.jsonl');
+    expect(filePath).toBe(join(homedir(), '.cadre', 'notifications.jsonl'));
     expect(content).toMatch(/^\{.*\}\n$/);
   });
 


### PR DESCRIPTION
## Summary
- Default  to  (single shared state root)
- Resolve relative  from the config file directory (strict, deterministic semantics)
- Resolve relative  from resolved 
- Remove special-case  path fallback behavior in notification path resolution
- Align fallback state/log defaults and docs with home-rooted state behavior
- Update tests for the new defaults and resolution rules

## Validation
- 
 RUN  v2.1.9 /Users/jacobfreck/Source/cadre

 ✓ tests/config-loader-paths.test.ts (14 tests) 6ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
   Start at  15:55:25
   Duration  372ms (transform 36ms, setup 0ms, collect 42ms, tests 6ms, environment 0ms, prepare 33ms)
- 
 RUN  v2.1.9 /Users/jacobfreck/Source/cadre

 ✓ tests/log-provider.test.ts (9 tests) 6ms
 ✓ tests/notification-manager.test.ts (21 tests) 6ms
 ✓ tests/config-loader-paths.test.ts (14 tests) 6ms

 Test Files  3 passed (3)
      Tests  44 passed (44)
   Start at  15:55:25
   Duration  371ms (transform 136ms, setup 0ms, collect 173ms, tests 18ms, environment 0ms, prepare 169ms)
- 
> cadre@0.1.0 build
> tsc


> cadre@0.1.0 postbuild
> mkdir -p dist/agents && rm -rf dist/agents/templates && cp -r src/agents/templates dist/agents/templates
