### PR TITLE
feat(packages): harden @cadre/pipeline-engine workspace package (#266)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -522,6 +522,8 @@ graph TD
 
 `PHASE_MANIFEST` in `src/core/phase-registry.ts` is the **single source of truth** for all pipeline phase metadata. Rather than scattering phase registrations, gate assignments, and review-response membership across multiple files, every piece of per-phase configuration lives in one typed array entry.
 
+The shared phase primitives are consumed from the workspace package boundary, `@cadre/pipeline-engine`. Runtime modules should import from `@cadre/pipeline-engine` (or CADRE core wrappers such as `src/core/phase-registry.ts`) rather than `packages/pipeline-engine/src/*` paths.
+
 ### `PhaseManifestEntry` Fields
 
 | Field | Type | Purpose |

--- a/tests/packages/pipeline-engine/index.test.ts
+++ b/tests/packages/pipeline-engine/index.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as pipelineEngine from '@cadre/pipeline-engine';
+import { PhaseRegistry as CorePhaseRegistry, buildRegistry as buildCoreRegistry } from '../../../src/core/phase-registry.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('@cadre/pipeline-engine barrel exports', () => {
+  it('should export PhaseRegistry', () => {
+    expect(typeof pipelineEngine.PhaseRegistry).toBe('function');
+  });
+
+  it('should export CheckpointManager and FleetCheckpointManager', () => {
+    expect(typeof pipelineEngine.CheckpointManager).toBe('function');
+    expect(typeof pipelineEngine.FleetCheckpointManager).toBe('function');
+  });
+
+  it('should export IssueDag', () => {
+    expect(typeof pipelineEngine.IssueDag).toBe('function');
+  });
+
+  it('should export helper functions for phase manifests', () => {
+    expect(typeof pipelineEngine.getPhaseSubset).toBe('function');
+    expect(typeof pipelineEngine.getPhase).toBe('function');
+    expect(typeof pipelineEngine.getPhaseCount).toBe('function');
+    expect(typeof pipelineEngine.isLastPhase).toBe('function');
+    expect(typeof pipelineEngine.buildRegistry).toBe('function');
+    expect(typeof pipelineEngine.buildGateMap).toBe('function');
+  });
+});
+
+describe('pipeline-engine runtime integration path', () => {
+  it('core PhaseRegistry re-export should match package export identity', () => {
+    expect(CorePhaseRegistry).toBe(pipelineEngine.PhaseRegistry);
+  });
+
+  it('core buildRegistry should construct package PhaseRegistry instances', () => {
+    const registry = buildCoreRegistry();
+    expect(registry).toBeInstanceOf(pipelineEngine.PhaseRegistry);
+  });
+
+  it('core wrappers should avoid packages/pipeline-engine/src path leaks', () => {
+    const coreFiles = [
+      '../../../src/core/phase-executor.ts',
+      '../../../src/core/phase-gate.ts',
+      '../../../src/core/phase-registry.ts',
+      '../../../src/core/issue-dag.ts',
+      '../../../src/core/checkpoint.ts',
+      '../../../src/core/progress.ts',
+    ];
+
+    for (const relativePath of coreFiles) {
+      const content = readFileSync(resolve(__dirname, relativePath), 'utf8');
+      expect(content).not.toContain('packages/pipeline-engine/src/');
+    }
+  });
+});


### PR DESCRIPTION
Implements #266.

- Adds/solidifies `@cadre/pipeline-engine` package boundary
- Migrates consumers to package import path
- Aligns package usage with workspace conventions
- Updates tests/docs for package API usage