### PR TITLE
feat(flow): enforce typed inter-agent routing contracts (#295)

### DIFF
--- a/packages/framework/src/flow/contracts.typecheck.ts
+++ b/packages/framework/src/flow/contracts.typecheck.ts
@@ -16,7 +16,7 @@ const _contracts: Contracts = {
 step<Record<string, unknown>, { value: { value: number } }, string>({
   id: 'consumerOk',
   input: {
-    value: fromStep<Contracts, 'producer'>('producer'),
+    value: fromStep<Contracts, 'producer'>('producer', 'value'),
   },
   run: (_ctx, input) => JSON.stringify(input.value.value),
 });
@@ -28,4 +28,22 @@ step<Record<string, unknown>, { value: string }, string>({
     value: fromStep<Contracts, 'producer'>('producer'),
   },
   run: (_ctx, input) => input.value,
+});
+
+step<Record<string, unknown>, { value: number }, string>({
+  id: 'consumerInvalidPath',
+  input: {
+    // @ts-expect-error producer output path does not exist on contract output type
+    value: fromStep<Contracts, 'producer'>('producer', 'value.missing'),
+  },
+  run: (_ctx, input) => String(input.value),
+});
+
+step<Record<string, unknown>, { value: number }, string>({
+  id: 'consumerInvalidProducer',
+  input: {
+    // @ts-expect-error producer id is not a valid contract key
+    value: fromStep<Contracts, 'missingProducer'>('missingProducer'),
+  },
+  run: (_ctx, input) => String(input.value),
 });

--- a/packages/framework/src/flow/refs.ts
+++ b/packages/framework/src/flow/refs.ts
@@ -1,6 +1,23 @@
 import type { DataRef, FlowContracts } from './types.js';
 
-type ContractOutput<TContracts extends FlowContracts, TStep extends string> =
+type Primitive = string | number | boolean | bigint | symbol | null | undefined;
+
+type PathFor<T> =
+  T extends Primitive
+    ? never
+    : T extends readonly (infer TEntry)[]
+      ? `${number}` | `${number}.${PathFor<TEntry>}`
+      : T extends object
+        ? {
+            [K in Extract<keyof T, string>]: K | `${K}.${PathFor<T[K]>}`;
+          }[Extract<keyof T, string>]
+        : never;
+
+type PathArg<T> = unknown extends T ? string : PathFor<T>;
+
+type ContractStep<TContracts extends FlowContracts> = Extract<keyof TContracts, string>;
+
+type ContractOutput<TContracts extends FlowContracts, TStep extends ContractStep<TContracts>> =
   TStep extends keyof TContracts
     ? TContracts[TStep] extends { outputSchema?: infer TSchema }
       ? TSchema extends { _output: infer TOutput }
@@ -9,21 +26,24 @@ type ContractOutput<TContracts extends FlowContracts, TStep extends string> =
       : unknown
     : unknown;
 
-type ContractOutputs<TContracts extends FlowContracts, TStepIds extends readonly string[]> = {
+type ContractOutputs<TContracts extends FlowContracts, TStepIds extends readonly ContractStep<TContracts>[]> = {
   [K in TStepIds[number]]: ContractOutput<TContracts, K>;
 };
 
-export function fromStep<TContracts extends FlowContracts = FlowContracts, TStep extends string = string>(
+export function fromStep<
+  TContracts extends FlowContracts = FlowContracts,
+  TStep extends ContractStep<TContracts> = ContractStep<TContracts>,
+>(
   stepId: TStep,
-  path?: string,
+  path?: PathArg<ContractOutput<TContracts, TStep>>,
 ): DataRef<ContractOutput<TContracts, TStep>> {
   return { kind: 'fromStep', stepId, path };
 }
 
 export function fromSteps<
   TContracts extends FlowContracts = FlowContracts,
-  TStepIds extends readonly string[] = readonly string[],
->(stepIds: TStepIds, path?: string): DataRef<ContractOutputs<TContracts, TStepIds>> {
+  TStepIds extends readonly ContractStep<TContracts>[] = readonly ContractStep<TContracts>[],
+>(stepIds: TStepIds, path?: PathArg<ContractOutput<TContracts, TStepIds[number]>>): DataRef<ContractOutputs<TContracts, TStepIds>> {
   return { kind: 'fromSteps', stepIds, path };
 }
 


### PR DESCRIPTION
## Summary
- enforce compile-time step-id validity in `fromStep` / `fromSteps` for contract-driven flows
- add typed producer path inference for routed outputs (dot-paths now checked against producer output type)
- expand flow typecheck assertions for invalid producer IDs and invalid producer output paths

## Why
Issue #295 requires stronger inter-agent data contract enforcement at compile time in addition to existing runtime and static flow validation.

## Changes
- updated `packages/framework/src/flow/refs.ts`
  - constrain step IDs to known `FlowContracts` keys
  - add typed path support via `PathFor<T>` and `PathArg<T>`
- updated `packages/framework/src/flow/contracts.typecheck.ts`
  - added `@ts-expect-error` checks for:
    - invalid producer output path
    - invalid producer step reference

## Validation
- `npm run test -- packages/framework/__tests__/flow/runner.test.ts`
- `npm run build`

Closes #295