### PR TITLE
feat: define AgentContract with Zod schema validation for structured I/O (#281)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4825,7 +4825,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@cadre/command-diagnostics": "file:../command-diagnostics"
+        "@cadre/command-diagnostics": "file:../command-diagnostics",
+        "zod": "^3.23"
       }
     },
     "packages/agent-runtime-provider-docker": {

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -17,6 +17,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@cadre/command-diagnostics": "file:../command-diagnostics"
+    "@cadre/command-diagnostics": "file:../command-diagnostics",
+    "zod": "^3.23"
   }
 }

--- a/packages/agent-runtime/src/context/types.ts
+++ b/packages/agent-runtime/src/context/types.ts
@@ -202,6 +202,8 @@ export interface AgentContext {
   };
   inputFiles: string[];
   outputPath: string;
+  /** Typed payload — per-phase structured input passed to the agent.
+   *  Use the corresponding phase input schema from AgentContract for type-safe validation. */
   payload?: Record<string, unknown>;
   outputSchema?: Record<string, unknown>;
 }

--- a/packages/agent-runtime/src/contract.ts
+++ b/packages/agent-runtime/src/contract.ts
@@ -1,0 +1,27 @@
+import type { ZodType, ZodTypeDef } from 'zod';
+
+/**
+ * An AgentContract binds a named agent to typed input and output schemas.
+ *
+ * - `TInput` is the type of the payload passed to the agent.
+ * - `TOutput` is the type of the structured output the agent produces.
+ */
+export interface AgentContract<TInput = unknown, TOutput = unknown> {
+  /** Unique agent name. */
+  name: string;
+  /** Zod schema for validating the agent's input payload. */
+  inputSchema: ZodType<TInput, ZodTypeDef, unknown>;
+  /** Zod schema for validating the agent's structured output. */
+  outputSchema: ZodType<TOutput, ZodTypeDef, unknown>;
+}
+
+/**
+ * Helper to create a type-safe AgentContract.
+ */
+export function defineContract<TInput, TOutput>(
+  name: string,
+  inputSchema: ZodType<TInput, ZodTypeDef, unknown>,
+  outputSchema: ZodType<TOutput, ZodTypeDef, unknown>,
+): AgentContract<TInput, TOutput> {
+  return { name, inputSchema, outputSchema };
+}

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -1,6 +1,31 @@
 export * from './budget/token-tracker.js';
 export * from './output/cadre-json.js';
 export * from './context/types.js';
+
+export type { AgentContract } from './contract.js';
+export { defineContract } from './contract.js';
+
+export {
+  analysisResultSchema,
+  scoutReportSchema,
+  reviewIssueSchema,
+  reviewResultSchema,
+  commandResultSchema,
+  integrationReportSchema,
+  prContentSchema,
+  analysisInputSchema,
+  planningInputSchema,
+  implementationInputSchema,
+  integrationInputSchema,
+  prCompositionInputSchema,
+} from './schemas/index.js';
+export type {
+  AnalysisInput,
+  PlanningInput,
+  ImplementationInput,
+  IntegrationInput,
+  PRCompositionInput,
+} from './schemas/index.js';
 export * from './retry/retry.js';
 export * from './backend/backend.js';
 export * from './backend/factory.js';

--- a/packages/agent-runtime/src/output/cadre-json.ts
+++ b/packages/agent-runtime/src/output/cadre-json.ts
@@ -1,3 +1,19 @@
+import type { ZodType } from 'zod';
+
+/**
+ * Like extractCadreJson, but validates the parsed result against a Zod schema.
+ * Returns a typed result on success, or null if no cadre-json block found.
+ * Throws ZodError if the block exists but fails schema validation.
+ */
+export function extractCadreJsonTyped<T>(
+  content: string,
+  schema: ZodType<T>,
+): T | null {
+  const { parsed } = extractCadreJsonWithError(content);
+  if (parsed === null) return null;
+  return schema.parse(parsed);
+}
+
 /**
  * Extract and JSON-parse the first ```cadre-json``` fenced block from content.
  * Returns the parsed value, or null if no such block exists or the JSON is invalid.

--- a/packages/agent-runtime/src/schemas/index.ts
+++ b/packages/agent-runtime/src/schemas/index.ts
@@ -1,0 +1,24 @@
+export {
+  analysisResultSchema,
+  scoutReportSchema,
+  reviewIssueSchema,
+  reviewResultSchema,
+  commandResultSchema,
+  integrationReportSchema,
+  prContentSchema,
+} from './output-schemas.js';
+
+export {
+  analysisInputSchema,
+  planningInputSchema,
+  implementationInputSchema,
+  integrationInputSchema,
+  prCompositionInputSchema,
+} from './input-schemas.js';
+export type {
+  AnalysisInput,
+  PlanningInput,
+  ImplementationInput,
+  IntegrationInput,
+  PRCompositionInput,
+} from './input-schemas.js';

--- a/packages/agent-runtime/src/schemas/input-schemas.ts
+++ b/packages/agent-runtime/src/schemas/input-schemas.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+/** Input payload for the Analysis & Scouting phase (phase 1). */
+export const analysisInputSchema = z.object({
+  issueNumber: z.number(),
+  issueTitle: z.string(),
+  issueBody: z.string(),
+  labels: z.array(z.string()).optional(),
+});
+export type AnalysisInput = z.infer<typeof analysisInputSchema>;
+
+/** Input payload for the Planning phase (phase 2). */
+export const planningInputSchema = z.object({
+  issueNumber: z.number(),
+  analysisPath: z.string(),
+  scoutReportPath: z.string(),
+});
+export type PlanningInput = z.infer<typeof planningInputSchema>;
+
+/** Input payload for the Implementation phase (phase 3). */
+export const implementationInputSchema = z.object({
+  issueNumber: z.number(),
+  sessionId: z.string(),
+  planPath: z.string(),
+});
+export type ImplementationInput = z.infer<typeof implementationInputSchema>;
+
+/** Input payload for the Integration Verification phase (phase 4). */
+export const integrationInputSchema = z.object({
+  issueNumber: z.number(),
+  worktreePath: z.string(),
+  baseCommit: z.string(),
+});
+export type IntegrationInput = z.infer<typeof integrationInputSchema>;
+
+/** Input payload for the PR Composition phase (phase 5). */
+export const prCompositionInputSchema = z.object({
+  issueNumber: z.number(),
+  issueTitle: z.string(),
+  issueBody: z.string(),
+  analysisPath: z.string().optional(),
+  planPath: z.string().optional(),
+});
+export type PRCompositionInput = z.infer<typeof prCompositionInputSchema>;

--- a/packages/agent-runtime/src/schemas/output-schemas.ts
+++ b/packages/agent-runtime/src/schemas/output-schemas.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+/** Analysis result output schema. */
+export const analysisResultSchema = z.object({
+  requirements: z.array(z.string()),
+  changeType: z.enum(['bug-fix', 'feature', 'refactor', 'docs', 'chore']),
+  scope: z.enum(['small', 'medium', 'large']),
+  affectedAreas: z.array(z.string()),
+  ambiguities: z.array(z.string()),
+});
+
+/** Scout report output schema. */
+export const scoutReportSchema = z.object({
+  relevantFiles: z.array(z.object({ path: z.string(), reason: z.string() })),
+  dependencyMap: z.record(z.string(), z.array(z.string())),
+  testFiles: z.array(z.string()),
+  estimatedChanges: z.array(z.object({ path: z.string(), linesEstimate: z.number() })),
+});
+
+/** Review issue schema. */
+export const reviewIssueSchema = z.object({
+  file: z.string(),
+  line: z.number().optional(),
+  severity: z.enum(['error', 'warning', 'suggestion']),
+  description: z.string(),
+});
+
+/** Code review result output schema. */
+export const reviewResultSchema = z.object({
+  verdict: z.enum(['pass', 'needs-fixes']),
+  issues: z.array(reviewIssueSchema),
+  summary: z.string(),
+});
+
+/** Command result schema. */
+export const commandResultSchema = z.object({
+  command: z.string(),
+  exitCode: z.number().nullable(),
+  signal: z.string().nullable().optional(),
+  output: z.string(),
+  pass: z.boolean(),
+});
+
+/** Integration report output schema. */
+export const integrationReportSchema = z.object({
+  buildResult: commandResultSchema,
+  testResult: commandResultSchema,
+  lintResult: commandResultSchema.optional(),
+  overallPass: z.boolean(),
+  baselineFailures: z.array(z.string()).optional(),
+  regressionFailures: z.array(z.string()).optional(),
+});
+
+/** PR content output schema. */
+export const prContentSchema = z.object({
+  title: z.string(),
+  body: z.string(),
+  labels: z.array(z.string()),
+});


### PR DESCRIPTION
## Summary

Defines the `AgentContract<TInput, TOutput>` interface and adds Zod schema validation for structured agent I/O, establishing the core typed contract abstraction for the agent-orchestration framework.

## Changes

### New: `AgentContract` interface
- `AgentContract<TInput, TOutput>` binds a named agent to typed input and output Zod schemas
- `defineContract()` factory helper for type-safe contract creation

### New: Schema-validated JSON extraction
- `extractCadreJsonTyped<T>(content, schema)` — extracts cadre-json block and validates against a Zod schema, returning typed result or null

### New: Input schemas (per-phase)
- `analysisInputSchema` — Analysis & Scouting phase
- `planningInputSchema` — Planning phase
- `implementationInputSchema` — Implementation phase
- `integrationInputSchema` — Integration Verification phase
- `prCompositionInputSchema` — PR Composition phase

### New: Output schemas (canonical Zod schemas in `@cadre/agent-runtime`)
- `analysisResultSchema`, `scoutReportSchema`, `reviewResultSchema`, `integrationReportSchema`, `prContentSchema`, `commandResultSchema`, `reviewIssueSchema`

### Package updates
- Added `zod: ^3.23` as dependency of `@cadre/agent-runtime`
- All new schemas and types exported from package barrel

Closes #281