### PR TITLE
feat: wire provider packages with registry/plugin mechanism (#283)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
       ],
       "dependencies": {
         "@cadre/agent-runtime": "workspace:*",
+        "@cadre/agent-runtime-provider-docker": "workspace:*",
+        "@cadre/agent-runtime-provider-host": "workspace:*",
+        "@cadre/agent-runtime-provider-kata": "workspace:*",
         "@cadre/command-diagnostics": "workspace:*",
         "@cadre/pipeline-engine": "workspace:*",
         "@inquirer/prompts": "^7",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   },
   "dependencies": {
     "@cadre/agent-runtime": "workspace:*",
+    "@cadre/agent-runtime-provider-docker": "workspace:*",
+    "@cadre/agent-runtime-provider-host": "workspace:*",
+    "@cadre/agent-runtime-provider-kata": "workspace:*",
     "@cadre/command-diagnostics": "workspace:*",
     "@cadre/pipeline-engine": "workspace:*",
     "@inquirer/prompts": "^7",

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -48,5 +48,6 @@ export type {
 } from './types.js';
 
 export { ProviderRegistry } from './registry.js';
+export type { ProviderFactory } from './registry.js';
 export { negotiatePolicy, CapabilityMismatchError } from './negotiation.js';
 export type { NegotiationOptions } from './negotiation.js';

--- a/packages/agent-runtime/src/registry.ts
+++ b/packages/agent-runtime/src/registry.ts
@@ -1,23 +1,60 @@
 import type { IsolationProvider } from './types.js';
 
+/** Lazy provider factory — called only when the provider is first resolved. */
+export type ProviderFactory = () => IsolationProvider;
+
 export class ProviderRegistry {
   private readonly providers = new Map<string, IsolationProvider>();
+  private readonly factories = new Map<string, ProviderFactory>();
 
+  /** Register a ready-to-use provider instance. */
   register(provider: IsolationProvider): void {
     this.providers.set(provider.name, provider);
   }
 
+  /** Register a lazy factory that creates a provider on first resolve. */
+  registerFactory(name: string, factory: ProviderFactory): void {
+    this.factories.set(name, factory);
+  }
+
+  /** Check if a provider is registered (either directly or via factory). */
+  has(name: string): boolean {
+    return this.providers.has(name) || this.factories.has(name);
+  }
+
+  /** Return all registered provider names. */
+  list(): string[] {
+    return [...new Set([...this.providers.keys(), ...this.factories.keys()])];
+  }
+
+  /** Remove a provider by name. */
+  unregister(name: string): void {
+    this.providers.delete(name);
+    this.factories.delete(name);
+  }
+
   /**
    * Resolves the active provider using precedence: CLI override > config > default ('host').
+   * Lazy factories are instantiated on first resolve.
    */
   resolve(cliOverride?: string, configProvider?: string): IsolationProvider {
     const name = cliOverride ?? configProvider ?? 'host';
-    const provider = this.providers.get(name);
-    if (!provider) {
-      throw new Error(
-        `Unknown isolation provider "${name}". Registered providers: ${[...this.providers.keys()].join(', ') || '(none)'}.`
-      );
+
+    // Try direct registration first
+    let provider = this.providers.get(name);
+    if (provider) return provider;
+
+    // Try lazy factory
+    const factory = this.factories.get(name);
+    if (factory) {
+      provider = factory();
+      this.providers.set(name, provider);
+      this.factories.delete(name);
+      return provider;
     }
-    return provider;
+
+    throw new Error(
+      `Unknown isolation provider "${name}". Registered providers: ${this.list().join(', ') || '(none)'}.`
+    );
   }
 }

--- a/packages/agent-runtime/src/tests/registry.test.ts
+++ b/packages/agent-runtime/src/tests/registry.test.ts
@@ -87,4 +87,57 @@ describe('ProviderRegistry', () => {
     registry.register(config);
     expect(registry.resolve('sandbox', 'docker')).toBe(cli);
   });
+
+  it('has() returns true for registered providers', () => {
+    registry.register(makeProvider('host'));
+    expect(registry.has('host')).toBe(true);
+    expect(registry.has('docker')).toBe(false);
+  });
+
+  it('has() returns true for factory-registered providers', () => {
+    registry.registerFactory('docker', () => makeProvider('docker'));
+    expect(registry.has('docker')).toBe(true);
+  });
+
+  it('list() returns all registered names', () => {
+    registry.register(makeProvider('host'));
+    registry.registerFactory('docker', () => makeProvider('docker'));
+    expect(registry.list().sort()).toEqual(['docker', 'host']);
+  });
+
+  it('list() deduplicates names present in both maps', () => {
+    registry.register(makeProvider('host'));
+    registry.registerFactory('host', () => makeProvider('host'));
+    expect(registry.list()).toEqual(['host']);
+  });
+
+  it('resolve() instantiates lazy factories on first call', () => {
+    let called = 0;
+    registry.registerFactory('docker', () => { called++; return makeProvider('docker'); });
+    expect(called).toBe(0);
+    registry.resolve('docker');
+    expect(called).toBe(1);
+    // Second resolve uses cached instance
+    registry.resolve('docker');
+    expect(called).toBe(1);
+  });
+
+  it('resolve() prefers direct registration over factory', () => {
+    const direct = makeProvider('docker');
+    registry.register(direct);
+    registry.registerFactory('docker', () => makeProvider('docker'));
+    expect(registry.resolve('docker')).toBe(direct);
+  });
+
+  it('unregister() removes providers', () => {
+    registry.register(makeProvider('host'));
+    registry.unregister('host');
+    expect(registry.has('host')).toBe(false);
+  });
+
+  it('unregister() removes factory-registered providers', () => {
+    registry.registerFactory('docker', () => makeProvider('docker'));
+    registry.unregister('docker');
+    expect(registry.has('docker')).toBe(false);
+  });
 });

--- a/src/platform/provider-loader.ts
+++ b/src/platform/provider-loader.ts
@@ -1,0 +1,44 @@
+import { ProviderRegistry } from '@cadre/agent-runtime';
+import { HostProvider } from '@cadre/agent-runtime-provider-host';
+import { DockerProvider } from '@cadre/agent-runtime-provider-docker';
+import { KataProvider } from '@cadre/agent-runtime-provider-kata';
+
+export interface ProviderLoaderOptions {
+  /** Docker image to use for Docker provider sessions. */
+  dockerImage?: string;
+  /** Worktree path to mount in Docker sessions. */
+  worktreePath?: string;
+}
+
+/**
+ * Creates a ProviderRegistry pre-loaded with all built-in providers.
+ *
+ * - `host` is always registered eagerly (zero-config).
+ * - `docker` and `kata` are registered as lazy factories since they may
+ *   require configuration or external dependencies.
+ */
+export function createProviderRegistry(options: ProviderLoaderOptions = {}): ProviderRegistry {
+  const registry = new ProviderRegistry();
+
+  // Host provider is always available (no config needed)
+  registry.register(new HostProvider());
+
+  // Docker provider — lazy, requires image config
+  registry.registerFactory('docker', () => {
+    if (!options.dockerImage) {
+      throw new Error(
+        'Docker provider requires a "dockerImage" configuration. ' +
+        'Set isolation.dockerImage in cadre.config.json.',
+      );
+    }
+    return new DockerProvider({
+      image: options.dockerImage,
+      worktreePath: options.worktreePath,
+    });
+  });
+
+  // Kata provider — lazy
+  registry.registerFactory('kata', () => new KataProvider());
+
+  return registry;
+}

--- a/tests/provider-loader.test.ts
+++ b/tests/provider-loader.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { createProviderRegistry } from '../src/platform/provider-loader.js';
+
+describe('createProviderRegistry', () => {
+  it('registers host provider by default', () => {
+    const reg = createProviderRegistry();
+    const provider = reg.resolve(undefined, 'host');
+    expect(provider.name).toBe('host');
+  });
+
+  it('has docker and kata factory-registered', () => {
+    const reg = createProviderRegistry({ dockerImage: 'node:20' });
+    expect(reg.has('docker')).toBe(true);
+    expect(reg.has('kata')).toBe(true);
+  });
+
+  it('lists all built-in providers', () => {
+    const reg = createProviderRegistry();
+    expect(reg.list().sort()).toEqual(['docker', 'host', 'kata']);
+  });
+
+  it('resolves docker provider with image config', () => {
+    const reg = createProviderRegistry({ dockerImage: 'node:20' });
+    const provider = reg.resolve('docker');
+    expect(provider.name).toBe('docker');
+  });
+
+  it('throws when resolving docker without image config', () => {
+    const reg = createProviderRegistry();
+    expect(() => reg.resolve('docker')).toThrow('dockerImage');
+  });
+
+  it('resolves kata provider', () => {
+    const reg = createProviderRegistry();
+    const provider = reg.resolve('kata');
+    expect(provider.name).toBe('kata');
+  });
+
+  it('defaults to host when no override or config is given', () => {
+    const reg = createProviderRegistry();
+    const provider = reg.resolve();
+    expect(provider.name).toBe('host');
+  });
+});


### PR DESCRIPTION
## Summary

Wires the three `agent-runtime-provider-*` packages into the root project and extends `ProviderRegistry` with lazy factory registration and auto-discovery, enabling runtime provider resolution from config.

## Changes

### Root `package.json`
- Added `@cadre/agent-runtime-provider-docker`, `@cadre/agent-runtime-provider-host`, `@cadre/agent-runtime-provider-kata` as `workspace:*` dependencies

### `ProviderRegistry` enhancements (`@cadre/agent-runtime`)
- `registerFactory(name, factory)` — lazy provider instantiation (factory called on first `resolve()`)
- `has(name)` — check for registered providers or factories
- `list()` — return all registered provider names
- `unregister(name)` — remove providers
- `resolve()` now checks lazy factories and caches instances

### New: Provider auto-discovery (`src/platform/provider-loader.ts`)
- `createProviderRegistry(options?)` factory creates a pre-configured registry:
  - `host` — registered eagerly (zero-config)
  - `docker` — lazy factory (requires `dockerImage` option)
  - `kata` — lazy factory

### Tests
- 8 new tests for `ProviderRegistry` (factories, has, list, unregister, caching)
- 7 new tests for `createProviderRegistry` (provider resolution, error cases)

Closes #283