### PR TITLE
feat(flow): enforce inter-agent data contracts (#295) [resolved-late]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4905,7 +4905,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "p-limit": "^6"
+        "p-limit": "^6",
+        "zod": "^3.23"
       }
     },
     "packages/notifications": {

--- a/packages/flow/package.json
+++ b/packages/flow/package.json
@@ -14,7 +14,8 @@
     "dist/"
   ],
   "dependencies": {
-    "p-limit": "^6"
+    "p-limit": "^6",
+    "zod": "^3.23"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/flow/src/contracts.ts
+++ b/packages/flow/src/contracts.ts
@@ -1,0 +1,406 @@
+import {
+  ZodAny,
+  ZodArray,
+  ZodDefault,
+  ZodDiscriminatedUnion,
+  ZodEffects,
+  ZodEnum,
+  ZodLiteral,
+  ZodNativeEnum,
+  ZodNullable,
+  ZodNumber,
+  ZodObject,
+  ZodOptional,
+  ZodString,
+  ZodType,
+  ZodTypeAny,
+  ZodUnion,
+  ZodUnknown,
+  ZodBoolean,
+  ZodNull,
+  ZodUndefined,
+} from 'zod';
+import type {
+  DataRef,
+  FlowContractIssue,
+  FlowContractValidationResult,
+  FlowContracts,
+  FlowDefinition,
+  FlowNode,
+  StepContract,
+} from './types.js';
+
+export interface IndexedNode {
+  id: string;
+  input?: unknown;
+  inputSchema?: ZodTypeAny;
+  outputSchema?: ZodTypeAny;
+}
+
+export interface IndexedFlow {
+  nodes: Map<string, IndexedNode>;
+}
+
+export function validateFlowContracts<TContext = Record<string, unknown>>(
+  flow: FlowDefinition<TContext>,
+  contracts?: FlowContracts,
+): FlowContractValidationResult {
+  const issues: FlowContractIssue[] = [];
+  const mergedContracts = mergeContracts(flow.contracts, contracts);
+  const indexed = indexFlow(flow);
+
+  for (const [, node] of indexed.nodes) {
+    if (!node.input) {
+      continue;
+    }
+    const refs = collectRefs(node.input, 'input');
+    for (const ref of refs) {
+      if (ref.ref.kind === 'fromContext') {
+        continue;
+      }
+      if (ref.ref.kind === 'fromStep') {
+        issues.push(
+          ...validateSingleRef({
+            fromStep: ref.ref.stepId,
+            toStep: node.id,
+            fieldPath: ref.fieldPath,
+            refPath: ref.ref.path,
+            consumerPath: ref.fieldPath,
+            mergedContracts,
+            indexed,
+          }),
+        );
+        continue;
+      }
+      for (const fromStep of ref.ref.stepIds) {
+        const stepFieldPath = `${ref.fieldPath}.${fromStep}`;
+        issues.push(
+          ...validateSingleRef({
+            fromStep,
+            toStep: node.id,
+            fieldPath: stepFieldPath,
+            refPath: ref.ref.path,
+            consumerPath: stepFieldPath,
+            mergedContracts,
+            indexed,
+          }),
+        );
+      }
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+}
+
+export function mergeContracts(
+  flowContracts?: FlowContracts,
+  runtimeContracts?: FlowContracts,
+): FlowContracts {
+  return {
+    ...(flowContracts ?? {}),
+    ...(runtimeContracts ?? {}),
+  };
+}
+
+export function getContractForStep(
+  stepId: string,
+  indexed: IndexedFlow,
+  mergedContracts: FlowContracts,
+): StepContract<unknown, unknown> {
+  const node = indexed.nodes.get(stepId);
+  const fromNode: StepContract<unknown, unknown> = {
+    inputSchema: node?.inputSchema,
+    outputSchema: node?.outputSchema,
+  };
+  const fromContracts = mergedContracts[stepId] ?? {};
+  return {
+    inputSchema: fromNode.inputSchema ?? fromContracts.inputSchema,
+    outputSchema: fromNode.outputSchema ?? fromContracts.outputSchema,
+  };
+}
+
+export function schemaAtPath(schema: ZodTypeAny | undefined, path?: string): ZodTypeAny | undefined {
+  if (!schema || !path || path.trim().length === 0) {
+    return schema;
+  }
+
+  const parts = path.split('.').filter(Boolean);
+  let cursor: ZodTypeAny | undefined = schema;
+
+  for (const part of parts) {
+    if (!cursor) {
+      return undefined;
+    }
+
+    const base = unwrapSchema(cursor);
+
+    if (base instanceof ZodObject) {
+      const shape = base.shape;
+      cursor = shape[part] as ZodTypeAny | undefined;
+      continue;
+    }
+
+    if (base instanceof ZodArray) {
+      const index = Number(part);
+      if (Number.isNaN(index)) {
+        return undefined;
+      }
+      cursor = base.element;
+      continue;
+    }
+
+    return undefined;
+  }
+
+  return cursor;
+}
+
+function validateSingleRef(params: {
+  fromStep: string;
+  toStep: string;
+  fieldPath: string;
+  refPath?: string;
+  consumerPath: string;
+  mergedContracts: FlowContracts;
+  indexed: IndexedFlow;
+}): FlowContractIssue[] {
+  const { fromStep, toStep, fieldPath, refPath, consumerPath, mergedContracts, indexed } = params;
+
+  if (!indexed.nodes.has(fromStep)) {
+    return [
+      {
+        fromStep,
+        toStep,
+        fieldPath,
+        reason: `Producer step '${fromStep}' does not exist in flow`,
+      },
+    ];
+  }
+
+  const producerContract = getContractForStep(fromStep, indexed, mergedContracts);
+  if (!producerContract.outputSchema) {
+    return [
+      {
+        fromStep,
+        toStep,
+        fieldPath,
+        reason: `Producer '${fromStep}' has no output schema`,
+      },
+    ];
+  }
+
+  const consumerContract = getContractForStep(toStep, indexed, mergedContracts);
+  if (!consumerContract.inputSchema) {
+    return [
+      {
+        fromStep,
+        toStep,
+        fieldPath,
+        reason: `Consumer '${toStep}' has no input schema`,
+      },
+    ];
+  }
+
+  const producerSchema = schemaAtPath(producerContract.outputSchema, refPath);
+  if (!producerSchema) {
+    const atPath = refPath && refPath.length > 0 ? refPath : '<root>';
+    return [
+      {
+        fromStep,
+        toStep,
+        fieldPath,
+        reason: `Producer schema path '${atPath}' does not exist`,
+      },
+    ];
+  }
+
+  const consumerSchema = schemaAtPath(consumerContract.inputSchema, consumerPath.replace(/^input\.?/, ''));
+  if (!consumerSchema) {
+    const atPath = consumerPath.replace(/^input\.?/, '') || '<root>';
+    return [
+      {
+        fromStep,
+        toStep,
+        fieldPath,
+        reason: `Consumer schema path '${atPath}' does not exist`,
+      },
+    ];
+  }
+
+  const mismatchReason = compatibilityReason(producerSchema, consumerSchema);
+  if (!mismatchReason) {
+    return [];
+  }
+
+  return [
+    {
+      fromStep,
+      toStep,
+      fieldPath,
+      reason: mismatchReason,
+    },
+  ];
+}
+
+function indexFlow<TContext = Record<string, unknown>>(flow: FlowDefinition<TContext>): IndexedFlow {
+  const nodes = new Map<string, IndexedNode>();
+
+  const visit = (items: FlowNode<TContext>[]): void => {
+    for (const node of items) {
+      if (!nodes.has(node.id)) {
+        nodes.set(node.id, {
+          id: node.id,
+          input: node.input,
+          inputSchema: 'inputSchema' in node ? node.inputSchema : undefined,
+          outputSchema: 'outputSchema' in node ? node.outputSchema : undefined,
+        });
+      }
+      if (node.kind === 'conditional') {
+        visit(node.then);
+        visit(node.else ?? []);
+      }
+      if (node.kind === 'loop') {
+        visit(node.do);
+      }
+      if (node.kind === 'parallel') {
+        for (const branch of Object.values(node.branches)) {
+          visit(branch);
+        }
+      }
+    }
+  };
+
+  visit(flow.nodes);
+  return { nodes };
+}
+
+function collectRefs(input: unknown, fieldPath: string): Array<{ ref: DataRef; fieldPath: string }> {
+  const refs: Array<{ ref: DataRef; fieldPath: string }> = [];
+  const walk = (value: unknown, path: string): void => {
+    if (isDataRef(value)) {
+      refs.push({ ref: value, fieldPath: path });
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach((entry, index) => walk(entry, `${path}.${index}`));
+      return;
+    }
+
+    if (value && typeof value === 'object') {
+      for (const [key, entry] of Object.entries(value)) {
+        walk(entry, `${path}.${key}`);
+      }
+    }
+  };
+
+  walk(input, fieldPath);
+  return refs;
+}
+
+function isDataRef(value: unknown): value is DataRef {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as { kind?: string };
+  return candidate.kind === 'fromStep' || candidate.kind === 'fromSteps' || candidate.kind === 'fromContext';
+}
+
+function compatibilityReason(source: ZodTypeAny, target: ZodTypeAny): string | undefined {
+  const src = unwrapSchema(source);
+  const dst = unwrapSchema(target);
+
+  if (dst instanceof ZodAny || dst instanceof ZodUnknown) {
+    return undefined;
+  }
+
+  if (src instanceof ZodAny || src instanceof ZodUnknown) {
+    return undefined;
+  }
+
+  if (dst instanceof ZodUnion) {
+    const works = (dst.options as ZodTypeAny[]).some((option: ZodTypeAny) => compatibilityReason(src, option) === undefined);
+    return works ? undefined : `Source type ${schemaLabel(src)} is incompatible with union target ${schemaLabel(dst)}`;
+  }
+
+  if (src instanceof ZodUnion) {
+    const incompatible = (src.options as ZodTypeAny[]).find((option: ZodTypeAny) => compatibilityReason(option, dst) !== undefined);
+    if (!incompatible) {
+      return undefined;
+    }
+    return `Union source ${schemaLabel(src)} includes incompatible variant ${schemaLabel(incompatible as ZodTypeAny)} for ${schemaLabel(dst)}`;
+  }
+
+  if (dst instanceof ZodDiscriminatedUnion) {
+    const options = Array.from(dst.options.values()) as ZodTypeAny[];
+    const works = options.some((option) => compatibilityReason(src, option) === undefined);
+    return works ? undefined : `Source type ${schemaLabel(src)} is incompatible with discriminated union target ${schemaLabel(dst)}`;
+  }
+
+  if (src instanceof ZodDiscriminatedUnion) {
+    const options = Array.from(src.options.values()) as ZodTypeAny[];
+    const incompatible = options.find((option) => compatibilityReason(option, dst) !== undefined);
+    if (!incompatible) {
+      return undefined;
+    }
+    return `Discriminated union source ${schemaLabel(src)} includes incompatible variant ${schemaLabel(incompatible)} for ${schemaLabel(dst)}`;
+  }
+
+  if (src instanceof ZodLiteral) {
+    if (dst instanceof ZodString || dst instanceof ZodNumber || dst instanceof ZodBoolean || dst instanceof ZodNull || dst instanceof ZodUndefined) {
+      return undefined;
+    }
+    if (dst instanceof ZodEnum || dst instanceof ZodNativeEnum) {
+      return undefined;
+    }
+    if (dst instanceof ZodLiteral) {
+      return src.value === dst.value ? undefined : `Literal ${String(src.value)} does not match ${String(dst.value)}`;
+    }
+  }
+
+  if (src.constructor === dst.constructor) {
+    if (src instanceof ZodArray && dst instanceof ZodArray) {
+      return compatibilityReason(src.element, dst.element);
+    }
+    if (src instanceof ZodObject && dst instanceof ZodObject) {
+      const sourceShape = src.shape;
+      const targetShape = dst.shape;
+      for (const [key, targetSchema] of Object.entries(targetShape)) {
+        const sourceSchema = sourceShape[key] as ZodTypeAny | undefined;
+        if (!sourceSchema) {
+          const targetIsOptional = unwrapSchema(targetSchema as ZodTypeAny) instanceof ZodOptional;
+          if (!targetIsOptional) {
+            return `Missing required field '${key}'`;
+          }
+          continue;
+        }
+        const mismatch = compatibilityReason(sourceSchema, targetSchema as ZodTypeAny);
+        if (mismatch) {
+          return `Field '${key}' is incompatible: ${mismatch}`;
+        }
+      }
+      return undefined;
+    }
+    return undefined;
+  }
+
+  return `Type ${schemaLabel(src)} is not assignable to ${schemaLabel(dst)}`;
+}
+
+function unwrapSchema(schema: ZodTypeAny): ZodTypeAny {
+  if (schema instanceof ZodOptional || schema instanceof ZodNullable || schema instanceof ZodDefault) {
+    return unwrapSchema(schema._def.innerType as ZodTypeAny);
+  }
+  if (schema instanceof ZodEffects) {
+    return unwrapSchema(schema._def.schema as ZodTypeAny);
+  }
+  return schema;
+}
+
+function schemaLabel(schema: ZodTypeAny): string {
+  const unwrapped = unwrapSchema(schema);
+  return unwrapped._def.typeName.replace('Zod', '').toLowerCase();
+}

--- a/packages/flow/src/contracts.typecheck.ts
+++ b/packages/flow/src/contracts.typecheck.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { fromStep, step, type StepContract } from './index.js';
+
+type Contracts = {
+  producer: StepContract<unknown, { value: number }>;
+  consumerOk: StepContract<{ value: { value: number } }, string>;
+  consumerBad: StepContract<{ value: string }, string>;
+};
+
+const _contracts: Contracts = {
+  producer: { outputSchema: z.object({ value: z.number() }) },
+  consumerOk: { inputSchema: z.object({ value: z.object({ value: z.number() }) }) },
+  consumerBad: { inputSchema: z.object({ value: z.string() }) },
+};
+
+step<Record<string, unknown>, { value: { value: number } }, string>({
+  id: 'consumerOk',
+  input: {
+    value: fromStep<Contracts, 'producer'>('producer'),
+  },
+  run: (_ctx, input) => JSON.stringify(input.value.value),
+});
+
+step<Record<string, unknown>, { value: string }, string>({
+  id: 'consumerBad',
+  input: {
+    // @ts-expect-error producer output object is not assignable to consumer string input
+    value: fromStep<Contracts, 'producer'>('producer'),
+  },
+  run: (_ctx, input) => input.value,
+});

--- a/packages/flow/src/dsl.ts
+++ b/packages/flow/src/dsl.ts
@@ -16,21 +16,21 @@ export function defineFlow<TContext = Record<string, unknown>>(
   return { id, nodes, description };
 }
 
-export function step<TContext = Record<string, unknown>>(
-  config: Omit<FlowStepNode<TContext>, 'kind'>,
-): FlowStepNode<TContext> {
+export function step<TContext = Record<string, unknown>, TInput = unknown, TOutput = unknown>(
+  config: Omit<FlowStepNode<TContext, TInput, TOutput>, 'kind'>,
+): FlowStepNode<TContext, TInput, TOutput> {
   return { kind: 'step', ...config };
 }
 
-export function gate<TContext = Record<string, unknown>>(
-  config: Omit<FlowGateNode<TContext>, 'kind'>,
-): FlowGateNode<TContext> {
+export function gate<TContext = Record<string, unknown>, TInput = unknown>(
+  config: Omit<FlowGateNode<TContext, TInput>, 'kind'>,
+): FlowGateNode<TContext, TInput> {
   return { kind: 'gate', ...config };
 }
 
-export function conditional<TContext = Record<string, unknown>>(
-  config: Omit<FlowConditionalNode<TContext>, 'kind'>,
-): FlowConditionalNode<TContext> {
+export function conditional<TContext = Record<string, unknown>, TInput = unknown>(
+  config: Omit<FlowConditionalNode<TContext, TInput>, 'kind'>,
+): FlowConditionalNode<TContext, TInput> {
   return { kind: 'conditional', ...config };
 }
 

--- a/packages/flow/src/index.ts
+++ b/packages/flow/src/index.ts
@@ -9,9 +9,14 @@ export {
 
 export { fromStep, fromSteps, fromContext } from './refs.js';
 export { FlowRunner } from './runner.js';
+export { validateFlowContracts } from './contracts.js';
 
 export type {
   DataRef,
+  FlowContracts,
+  StepContract,
+  FlowContractIssue,
+  FlowContractValidationResult,
   FlowNode,
   FlowStepNode,
   FlowGateNode,
@@ -26,4 +31,4 @@ export type {
   FlowCheckpointSnapshot,
 } from './types.js';
 
-export { FlowExecutionError, FlowCycleError } from './types.js';
+export { FlowExecutionError, FlowCycleError, FlowContractError } from './types.js';

--- a/packages/flow/src/refs.ts
+++ b/packages/flow/src/refs.ts
@@ -1,13 +1,32 @@
-import type { DataRef } from './types.js';
+import type { DataRef, FlowContracts } from './types.js';
 
-export function fromStep(stepId: string, path?: string): DataRef {
+type ContractOutput<TContracts extends FlowContracts, TStep extends string> =
+  TStep extends keyof TContracts
+    ? TContracts[TStep] extends { outputSchema?: infer TSchema }
+      ? TSchema extends { _output: infer TOutput }
+        ? TOutput
+        : unknown
+      : unknown
+    : unknown;
+
+type ContractOutputs<TContracts extends FlowContracts, TStepIds extends readonly string[]> = {
+  [K in TStepIds[number]]: ContractOutput<TContracts, K>;
+};
+
+export function fromStep<TContracts extends FlowContracts = FlowContracts, TStep extends string = string>(
+  stepId: TStep,
+  path?: string,
+): DataRef<ContractOutput<TContracts, TStep>> {
   return { kind: 'fromStep', stepId, path };
 }
 
-export function fromSteps(stepIds: string[], path?: string): DataRef {
+export function fromSteps<
+  TContracts extends FlowContracts = FlowContracts,
+  TStepIds extends readonly string[] = readonly string[],
+>(stepIds: TStepIds, path?: string): DataRef<ContractOutputs<TContracts, TStepIds>> {
   return { kind: 'fromSteps', stepIds, path };
 }
 
-export function fromContext(path?: string): DataRef {
+export function fromContext<TValue = unknown>(path?: string): DataRef<TValue> {
   return { kind: 'fromContext', path };
 }

--- a/packages/flow/src/runner.ts
+++ b/packages/flow/src/runner.ts
@@ -1,19 +1,23 @@
 import pLimit from 'p-limit';
+import { getContractForStep, mergeContracts, schemaAtPath, validateFlowContracts, type IndexedFlow } from './contracts.js';
 import {
+  FlowContractError,
   FlowCycleError,
   FlowExecutionError,
   type DataRef,
   type FlowCheckpointSnapshot,
+  type FlowContracts,
   type FlowDefinition,
   type FlowExecutionContext,
   type FlowNode,
   type FlowRunResult,
   type FlowRunnerOptions,
-  type InputValue,
 } from './types.js';
 
 interface RunnerState<TContext> {
   flow: FlowDefinition<TContext>;
+  indexedNodes: Map<string, FlowNode<TContext>>;
+  contracts: FlowContracts;
   context: TContext;
   outputs: Record<string, unknown>;
   executionOutputs: Record<string, unknown>;
@@ -37,6 +41,8 @@ export class FlowRunner<TContext = Record<string, unknown>> {
     const startedAt = new Date().toISOString();
     const state: RunnerState<TContext> = {
       flow,
+      indexedNodes: this.indexNodes(flow.nodes),
+      contracts: mergeContracts(flow.contracts, options.contracts ?? this.defaults.contracts),
       context,
       outputs: {},
       executionOutputs: {},
@@ -47,6 +53,21 @@ export class FlowRunner<TContext = Record<string, unknown>> {
     };
 
     await this.loadCheckpoint(state);
+
+    if (Object.keys(state.contracts).length > 0) {
+      const validation = validateFlowContracts(flow, state.contracts);
+      if (!validation.valid) {
+        const first = validation.issues[0];
+        throw new FlowContractError(
+          flow.id,
+          first.toStep,
+          `${flow.id}/${first.toStep}`,
+          first.fromStep,
+          first.fieldPath,
+          first.reason,
+        );
+      }
+    }
 
     try {
       await this.executeNodeList(state, flow.nodes, [flow.id]);
@@ -189,11 +210,14 @@ export class FlowRunner<TContext = Record<string, unknown>> {
     executionId: string,
   ): Promise<unknown> {
     const context = this.buildExecutionContext(state, executionPath);
-    const resolvedInput = this.resolveInput(node.input, context);
+    const resolvedInput = this.resolveInput(state, node.input, context, node.id, executionId, 'input');
+    this.validateConsumerInput(state, node.id, executionId, resolvedInput, 'input', 'flow-input');
 
     switch (node.kind) {
       case 'step': {
-        return node.run(context, resolvedInput);
+        const output = await node.run(context, resolvedInput);
+        this.validateProducerOutput(state, node.id, executionId, output);
+        return output;
       }
       case 'gate': {
         const passed = await node.evaluate(context, resolvedInput);
@@ -261,7 +285,14 @@ export class FlowRunner<TContext = Record<string, unknown>> {
     }
   }
 
-  private resolveInput(value: InputValue | undefined, context: FlowExecutionContext<TContext>): unknown {
+  private resolveInput(
+    state: RunnerState<TContext>,
+    value: unknown,
+    context: FlowExecutionContext<TContext>,
+    toStepId: string,
+    executionId: string,
+    inputPath: string,
+  ): unknown {
     if (value === undefined) return undefined;
     if (value === null) return null;
     if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
@@ -269,30 +300,44 @@ export class FlowRunner<TContext = Record<string, unknown>> {
     }
 
     if (Array.isArray(value)) {
-      return value.map((entry) => this.resolveInput(entry, context));
+      return value.map((entry, index) => this.resolveInput(state, entry, context, toStepId, executionId, `${inputPath}.${index}`));
     }
 
     if (this.isDataRef(value)) {
-      return this.resolveDataRef(value, context);
+      return this.resolveDataRef(state, value, context, toStepId, executionId, inputPath);
     }
 
     const out: Record<string, unknown> = {};
     for (const [key, entry] of Object.entries(value)) {
-      out[key] = this.resolveInput(entry as InputValue, context);
+      out[key] = this.resolveInput(state, entry, context, toStepId, executionId, `${inputPath}.${key}`);
     }
     return out;
   }
 
-  private resolveDataRef(ref: DataRef, context: FlowExecutionContext<TContext>): unknown {
+  private resolveDataRef(
+    state: RunnerState<TContext>,
+    ref: DataRef,
+    context: FlowExecutionContext<TContext>,
+    toStepId: string,
+    executionId: string,
+    inputPath: string,
+  ): unknown {
     switch (ref.kind) {
       case 'fromStep': {
-        return this.getAtPath(context.getStepOutput(ref.stepId), ref.path);
+        const value = this.getAtPath(context.getStepOutput(ref.stepId), ref.path);
+        this.validateProducerRefPath(state, executionId, ref.stepId, toStepId, ref.path, value, inputPath);
+        this.validateConsumerInput(state, toStepId, executionId, value, inputPath, ref.stepId);
+        return value;
       }
       case 'fromSteps': {
         const out: Record<string, unknown> = {};
         for (const stepId of ref.stepIds) {
-          out[stepId] = this.getAtPath(context.getStepOutput(stepId), ref.path);
+          const value = this.getAtPath(context.getStepOutput(stepId), ref.path);
+          this.validateProducerRefPath(state, executionId, stepId, toStepId, ref.path, value, `${inputPath}.${stepId}`);
+          this.validateConsumerInput(state, toStepId, executionId, value, `${inputPath}.${stepId}`, stepId);
+          out[stepId] = value;
         }
+        this.validateConsumerInput(state, toStepId, executionId, out, inputPath, ref.stepIds.join(','));
         return out;
       }
       case 'fromContext': {
@@ -336,6 +381,116 @@ export class FlowRunner<TContext = Record<string, unknown>> {
     }
     const candidate = value as { kind?: string };
     return candidate.kind === 'fromStep' || candidate.kind === 'fromSteps' || candidate.kind === 'fromContext';
+  }
+
+  private validateProducerOutput(
+    state: RunnerState<TContext>,
+    stepId: string,
+    executionId: string,
+    output: unknown,
+  ): void {
+    const contract = getContractForStep(stepId, this.asIndexedFlow(state), state.contracts);
+    if (!contract.outputSchema) {
+      return;
+    }
+    const parsed = contract.outputSchema.safeParse(output);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+      throw new FlowContractError(state.flow.id, stepId, executionId, stepId, path, issue.message, parsed.error);
+    }
+  }
+
+  private validateProducerRefPath(
+    state: RunnerState<TContext>,
+    executionId: string,
+    fromStepId: string,
+    toStepId: string,
+    producerPath: string | undefined,
+    value: unknown,
+    inputPath: string,
+  ): void {
+    const contract = getContractForStep(fromStepId, this.asIndexedFlow(state), state.contracts);
+    if (!contract.outputSchema) {
+      return;
+    }
+    const expectedSchema = schemaAtPath(contract.outputSchema, producerPath);
+    if (!expectedSchema) {
+      const refPath = producerPath && producerPath.length > 0 ? producerPath : '<root>';
+      throw new FlowContractError(state.flow.id, toStepId, executionId, fromStepId, inputPath, `Producer schema path '${refPath}' does not exist`);
+    }
+    const parsed = expectedSchema.safeParse(value);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      throw new FlowContractError(state.flow.id, toStepId, executionId, fromStepId, inputPath, issue.message, parsed.error);
+    }
+  }
+
+  private validateConsumerInput(
+    state: RunnerState<TContext>,
+    toStepId: string,
+    executionId: string,
+    value: unknown,
+    inputPath: string,
+    fromStepId: string,
+  ): void {
+    const contract = getContractForStep(toStepId, this.asIndexedFlow(state), state.contracts);
+    if (!contract.inputSchema) {
+      return;
+    }
+    const targetSchema = schemaAtPath(contract.inputSchema, inputPath.replace(/^input\.?/, ''));
+    if (!targetSchema) {
+      throw new FlowContractError(
+        state.flow.id,
+        toStepId,
+        executionId,
+        fromStepId,
+        inputPath,
+        `Consumer schema path '${inputPath.replace(/^input\.?/, '') || '<root>'}' does not exist`,
+      );
+    }
+    const parsed = targetSchema.safeParse(value);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      throw new FlowContractError(state.flow.id, toStepId, executionId, fromStepId, inputPath, issue.message, parsed.error);
+    }
+  }
+
+  private asIndexedFlow(state: RunnerState<TContext>): IndexedFlow {
+    const nodes: IndexedFlow['nodes'] = new Map();
+    for (const [id, node] of state.indexedNodes) {
+      nodes.set(id, {
+        id,
+        inputSchema: 'inputSchema' in node ? node.inputSchema : undefined,
+        outputSchema: 'outputSchema' in node ? node.outputSchema : undefined,
+      });
+    }
+    return { nodes };
+  }
+
+  private indexNodes(nodes: FlowNode<TContext>[]): Map<string, FlowNode<TContext>> {
+    const indexed = new Map<string, FlowNode<TContext>>();
+    const visit = (items: FlowNode<TContext>[]): void => {
+      for (const node of items) {
+        if (!indexed.has(node.id)) {
+          indexed.set(node.id, node);
+        }
+        if (node.kind === 'conditional') {
+          visit(node.then);
+          visit(node.else ?? []);
+        }
+        if (node.kind === 'loop') {
+          visit(node.do);
+        }
+        if (node.kind === 'parallel') {
+          for (const branch of Object.values(node.branches)) {
+            visit(branch);
+          }
+        }
+      }
+    };
+    visit(nodes);
+    return indexed;
   }
 
   private validateNodeIds(nodes: FlowNode<TContext>[], scope: string): void {

--- a/packages/flow/src/types.ts
+++ b/packages/flow/src/types.ts
@@ -1,9 +1,11 @@
+import type { ZodType } from 'zod';
+
 export type MaybePromise<T> = T | Promise<T>;
 
-export type DataRef =
-  | { kind: 'fromStep'; stepId: string; path?: string }
-  | { kind: 'fromSteps'; stepIds: string[]; path?: string }
-  | { kind: 'fromContext'; path?: string };
+export type DataRef<TValue = unknown> =
+  | ({ kind: 'fromStep'; stepId: string; path?: string } & { readonly __valueType?: TValue })
+  | ({ kind: 'fromSteps'; stepIds: readonly string[]; path?: string } & { readonly __valueType?: TValue })
+  | ({ kind: 'fromContext'; path?: string } & { readonly __valueType?: TValue });
 
 export type InputValue =
   | string
@@ -14,6 +16,35 @@ export type InputValue =
   | DataRef
   | InputValue[]
   | { [key: string]: InputValue };
+
+export type RoutedInput<T> = unknown extends T
+  ? InputValue
+  : T extends string | number | boolean | null | undefined
+    ? T | DataRef<T>
+    : T extends Array<infer TEntry>
+      ? Array<RoutedInput<TEntry>> | DataRef<T>
+      : T extends object
+        ? { [K in keyof T]: RoutedInput<T[K]> } | DataRef<T>
+        : T | DataRef<T>;
+
+export interface StepContract<TInput = unknown, TOutput = unknown> {
+  inputSchema?: ZodType<TInput>;
+  outputSchema?: ZodType<TOutput>;
+}
+
+export type FlowContracts = Record<string, StepContract<unknown, unknown>>;
+
+export interface FlowContractIssue {
+  fromStep: string;
+  toStep: string;
+  fieldPath: string;
+  reason: string;
+}
+
+export interface FlowContractValidationResult {
+  valid: boolean;
+  issues: FlowContractIssue[];
+}
 
 export interface FlowExecutionContext<TContext = Record<string, unknown>> {
   readonly flowId: string;
@@ -28,24 +59,32 @@ export interface FlowExecutionContext<TContext = Record<string, unknown>> {
 export interface FlowNodeBase<TContext = Record<string, unknown>> {
   id: string;
   dependsOn?: string[];
-  input?: InputValue;
+  input?: unknown;
   checkpoint?: boolean;
   metadata?: Record<string, unknown>;
 }
 
-export interface FlowStepNode<TContext = Record<string, unknown>> extends FlowNodeBase<TContext> {
+export interface FlowStepNode<TContext = Record<string, unknown>, TInput = unknown, TOutput = unknown>
+  extends FlowNodeBase<TContext> {
   kind: 'step';
-  run: (ctx: FlowExecutionContext<TContext>, input: unknown) => MaybePromise<unknown>;
+  input?: RoutedInput<TInput>;
+  inputSchema?: ZodType<TInput>;
+  outputSchema?: ZodType<TOutput>;
+  run: (ctx: FlowExecutionContext<TContext>, input: TInput) => MaybePromise<TOutput>;
 }
 
-export interface FlowGateNode<TContext = Record<string, unknown>> extends FlowNodeBase<TContext> {
+export interface FlowGateNode<TContext = Record<string, unknown>, TInput = unknown> extends FlowNodeBase<TContext> {
   kind: 'gate';
-  evaluate: (ctx: FlowExecutionContext<TContext>, input: unknown) => MaybePromise<boolean>;
+  input?: RoutedInput<TInput>;
+  inputSchema?: ZodType<TInput>;
+  evaluate: (ctx: FlowExecutionContext<TContext>, input: TInput) => MaybePromise<boolean>;
 }
 
-export interface FlowConditionalNode<TContext = Record<string, unknown>> extends FlowNodeBase<TContext> {
+export interface FlowConditionalNode<TContext = Record<string, unknown>, TInput = unknown> extends FlowNodeBase<TContext> {
   kind: 'conditional';
-  when: (ctx: FlowExecutionContext<TContext>, input: unknown) => MaybePromise<boolean>;
+  input?: RoutedInput<TInput>;
+  inputSchema?: ZodType<TInput>;
+  when: (ctx: FlowExecutionContext<TContext>, input: TInput) => MaybePromise<boolean>;
   then: FlowNode<TContext>[];
   else?: FlowNode<TContext>[];
 }
@@ -75,6 +114,7 @@ export interface FlowDefinition<TContext = Record<string, unknown>> {
   id: string;
   description?: string;
   nodes: FlowNode<TContext>[];
+  contracts?: FlowContracts;
 }
 
 export type FlowRunStatus = 'completed' | 'failed';
@@ -100,6 +140,7 @@ export interface FlowRunnerOptions<TContext = Record<string, unknown>> {
   concurrency?: number;
   continueOnError?: boolean;
   checkpoint?: FlowCheckpointAdapter<TContext>;
+  contracts?: FlowContracts;
 }
 
 export interface FlowRunResult<TContext = Record<string, unknown>> {
@@ -135,5 +176,35 @@ export class FlowCycleError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'FlowCycleError';
+  }
+}
+
+export class FlowContractError extends FlowExecutionError {
+  readonly fromStep: string;
+  readonly toStep: string;
+  readonly fieldPath: string;
+  readonly reason: string;
+
+  constructor(
+    flowId: string,
+    toStep: string,
+    executionId: string,
+    fromStep: string,
+    fieldPath: string,
+    reason: string,
+    cause?: unknown,
+  ) {
+    super(
+      `Contract mismatch from '${fromStep}' to '${toStep}' at '${fieldPath}': ${reason}`,
+      flowId,
+      toStep,
+      executionId,
+      cause,
+    );
+    this.name = 'FlowContractError';
+    this.fromStep = fromStep;
+    this.toStep = toStep;
+    this.fieldPath = fieldPath;
+    this.reason = reason;
   }
 }

--- a/tests/flow-runner.test.ts
+++ b/tests/flow-runner.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 import {
+  FlowContractError,
   FlowRunner,
   conditional,
   defineFlow,
@@ -10,6 +12,7 @@ import {
   loop,
   parallel,
   step,
+  validateFlowContracts,
   type FlowCheckpointAdapter,
   type FlowCheckpointSnapshot,
 } from '@cadre/flow';
@@ -280,5 +283,123 @@ describe('@cadre/flow FlowRunner', () => {
     expect(result.status).toBe('completed');
     expect(runSpy).not.toHaveBeenCalled();
     expect(result.outputs.next).toBe(43);
+  });
+
+  it('validates compatible contracts across fromStep and fromSteps routing', async () => {
+    const flow = defineFlow('contracts-valid', [
+      step({
+        id: 'producerA',
+        outputSchema: z.object({ score: z.number() }),
+        run: () => ({ score: 5 }),
+      }),
+      step({
+        id: 'producerB',
+        outputSchema: z.object({ score: z.number() }),
+        run: () => ({ score: 7 }),
+      }),
+      step({
+        id: 'consumerOne',
+        inputSchema: z.object({ score: z.number() }),
+        input: fromStep('producerA'),
+        run: (_ctx, input) => (input as { score: number }).score,
+      }),
+      step({
+        id: 'consumerMany',
+        inputSchema: z.object({ producerA: z.object({ score: z.number() }), producerB: z.object({ score: z.number() }) }),
+        input: fromSteps(['producerA', 'producerB']),
+        run: (_ctx, input) => {
+          const payload = input as { producerA: { score: number }; producerB: { score: number } };
+          return payload.producerA.score + payload.producerB.score;
+        },
+      }),
+    ]);
+
+    const staticValidation = validateFlowContracts(flow);
+    expect(staticValidation.valid).toBe(true);
+
+    const result = await new FlowRunner().run(flow, {});
+    expect(result.status).toBe('completed');
+    expect(result.outputs.consumerOne).toBe(5);
+    expect(result.outputs.consumerMany).toBe(12);
+  });
+
+  it('reports type mismatch with from-step and to-step details', async () => {
+    const flow = defineFlow('contracts-type-mismatch', [
+      step({
+        id: 'producer',
+        outputSchema: z.object({ score: z.number() }),
+        run: () => ({ score: 5 }),
+      }),
+      step({
+        id: 'consumer',
+        inputSchema: z.object({ score: z.string() }),
+        input: fromStep('producer'),
+        run: (_ctx, input) => input,
+      }),
+    ]);
+
+    const staticValidation = validateFlowContracts(flow);
+    expect(staticValidation.valid).toBe(false);
+    expect(staticValidation.issues[0]).toMatchObject({
+      fromStep: 'producer',
+      toStep: 'consumer',
+      fieldPath: 'input',
+    });
+
+    await expect(new FlowRunner().run(flow, {})).rejects.toMatchObject({
+      name: 'FlowContractError',
+      fromStep: 'producer',
+      toStep: 'consumer',
+      fieldPath: 'input',
+    } satisfies Partial<FlowContractError>);
+  });
+
+  it('reports missing producer field/path mismatch', async () => {
+    const flow = defineFlow('contracts-missing-field', [
+      step({
+        id: 'producer',
+        outputSchema: z.object({ score: z.number() }),
+        run: () => ({ score: 5 }),
+      }),
+      step({
+        id: 'consumer',
+        inputSchema: z.object({ score: z.number() }),
+        input: fromStep('producer', 'score.value'),
+        run: (_ctx, input) => input,
+      }),
+    ]);
+
+    const staticValidation = validateFlowContracts(flow);
+    expect(staticValidation.valid).toBe(false);
+    expect(staticValidation.issues[0]?.reason).toContain('does not exist');
+
+    await expect(new FlowRunner().run(flow, {})).rejects.toMatchObject({
+      name: 'FlowContractError',
+      fromStep: 'producer',
+      toStep: 'consumer',
+    } satisfies Partial<FlowContractError>);
+  });
+
+  it('detects schema evolution incompatibility between producer and consumer versions', async () => {
+    const flow = defineFlow('contracts-schema-evolution', [
+      step({
+        id: 'producerV2',
+        outputSchema: z.object({ score: z.string() }),
+        run: () => ({ score: '5' }),
+      }),
+      step({
+        id: 'consumerV1',
+        inputSchema: z.object({ score: z.number() }),
+        input: fromStep('producerV2'),
+        run: (_ctx, input) => input,
+      }),
+    ]);
+
+    const staticValidation = validateFlowContracts(flow);
+    expect(staticValidation.valid).toBe(false);
+    expect(staticValidation.issues[0]).toMatchObject({
+      fromStep: 'producerV2',
+      toStep: 'consumerV1',
+    });
   });
 });


### PR DESCRIPTION
Replacement merge for #315 (missed earlier in chain processing).

- Fresh branch from latest `main`
- Cherry-picked #295 commit payload
- Validated with local build and focused flow/orchestrator/validation tests