### PR TITLE
fix(agent-runtime): improve AgentContract payload typing and extractCadreJson schema support (#281)

### DIFF
--- a/packages/agent-runtime/src/context/types.ts
+++ b/packages/agent-runtime/src/context/types.ts
@@ -183,8 +183,12 @@ export interface IssueDetail {
   linkedPRs: number[];
 }
 
-/** Agent context file structure written before launching an agent. */
-export interface AgentContext {
+/** Agent context file structure written before launching an agent.
+ *
+ *  `TPayload` defaults to `Record<string, unknown>` for backward compatibility.
+ *  Narrow it to a phase-specific input type (e.g. `AgentContext<AnalysisInput>`)
+ *  for compile-time safety on `payload`. */
+export interface AgentContext<TPayload = Record<string, unknown>> {
   agent: string;
   issueNumber: number;
   projectName: string;
@@ -203,7 +207,7 @@ export interface AgentContext {
   inputFiles: string[];
   outputPath: string;
   /** Typed payload — per-phase structured input passed to the agent.
-   *  Use the corresponding phase input schema from AgentContract for type-safe validation. */
-  payload?: Record<string, unknown>;
+   *  When `TPayload` is narrowed, this field is fully typed at compile time. */
+  payload?: TPayload;
   outputSchema?: Record<string, unknown>;
 }

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -20,6 +20,13 @@ export {
   prCompositionInputSchema,
 } from './schemas/index.js';
 export type {
+  AnalysisResultOutput,
+  ScoutReportOutput,
+  ReviewIssueOutput,
+  ReviewResultOutput,
+  CommandResultOutput,
+  IntegrationReportOutput,
+  PRContentOutput,
   AnalysisInput,
   PlanningInput,
   ImplementationInput,

--- a/packages/agent-runtime/src/output/cadre-json.ts
+++ b/packages/agent-runtime/src/output/cadre-json.ts
@@ -4,26 +4,34 @@ import type { ZodType } from 'zod';
  * Like extractCadreJson, but validates the parsed result against a Zod schema.
  * Returns a typed result on success, or null if no cadre-json block found.
  * Throws ZodError if the block exists but fails schema validation.
+ * @deprecated Use `extractCadreJson(content, schema)` instead.
  */
 export function extractCadreJsonTyped<T>(
   content: string,
   schema: ZodType<T>,
 ): T | null {
-  const { parsed } = extractCadreJsonWithError(content);
-  if (parsed === null) return null;
-  return schema.parse(parsed);
+  return extractCadreJson(content, schema);
 }
 
 /**
  * Extract and JSON-parse the first ```cadre-json``` fenced block from content.
  * Returns the parsed value, or null if no such block exists or the JSON is invalid.
  *
+ * When a Zod `schema` is provided the parsed value is validated against it and
+ * the return type narrows to `T | null`.  A `ZodError` is thrown when the block
+ * exists but fails validation.
+ *
  * The closing fence must appear at the start of a line (preceded by a real newline).
  * This prevents false matches against ``` sequences embedded inside JSON string values
  * as escape sequences (e.g. `\n```ts` stored as two chars `\n` + backtick-backtick-backtick).
  */
-export function extractCadreJson(content: string): unknown | null {
-  return extractCadreJsonWithError(content).parsed;
+export function extractCadreJson<T>(content: string, schema: ZodType<T>): T | null;
+export function extractCadreJson(content: string): unknown | null;
+export function extractCadreJson<T>(content: string, schema?: ZodType<T>): T | unknown | null {
+  const { parsed } = extractCadreJsonWithError(content);
+  if (parsed === null) return null;
+  if (schema) return schema.parse(parsed);
+  return parsed;
 }
 
 /**

--- a/packages/agent-runtime/src/schemas/index.ts
+++ b/packages/agent-runtime/src/schemas/index.ts
@@ -7,6 +7,15 @@ export {
   integrationReportSchema,
   prContentSchema,
 } from './output-schemas.js';
+export type {
+  AnalysisResultOutput,
+  ScoutReportOutput,
+  ReviewIssueOutput,
+  ReviewResultOutput,
+  CommandResultOutput,
+  IntegrationReportOutput,
+  PRContentOutput,
+} from './output-schemas.js';
 
 export {
   analysisInputSchema,

--- a/packages/agent-runtime/src/schemas/output-schemas.ts
+++ b/packages/agent-runtime/src/schemas/output-schemas.ts
@@ -57,3 +57,16 @@ export const prContentSchema = z.object({
   body: z.string(),
   labels: z.array(z.string()),
 });
+
+/* ------------------------------------------------------------------ */
+/*  Inferred types — keep in sync with hand-written interfaces in      */
+/*  context/types.ts.  Prefer these for new code; they are the         */
+/*  single-source-of-truth derived from the Zod schemas above.         */
+/* ------------------------------------------------------------------ */
+export type AnalysisResultOutput  = z.infer<typeof analysisResultSchema>;
+export type ScoutReportOutput     = z.infer<typeof scoutReportSchema>;
+export type ReviewIssueOutput     = z.infer<typeof reviewIssueSchema>;
+export type ReviewResultOutput    = z.infer<typeof reviewResultSchema>;
+export type CommandResultOutput   = z.infer<typeof commandResultSchema>;
+export type IntegrationReportOutput = z.infer<typeof integrationReportSchema>;
+export type PRContentOutput       = z.infer<typeof prContentSchema>;


### PR DESCRIPTION
# Fix remaining gaps from Issue #281 — AgentContract with Zod validation schemas

## Problem

The original #281 implementation had three gaps identified during code review:

1. **`AgentContext.payload` remained `Record<string, unknown>`** — no compile-time type safety for per-phase payloads
2. **`extractCadreJson()` didn't accept an optional schema parameter** — a separate `extractCadreJsonTyped()` was added instead, diverging from the spec
3. **Output schema inferred types not exported** — input schemas exported `z.infer` types but output schemas didn't, creating drift risk between Zod schemas and hand-written interfaces

## Changes

### 1. Generic `AgentContext<TPayload>` (`context/types.ts`)

`AgentContext` is now `AgentContext<TPayload = Record<string, unknown>>`, so:
- `AgentContext` (no type param) is **fully backward-compatible** — defaults to the old `Record<string, unknown>` behavior
- Code that knows its phase can narrow: `AgentContext<AnalysisInput>` gives compile-time safety on `payload`

### 2. `extractCadreJson()` optional schema overload (`output/cadre-json.ts`)

Added TypeScript overloads to the existing `extractCadreJson`:
```ts
extractCadreJson(content: string): unknown | null;            // existing behavior
extractCadreJson<T>(content: string, schema: ZodType<T>): T | null;  // new: validated
```

`extractCadreJsonTyped` is preserved (calls through to the new overload) and marked `@deprecated`.

### 3. Export output schema inferred types (`schemas/output-schemas.ts`)

Added `z.infer` type exports for all output schemas:
- `AnalysisResultOutput`, `ScoutReportOutput`, `ReviewResultOutput`, `IntegrationReportOutput`, `PRContentOutput`, etc.

These are re-exported through `schemas/index.ts` → `index.ts`.

## Verification

- `npm run build` ✅ — compiles cleanly
- `npx vitest run` ✅ — 176 test files, 3515 tests all pass
- No regressions — all changes are backward-compatible (default type params, function overloads, additive exports)

Closes #281