### PR TITLE
feat(flow): add declarative flow graph DSL and runner (#293) [resolved]

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,63 @@ Each issue runs in its own git worktree with full isolation. Multiple issues are
 5. **Git operations are the runtime's job** — Agents write files; the runtime handles git.
 6. **MCP-native GitHub access** — GitHub interactions use the MCP protocol, not CLI wrappers.
 
+## Flow DSL Package (`@cadre/flow`)
+
+Cadre now includes a framework package for declarative pipeline orchestration graphs.
+This package is additive and does not replace the existing app orchestrators yet.
+See [docs/flow-dsl.md](docs/flow-dsl.md) for a complete reference.
+
+```ts
+import {
+  FlowRunner,
+  defineFlow,
+  step,
+  gate,
+  loop,
+  parallel,
+  conditional,
+  fromStep,
+  fromContext,
+} from '@cadre/flow';
+
+const flow = defineFlow('example', [
+  step({
+    id: 'seed',
+    input: fromContext('start'),
+    run: (_ctx, input) => Number(input),
+  }),
+  gate({
+    id: 'non-negative',
+    input: fromStep('seed'),
+    evaluate: (_ctx, value) => Number(value) >= 0,
+  }),
+  loop({
+    id: 'retry-loop',
+    maxIterations: 3,
+    do: [
+      parallel({
+        id: 'fan-out',
+        concurrency: 2,
+        branches: {
+          a: [step({ id: 'a-task', run: () => 'a' })],
+          b: [step({ id: 'b-task', run: () => 'b' })],
+        },
+      }),
+      conditional({
+        id: 'exit-check',
+        when: (ctx) => Boolean(ctx.getStepOutput('a-task')),
+        then: [step({ id: 'done', run: () => true })],
+        else: [step({ id: 'retry', run: () => false })],
+      }),
+    ],
+    until: (ctx) => Boolean(ctx.getStepOutput('done')),
+  }),
+]);
+
+const runner = new FlowRunner();
+await runner.run(flow, { start: 0 });
+```
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,7 @@ Cadre now publishes generic framework primitives as workspace packages:
 - `@cadre/observability`: logger, typed runtime events, fleet event bus, and cost estimator
 - `@cadre/execution`: serial/parallel executors, session queue/task queue, retry facade
 - `@cadre/validation`: pre-run validation suite/types and disk validator
+- `@cadre/flow`: declarative flow/graph DSL and `FlowRunner` with loops, conditionals, and parallel fan-out/fan-in
 
 Cadre-specific orchestration validators remain under `src/validation` and consume `@cadre/validation` types.
 

--- a/docs/flow-dsl.md
+++ b/docs/flow-dsl.md
@@ -1,0 +1,127 @@
+# `@cadre/flow` DSL and Runner
+
+`@cadre/flow` provides a declarative flow graph DSL and a generic execution engine (`FlowRunner`) for framework-level orchestration.
+
+## Core DSL
+
+- `defineFlow(id, nodes, description?)`
+- `step({ id, run, input?, dependsOn? })`
+- `gate({ id, evaluate, input?, dependsOn? })`
+- `conditional({ id, when, then, else?, input?, dependsOn? })`
+- `loop({ id, do, maxIterations, while?, until?, dependsOn? })`
+- `parallel({ id, branches, concurrency?, dependsOn? })`
+
+## Data Routing References
+
+- `fromStep(stepId, path?)`
+- `fromSteps(stepIds, path?)`
+- `fromContext(path?)`
+
+Path syntax is dot notation (`a.b.c`) and supports array indexes (`items.0.id`).
+
+## Example
+
+```ts
+import {
+  FlowRunner,
+  defineFlow,
+  step,
+  gate,
+  conditional,
+  loop,
+  parallel,
+  fromStep,
+  fromSteps,
+  fromContext,
+} from '@cadre/flow';
+
+type Context = {
+  attempts: number;
+  payload: { issueNumber: number; labels: string[] };
+};
+
+const flow = defineFlow<Context>('issue-pipeline', [
+  step({
+    id: 'extract-issue',
+    input: fromContext('payload.issueNumber'),
+    run: (_ctx, issueNumber) => ({ issueNumber, ready: true }),
+  }),
+  gate({
+    id: 'ready-gate',
+    input: fromStep('extract-issue.ready'),
+    evaluate: (_ctx, ready) => Boolean(ready),
+  }),
+  parallel({
+    id: 'fan-out',
+    concurrency: 2,
+    branches: {
+      files: [
+        step({
+          id: 'scan-files',
+          run: () => ['src/index.ts', 'src/core/runtime.ts'],
+        }),
+      ],
+      deps: [
+        step({
+          id: 'scan-deps',
+          run: () => ['@cadre/observability', '@cadre/execution'],
+        }),
+      ],
+    },
+  }),
+  loop({
+    id: 'retry-loop',
+    maxIterations: 3,
+    do: [
+      conditional({
+        id: 'retry-check',
+        when: (ctx) => Number(ctx.context.attempts) > 0,
+        then: [
+          step({
+            id: 'stabilize',
+            input: fromSteps(['scan-files', 'scan-deps']),
+            run: (ctx, refs) => {
+              ctx.context.attempts -= 1;
+              return refs;
+            },
+          }),
+        ],
+        else: [
+          step({
+            id: 'done',
+            run: () => true,
+          }),
+        ],
+      }),
+    ],
+    until: (ctx) => Boolean(ctx.getStepOutput('done')),
+  }),
+]);
+
+const runner = new FlowRunner<Context>({ concurrency: 2 });
+await runner.run(flow, {
+  attempts: 2,
+  payload: { issueNumber: 293, labels: ['flow', 'framework'] },
+});
+```
+
+## Checkpoint Integration
+
+`FlowRunner` accepts a `checkpoint` adapter via options. The adapter can persist snapshots after node completion and at terminal states.
+
+```ts
+import type { FlowCheckpointAdapter } from '@cadre/flow';
+
+const checkpoint: FlowCheckpointAdapter = {
+  async load(flowId) {
+    return null;
+  },
+  async save(snapshot) {
+    // persist snapshot
+  },
+};
+
+const runner = new FlowRunner({ checkpoint });
+```
+
+This package is framework-only for now. Cadre app orchestration migration is tracked separately.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@cadre/agent-runtime-provider-kata": "workspace:*",
         "@cadre/command-diagnostics": "workspace:*",
         "@cadre/execution": "workspace:*",
+        "@cadre/flow": "workspace:*",
         "@cadre/notifications": "workspace:*",
         "@cadre/observability": "workspace:*",
         "@cadre/pipeline-engine": "workspace:*",
@@ -139,6 +140,10 @@
     },
     "node_modules/@cadre/execution": {
       "resolved": "packages/execution",
+      "link": true
+    },
+    "node_modules/@cadre/flow": {
+      "resolved": "packages/flow",
       "link": true
     },
     "node_modules/@cadre/notifications": {
@@ -4892,6 +4897,14 @@
       "dependencies": {
         "@cadre/agent-runtime": "*",
         "@cadre/observability": "*",
+        "p-limit": "^6"
+      }
+    },
+    "packages/flow": {
+      "name": "@cadre/flow",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
         "p-limit": "^6"
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:e2e": "CADRE_E2E=1 vitest run tests/e2e-*.test.ts"
   },
   "dependencies": {
+    "@cadre/flow": "workspace:*",
     "@cadre/agent-runtime": "workspace:*",
     "@cadre/agent-runtime-provider-docker": "workspace:*",
     "@cadre/agent-runtime-provider-host": "workspace:*",

--- a/packages/flow/package.json
+++ b/packages/flow/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@cadre/flow",
+  "version": "0.1.0",
+  "description": "Declarative flow graph DSL and runner for CADRE",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "dependencies": {
+    "p-limit": "^6"
+  },
+  "scripts": {
+    "build": "tsc"
+  }
+}

--- a/packages/flow/src/dsl.ts
+++ b/packages/flow/src/dsl.ts
@@ -1,0 +1,47 @@
+import type {
+  FlowConditionalNode,
+  FlowDefinition,
+  FlowGateNode,
+  FlowLoopNode,
+  FlowNode,
+  FlowParallelNode,
+  FlowStepNode,
+} from './types.js';
+
+export function defineFlow<TContext = Record<string, unknown>>(
+  id: string,
+  nodes: FlowNode<TContext>[],
+  description?: string,
+): FlowDefinition<TContext> {
+  return { id, nodes, description };
+}
+
+export function step<TContext = Record<string, unknown>>(
+  config: Omit<FlowStepNode<TContext>, 'kind'>,
+): FlowStepNode<TContext> {
+  return { kind: 'step', ...config };
+}
+
+export function gate<TContext = Record<string, unknown>>(
+  config: Omit<FlowGateNode<TContext>, 'kind'>,
+): FlowGateNode<TContext> {
+  return { kind: 'gate', ...config };
+}
+
+export function conditional<TContext = Record<string, unknown>>(
+  config: Omit<FlowConditionalNode<TContext>, 'kind'>,
+): FlowConditionalNode<TContext> {
+  return { kind: 'conditional', ...config };
+}
+
+export function loop<TContext = Record<string, unknown>>(
+  config: Omit<FlowLoopNode<TContext>, 'kind'>,
+): FlowLoopNode<TContext> {
+  return { kind: 'loop', ...config };
+}
+
+export function parallel<TContext = Record<string, unknown>>(
+  config: Omit<FlowParallelNode<TContext>, 'kind'>,
+): FlowParallelNode<TContext> {
+  return { kind: 'parallel', ...config };
+}

--- a/packages/flow/src/index.ts
+++ b/packages/flow/src/index.ts
@@ -1,0 +1,29 @@
+export {
+  defineFlow,
+  step,
+  gate,
+  conditional,
+  loop,
+  parallel,
+} from './dsl.js';
+
+export { fromStep, fromSteps, fromContext } from './refs.js';
+export { FlowRunner } from './runner.js';
+
+export type {
+  DataRef,
+  FlowNode,
+  FlowStepNode,
+  FlowGateNode,
+  FlowLoopNode,
+  FlowParallelNode,
+  FlowConditionalNode,
+  FlowDefinition,
+  FlowExecutionContext,
+  FlowRunResult,
+  FlowRunnerOptions,
+  FlowCheckpointAdapter,
+  FlowCheckpointSnapshot,
+} from './types.js';
+
+export { FlowExecutionError, FlowCycleError } from './types.js';

--- a/packages/flow/src/refs.ts
+++ b/packages/flow/src/refs.ts
@@ -1,0 +1,13 @@
+import type { DataRef } from './types.js';
+
+export function fromStep(stepId: string, path?: string): DataRef {
+  return { kind: 'fromStep', stepId, path };
+}
+
+export function fromSteps(stepIds: string[], path?: string): DataRef {
+  return { kind: 'fromSteps', stepIds, path };
+}
+
+export function fromContext(path?: string): DataRef {
+  return { kind: 'fromContext', path };
+}

--- a/packages/flow/src/runner.ts
+++ b/packages/flow/src/runner.ts
@@ -1,0 +1,358 @@
+import pLimit from 'p-limit';
+import {
+  FlowCycleError,
+  FlowExecutionError,
+  type DataRef,
+  type FlowCheckpointSnapshot,
+  type FlowDefinition,
+  type FlowExecutionContext,
+  type FlowNode,
+  type FlowRunResult,
+  type FlowRunnerOptions,
+  type InputValue,
+} from './types.js';
+
+interface RunnerState<TContext> {
+  flow: FlowDefinition<TContext>;
+  context: TContext;
+  outputs: Record<string, unknown>;
+  executionOutputs: Record<string, unknown>;
+  completedExecutionIds: Set<string>;
+  hadError: boolean;
+  lastError?: FlowExecutionError;
+  startedAt: string;
+  options: Required<Pick<FlowRunnerOptions<TContext>, 'concurrency' | 'continueOnError'>> & Pick<FlowRunnerOptions<TContext>, 'checkpoint'>;
+}
+
+export class FlowRunner<TContext = Record<string, unknown>> {
+  constructor(private readonly defaults: FlowRunnerOptions<TContext> = {}) {}
+
+  async run(flow: FlowDefinition<TContext>, context: TContext, options: FlowRunnerOptions<TContext> = {}): Promise<FlowRunResult<TContext>> {
+    const merged: RunnerState<TContext>['options'] = {
+      concurrency: options.concurrency ?? this.defaults.concurrency ?? Number.POSITIVE_INFINITY,
+      continueOnError: options.continueOnError ?? this.defaults.continueOnError ?? false,
+      checkpoint: options.checkpoint ?? this.defaults.checkpoint,
+    };
+
+    const startedAt = new Date().toISOString();
+    const state: RunnerState<TContext> = {
+      flow,
+      context,
+      outputs: {},
+      executionOutputs: {},
+      completedExecutionIds: new Set(),
+      hadError: false,
+      startedAt,
+      options: merged,
+    };
+
+    await this.loadCheckpoint(state);
+
+    try {
+      await this.executeNodeList(state, flow.nodes, [flow.id]);
+      const finishedAt = new Date().toISOString();
+      const status = state.hadError ? 'failed' : 'completed';
+      await this.persistCheckpoint(state, status, state.lastError?.message);
+      return {
+        flowId: flow.id,
+        status,
+        outputs: { ...state.outputs },
+        executionOutputs: { ...state.executionOutputs },
+        context: state.context,
+        startedAt: state.startedAt,
+        finishedAt,
+        completedExecutionIds: [...state.completedExecutionIds],
+        error: state.lastError,
+      };
+    } catch (error) {
+      const wrapped = this.wrapError(flow.id, 'flow', flow.id, error);
+      await this.persistCheckpoint(state, 'failed', wrapped.message);
+      if (!merged.continueOnError) {
+        throw wrapped;
+      }
+      return {
+        flowId: flow.id,
+        status: 'failed',
+        outputs: { ...state.outputs },
+        executionOutputs: { ...state.executionOutputs },
+        context: state.context,
+        startedAt: state.startedAt,
+        finishedAt: new Date().toISOString(),
+        completedExecutionIds: [...state.completedExecutionIds],
+        error: wrapped,
+      };
+    }
+  }
+
+  private async loadCheckpoint(state: RunnerState<TContext>): Promise<void> {
+    if (!state.options.checkpoint) return;
+    const snapshot = await state.options.checkpoint.load(state.flow.id);
+    if (!snapshot) return;
+    state.outputs = { ...snapshot.outputs };
+    state.executionOutputs = { ...snapshot.executionOutputs };
+    for (const executionId of snapshot.completedExecutionIds) {
+      state.completedExecutionIds.add(executionId);
+    }
+  }
+
+  private async persistCheckpoint(
+    state: RunnerState<TContext>,
+    status: 'completed' | 'failed',
+    error?: string,
+  ): Promise<void> {
+    if (!state.options.checkpoint) return;
+    const snapshot: FlowCheckpointSnapshot<TContext> = {
+      flowId: state.flow.id,
+      status,
+      startedAt: state.startedAt,
+      updatedAt: new Date().toISOString(),
+      completedExecutionIds: [...state.completedExecutionIds],
+      outputs: { ...state.outputs },
+      executionOutputs: { ...state.executionOutputs },
+      context: state.context,
+      error,
+    };
+    await state.options.checkpoint.save(snapshot);
+  }
+
+  private buildExecutionContext(state: RunnerState<TContext>, executionPath: string[]): FlowExecutionContext<TContext> {
+    return {
+      flowId: state.flow.id,
+      executionPath,
+      context: state.context,
+      outputs: state.outputs,
+      executionOutputs: state.executionOutputs,
+      getStepOutput: <T = unknown>(stepId: string): T | undefined => state.outputs[stepId] as T | undefined,
+      getExecutionOutput: <T = unknown>(executionId: string): T | undefined => state.executionOutputs[executionId] as T | undefined,
+    };
+  }
+
+  private async executeNodeList(
+    state: RunnerState<TContext>,
+    nodes: FlowNode<TContext>[],
+    executionPath: string[],
+  ): Promise<Record<string, unknown>> {
+    this.validateNodeIds(nodes, executionPath.join('/'));
+
+    const pending = [...nodes];
+    const localResolved = new Set<string>();
+    const localOutputs: Record<string, unknown> = {};
+
+    while (pending.length > 0) {
+      const ready = pending.filter((node) => (node.dependsOn ?? []).every((dependency) => localResolved.has(dependency)));
+
+      if (ready.length === 0) {
+        const unresolved = pending.map((node) => node.id).join(', ');
+        throw new FlowCycleError(`No executable nodes remain in scope ${executionPath.join('/')} (pending: ${unresolved})`);
+      }
+
+      for (const node of ready) {
+        const executionId = `${executionPath.join('/')}/${node.id}`;
+        if (state.completedExecutionIds.has(executionId)) {
+          localResolved.add(node.id);
+          localOutputs[node.id] = state.executionOutputs[executionId];
+          const index = pending.findIndex((candidate) => candidate.id === node.id);
+          pending.splice(index, 1);
+          continue;
+        }
+
+        try {
+          const output = await this.executeNode(state, node, [...executionPath, node.id], executionId);
+          state.outputs[node.id] = output;
+          state.executionOutputs[executionId] = output;
+          state.completedExecutionIds.add(executionId);
+          localOutputs[node.id] = output;
+          localResolved.add(node.id);
+          await this.persistCheckpoint(state, 'completed');
+        } catch (error) {
+          const wrapped = this.wrapError(state.flow.id, node.id, executionId, error);
+          state.hadError = true;
+          state.lastError = wrapped;
+          localResolved.add(node.id);
+          if (!state.options.continueOnError) {
+            throw wrapped;
+          }
+        }
+
+        const index = pending.findIndex((candidate) => candidate.id === node.id);
+        pending.splice(index, 1);
+      }
+    }
+
+    return localOutputs;
+  }
+
+  private async executeNode(
+    state: RunnerState<TContext>,
+    node: FlowNode<TContext>,
+    executionPath: string[],
+    executionId: string,
+  ): Promise<unknown> {
+    const context = this.buildExecutionContext(state, executionPath);
+    const resolvedInput = this.resolveInput(node.input, context);
+
+    switch (node.kind) {
+      case 'step': {
+        return node.run(context, resolvedInput);
+      }
+      case 'gate': {
+        const passed = await node.evaluate(context, resolvedInput);
+        if (!passed) {
+          throw new Error(`Gate ${node.id} failed`);
+        }
+        return { passed: true };
+      }
+      case 'conditional': {
+        const matches = await node.when(context, resolvedInput);
+        const branch = matches ? node.then : (node.else ?? []);
+        const branchKey = matches ? 'then' : 'else';
+        const branchOutputs = await this.executeNodeList(state, branch, [...executionPath, branchKey]);
+        return { branch: branchKey, outputs: branchOutputs };
+      }
+      case 'loop': {
+        const outputs: unknown[] = [];
+        let iterations = 0;
+
+        while (iterations < node.maxIterations) {
+          const loopCtx = this.buildExecutionContext(state, [...executionPath, `iteration-${iterations + 1}`]);
+          if (node.while) {
+            const shouldContinue = await node.while(loopCtx);
+            if (!shouldContinue) break;
+          }
+
+          const iterationOutputs = await this.executeNodeList(
+            state,
+            node.do,
+            [...executionPath, `iteration-${iterations + 1}`],
+          );
+          outputs.push(iterationOutputs);
+          iterations += 1;
+
+          if (node.until) {
+            const done = await node.until(this.buildExecutionContext(state, [...executionPath, `iteration-${iterations}`]));
+            if (done) {
+              break;
+            }
+          }
+        }
+
+        return { iterations, outputs };
+      }
+      case 'parallel': {
+        const entries = Object.entries(node.branches);
+        const branchResults: Record<string, unknown> = {};
+        const limit = pLimit(Math.max(1, Math.floor(node.concurrency ?? state.options.concurrency)));
+
+        await Promise.all(
+          entries.map(([branchId, branchNodes]) =>
+            limit(async () => {
+              const result = await this.executeNodeList(state, branchNodes, [...executionPath, branchId]);
+              branchResults[branchId] = result;
+            }),
+          ),
+        );
+
+        return branchResults;
+      }
+      default: {
+        const exhaustive: never = node;
+        throw new Error(`Unsupported node kind ${(exhaustive as { kind?: string }).kind ?? 'unknown'}`);
+      }
+    }
+  }
+
+  private resolveInput(value: InputValue | undefined, context: FlowExecutionContext<TContext>): unknown {
+    if (value === undefined) return undefined;
+    if (value === null) return null;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      return value;
+    }
+
+    if (Array.isArray(value)) {
+      return value.map((entry) => this.resolveInput(entry, context));
+    }
+
+    if (this.isDataRef(value)) {
+      return this.resolveDataRef(value, context);
+    }
+
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      out[key] = this.resolveInput(entry as InputValue, context);
+    }
+    return out;
+  }
+
+  private resolveDataRef(ref: DataRef, context: FlowExecutionContext<TContext>): unknown {
+    switch (ref.kind) {
+      case 'fromStep': {
+        return this.getAtPath(context.getStepOutput(ref.stepId), ref.path);
+      }
+      case 'fromSteps': {
+        const out: Record<string, unknown> = {};
+        for (const stepId of ref.stepIds) {
+          out[stepId] = this.getAtPath(context.getStepOutput(stepId), ref.path);
+        }
+        return out;
+      }
+      case 'fromContext': {
+        const source = context.context as unknown;
+        return this.getAtPath(source, ref.path);
+      }
+      default: {
+        const exhaustive: never = ref;
+        throw new Error(`Unsupported data ref ${(exhaustive as { kind?: string }).kind ?? 'unknown'}`);
+      }
+    }
+  }
+
+  private getAtPath(source: unknown, path?: string): unknown {
+    if (!path || path.trim().length === 0) {
+      return source;
+    }
+
+    const parts = path.split('.').filter(Boolean);
+    let cursor: unknown = source;
+    for (const part of parts) {
+      if (cursor === null || cursor === undefined) {
+        return undefined;
+      }
+      if (Array.isArray(cursor)) {
+        const index = Number(part);
+        cursor = Number.isNaN(index) ? undefined : cursor[index];
+      } else if (typeof cursor === 'object') {
+        cursor = (cursor as Record<string, unknown>)[part];
+      } else {
+        return undefined;
+      }
+    }
+
+    return cursor;
+  }
+
+  private isDataRef(value: unknown): value is DataRef {
+    if (!value || typeof value !== 'object') {
+      return false;
+    }
+    const candidate = value as { kind?: string };
+    return candidate.kind === 'fromStep' || candidate.kind === 'fromSteps' || candidate.kind === 'fromContext';
+  }
+
+  private validateNodeIds(nodes: FlowNode<TContext>[], scope: string): void {
+    const seen = new Set<string>();
+    for (const node of nodes) {
+      if (seen.has(node.id)) {
+        throw new Error(`Duplicate node id '${node.id}' in scope ${scope}`);
+      }
+      seen.add(node.id);
+    }
+  }
+
+  private wrapError(flowId: string, nodeId: string, executionId: string, error: unknown): FlowExecutionError {
+    if (error instanceof FlowExecutionError) {
+      return error;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return new FlowExecutionError(message, flowId, nodeId, executionId, error);
+  }
+}

--- a/packages/flow/src/types.ts
+++ b/packages/flow/src/types.ts
@@ -1,0 +1,139 @@
+export type MaybePromise<T> = T | Promise<T>;
+
+export type DataRef =
+  | { kind: 'fromStep'; stepId: string; path?: string }
+  | { kind: 'fromSteps'; stepIds: string[]; path?: string }
+  | { kind: 'fromContext'; path?: string };
+
+export type InputValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | DataRef
+  | InputValue[]
+  | { [key: string]: InputValue };
+
+export interface FlowExecutionContext<TContext = Record<string, unknown>> {
+  readonly flowId: string;
+  readonly executionPath: readonly string[];
+  readonly context: TContext;
+  readonly outputs: Readonly<Record<string, unknown>>;
+  readonly executionOutputs: Readonly<Record<string, unknown>>;
+  getStepOutput<T = unknown>(stepId: string): T | undefined;
+  getExecutionOutput<T = unknown>(executionId: string): T | undefined;
+}
+
+export interface FlowNodeBase<TContext = Record<string, unknown>> {
+  id: string;
+  dependsOn?: string[];
+  input?: InputValue;
+  checkpoint?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface FlowStepNode<TContext = Record<string, unknown>> extends FlowNodeBase<TContext> {
+  kind: 'step';
+  run: (ctx: FlowExecutionContext<TContext>, input: unknown) => MaybePromise<unknown>;
+}
+
+export interface FlowGateNode<TContext = Record<string, unknown>> extends FlowNodeBase<TContext> {
+  kind: 'gate';
+  evaluate: (ctx: FlowExecutionContext<TContext>, input: unknown) => MaybePromise<boolean>;
+}
+
+export interface FlowConditionalNode<TContext = Record<string, unknown>> extends FlowNodeBase<TContext> {
+  kind: 'conditional';
+  when: (ctx: FlowExecutionContext<TContext>, input: unknown) => MaybePromise<boolean>;
+  then: FlowNode<TContext>[];
+  else?: FlowNode<TContext>[];
+}
+
+export interface FlowLoopNode<TContext = Record<string, unknown>> extends FlowNodeBase<TContext> {
+  kind: 'loop';
+  do: FlowNode<TContext>[];
+  maxIterations: number;
+  while?: (ctx: FlowExecutionContext<TContext>) => MaybePromise<boolean>;
+  until?: (ctx: FlowExecutionContext<TContext>) => MaybePromise<boolean>;
+}
+
+export interface FlowParallelNode<TContext = Record<string, unknown>> extends FlowNodeBase<TContext> {
+  kind: 'parallel';
+  branches: Record<string, FlowNode<TContext>[]>;
+  concurrency?: number;
+}
+
+export type FlowNode<TContext = Record<string, unknown>> =
+  | FlowStepNode<TContext>
+  | FlowGateNode<TContext>
+  | FlowConditionalNode<TContext>
+  | FlowLoopNode<TContext>
+  | FlowParallelNode<TContext>;
+
+export interface FlowDefinition<TContext = Record<string, unknown>> {
+  id: string;
+  description?: string;
+  nodes: FlowNode<TContext>[];
+}
+
+export type FlowRunStatus = 'completed' | 'failed';
+
+export interface FlowCheckpointSnapshot<TContext = Record<string, unknown>> {
+  flowId: string;
+  status: FlowRunStatus;
+  startedAt: string;
+  updatedAt: string;
+  completedExecutionIds: string[];
+  outputs: Record<string, unknown>;
+  executionOutputs: Record<string, unknown>;
+  context?: TContext;
+  error?: string;
+}
+
+export interface FlowCheckpointAdapter<TContext = Record<string, unknown>> {
+  load(flowId: string): MaybePromise<FlowCheckpointSnapshot<TContext> | null>;
+  save(snapshot: FlowCheckpointSnapshot<TContext>): MaybePromise<void>;
+}
+
+export interface FlowRunnerOptions<TContext = Record<string, unknown>> {
+  concurrency?: number;
+  continueOnError?: boolean;
+  checkpoint?: FlowCheckpointAdapter<TContext>;
+}
+
+export interface FlowRunResult<TContext = Record<string, unknown>> {
+  flowId: string;
+  status: FlowRunStatus;
+  outputs: Record<string, unknown>;
+  executionOutputs: Record<string, unknown>;
+  context: TContext;
+  startedAt: string;
+  finishedAt: string;
+  completedExecutionIds: string[];
+  error?: FlowExecutionError;
+}
+
+export class FlowExecutionError extends Error {
+  readonly flowId: string;
+  readonly nodeId: string;
+  readonly executionId: string;
+
+  constructor(message: string, flowId: string, nodeId: string, executionId: string, cause?: unknown) {
+    super(message);
+    this.name = 'FlowExecutionError';
+    this.flowId = flowId;
+    this.nodeId = nodeId;
+    this.executionId = executionId;
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+export class FlowCycleError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FlowCycleError';
+  }
+}

--- a/tests/flow-runner.test.ts
+++ b/tests/flow-runner.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  FlowRunner,
+  conditional,
+  defineFlow,
+  fromContext,
+  fromStep,
+  fromSteps,
+  gate,
+  loop,
+  parallel,
+  step,
+  type FlowCheckpointAdapter,
+  type FlowCheckpointSnapshot,
+} from '@cadre/flow';
+
+describe('@cadre/flow FlowRunner', () => {
+  it('runs a linear flow with data routing from context and prior steps', async () => {
+    const runner = new FlowRunner<{ numbers: number[] }>({});
+
+    const flow = defineFlow(
+      'linear',
+      [
+        step({
+          id: 'sum',
+          input: fromContext('numbers'),
+          run: (_ctx, input) => (input as number[]).reduce((total, n) => total + n, 0),
+        }),
+        gate({
+          id: 'positive-check',
+          input: fromStep('sum'),
+          evaluate: (_ctx, input) => Number(input) > 0,
+        }),
+        step({
+          id: 'double',
+          input: { value: fromStep('sum') },
+          run: (_ctx, input) => Number((input as { value: number }).value) * 2,
+        }),
+      ],
+    );
+
+    const result = await runner.run(flow, { numbers: [1, 2, 3] });
+
+    expect(result.status).toBe('completed');
+    expect(result.outputs.sum).toBe(6);
+    expect(result.outputs['positive-check']).toEqual({ passed: true });
+    expect(result.outputs.double).toBe(12);
+  });
+
+  it('supports conditional branching from runtime state and step outputs', async () => {
+    const runner = new FlowRunner<{ threshold: number }>({});
+
+    const flow = defineFlow(
+      'conditional-flow',
+      [
+        step({
+          id: 'seed',
+          run: () => 7,
+        }),
+        conditional({
+          id: 'branch',
+          input: {
+            seed: fromStep('seed'),
+            threshold: fromContext('threshold'),
+          },
+          when: (_ctx, input) => {
+            const payload = input as { seed: number; threshold: number };
+            return payload.seed > payload.threshold;
+          },
+          then: [
+            step({
+              id: 'high',
+              run: () => 'high-path',
+            }),
+          ],
+          else: [
+            step({
+              id: 'low',
+              run: () => 'low-path',
+            }),
+          ],
+        }),
+      ],
+    );
+
+    const result = await runner.run(flow, { threshold: 5 });
+
+    expect(result.status).toBe('completed');
+    expect(result.outputs.seed).toBe(7);
+    expect((result.outputs.branch as { branch: string }).branch).toBe('then');
+    expect(result.outputs.high).toBe('high-path');
+    expect(result.outputs.low).toBeUndefined();
+  });
+
+  it('supports loops with maxIterations and exit condition', async () => {
+    const runner = new FlowRunner<{ counter: number }>({});
+
+    const flow = defineFlow(
+      'loop-flow',
+      [
+        loop({
+          id: 'repeat',
+          maxIterations: 5,
+          do: [
+            step({
+              id: 'inc',
+              run: (ctx) => {
+                ctx.context.counter += 1;
+                return ctx.context.counter;
+              },
+            }),
+          ],
+          until: (ctx) => Number(ctx.getStepOutput('inc')) >= 3,
+        }),
+      ],
+    );
+
+    const result = await runner.run(flow, { counter: 0 });
+
+    expect(result.status).toBe('completed');
+    expect((result.outputs.repeat as { iterations: number }).iterations).toBe(3);
+    expect(result.context.counter).toBe(3);
+  });
+
+  it('supports fan-out/fan-in parallel branches with concurrency control', async () => {
+    const runner = new FlowRunner({ concurrency: 2 });
+    let active = 0;
+    let peak = 0;
+
+    const delayed = async (value: number): Promise<number> => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      active -= 1;
+      return value;
+    };
+
+    const flow = defineFlow('parallel-flow', [
+      parallel({
+        id: 'fan-out',
+        concurrency: 2,
+        branches: {
+          a: [step({ id: 'a1', run: async () => delayed(1) })],
+          b: [step({ id: 'b1', run: async () => delayed(2) })],
+          c: [step({ id: 'c1', run: async () => delayed(3) })],
+        },
+      }),
+      step({
+        id: 'fan-in',
+        input: fromStep('fan-out'),
+        run: (_ctx, input) => {
+          const branches = input as Record<string, Record<string, number>>;
+          return branches.a.a1 + branches.b.b1 + branches.c.c1;
+        },
+      }),
+    ]);
+
+    const result = await runner.run(flow, {});
+
+    expect(result.status).toBe('completed');
+    expect(result.outputs['fan-in']).toBe(6);
+    expect(peak).toBe(2);
+  });
+
+  it('supports nested constructs and fromSteps aggregation', async () => {
+    const runner = new FlowRunner<{ enabled: boolean }>({});
+
+    const flow = defineFlow('nested', [
+      parallel({
+        id: 'prep',
+        branches: {
+          left: [step({ id: 'leftValue', run: () => 10 })],
+          right: [step({ id: 'rightValue', run: () => 20 })],
+        },
+      }),
+      loop({
+        id: 'iterate',
+        maxIterations: 2,
+        do: [
+          conditional({
+            id: 'switch',
+            when: (ctx) => Boolean(ctx.context.enabled),
+            then: [
+              step({
+                id: 'merge',
+                input: fromSteps(['leftValue', 'rightValue']),
+                run: (_ctx, input) => {
+                  const values = input as Record<string, number>;
+                  return values.leftValue + values.rightValue;
+                },
+              }),
+            ],
+            else: [step({ id: 'merge', run: () => 0 })],
+          }),
+        ],
+      }),
+    ]);
+
+    const result = await runner.run(flow, { enabled: true });
+
+    expect(result.status).toBe('completed');
+    expect(result.outputs.merge).toBe(30);
+    expect((result.outputs.iterate as { iterations: number }).iterations).toBe(2);
+  });
+
+  it('captures checkpoint snapshots during execution', async () => {
+    const snapshots: FlowCheckpointSnapshot[] = [];
+    const checkpoint: FlowCheckpointAdapter = {
+      load: async () => null,
+      save: async (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    };
+
+    const runner = new FlowRunner({ checkpoint });
+    const flow = defineFlow('checkpointed', [
+      step({ id: 'first', run: () => 1 }),
+      step({ id: 'second', run: () => 2, dependsOn: ['first'] }),
+    ]);
+
+    const result = await runner.run(flow, {});
+
+    expect(result.status).toBe('completed');
+    expect(snapshots.length).toBeGreaterThanOrEqual(3);
+    expect(snapshots.at(-1)?.status).toBe('completed');
+    expect(snapshots.at(-1)?.outputs.second).toBe(2);
+  });
+
+  it('throws FlowExecutionError on node failure by default', async () => {
+    const runner = new FlowRunner();
+    const flow = defineFlow('failure', [
+      step({ id: 'boom', run: () => { throw new Error('kaboom'); } }),
+    ]);
+
+    await expect(runner.run(flow, {})).rejects.toMatchObject({
+      name: 'FlowExecutionError',
+      flowId: 'failure',
+      nodeId: 'boom',
+    });
+  });
+
+  it('returns failed result when continueOnError is enabled', async () => {
+    const runner = new FlowRunner({ continueOnError: true });
+
+    const flow = defineFlow('continue-on-error', [
+      step({ id: 'fail', run: () => { throw new Error('nope'); } }),
+      step({ id: 'later', run: () => 'after' }),
+    ]);
+
+    const result = await runner.run(flow, {});
+
+    expect(result.status).toBe('failed');
+    expect(result.error?.name).toBe('FlowExecutionError');
+    expect(result.outputs.later).toBe('after');
+  });
+
+  it('reuses checkpointed completed node execution IDs', async () => {
+    const runSpy = vi.fn().mockResolvedValue(123);
+    const checkpoint: FlowCheckpointAdapter = {
+      load: async () => ({
+        flowId: 'resume-flow',
+        status: 'failed',
+        startedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        completedExecutionIds: ['resume-flow/already'],
+        outputs: { already: 42 },
+        executionOutputs: { 'resume-flow/already': 42 },
+      }),
+      save: async () => undefined,
+    };
+
+    const runner = new FlowRunner({ checkpoint });
+    const flow = defineFlow('resume-flow', [
+      step({ id: 'already', run: runSpy }),
+      step({ id: 'next', input: fromStep('already'), run: (_ctx, input) => Number(input) + 1 }),
+    ]);
+
+    const result = await runner.run(flow, {});
+
+    expect(result.status).toBe('completed');
+    expect(runSpy).not.toHaveBeenCalled();
+    expect(result.outputs.next).toBe(43);
+  });
+});

--- a/tests/package-boundary-usage.test.ts
+++ b/tests/package-boundary-usage.test.ts
@@ -6,6 +6,7 @@ import { Logger, CostEstimator, FleetEventBus } from '@cadre/observability';
 import { NotificationManager } from '@cadre/notifications';
 import { SessionQueue, ParallelExecutor, RetryExecutor } from '@cadre/execution';
 import { PreRunValidationSuite, diskValidator } from '@cadre/validation';
+import { defineFlow, step, loop, parallel, conditional, gate, FlowRunner, fromStep, fromContext, fromSteps } from '@cadre/flow';
 
 function walkTsFiles(dir: string): string[] {
   const out: string[] = [];
@@ -34,6 +35,17 @@ describe('package boundary usage', () => {
 
     expect(PreRunValidationSuite).toBeTypeOf('function');
     expect(diskValidator.name).toBe('disk');
+
+    expect(defineFlow).toBeTypeOf('function');
+    expect(step).toBeTypeOf('function');
+    expect(loop).toBeTypeOf('function');
+    expect(parallel).toBeTypeOf('function');
+    expect(conditional).toBeTypeOf('function');
+    expect(gate).toBeTypeOf('function');
+    expect(fromStep).toBeTypeOf('function');
+    expect(fromContext).toBeTypeOf('function');
+    expect(fromSteps).toBeTypeOf('function');
+    expect(FlowRunner).toBeTypeOf('function');
   });
 
   it('does not use src-relative imports for extracted modules in production code', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "packages/notifications/src/**/*",
     "packages/observability/src/**/*",
     "packages/execution/src/**/*",
+    "packages/flow/src/**/*",
     "packages/validation/src/**/*",
     "packages/agent-runtime/src/**/*",
     "packages/agent-runtime-provider-host/src/**/*",


### PR DESCRIPTION
Replacement for #313 after #312 merge conflict.

- Fresh branch from latest `main`
- Cherry-picked #293 flow DSL/runner changes
- Resolved conflict minimally
- Ran local build and targeted flow/orchestrator/validation tests