### PR TITLE
fix(pr-composition): launch conflict-resolver for strip replay conflicts (#273)

### DIFF
--- a/src/executors/pr-composition-phase-executor.ts
+++ b/src/executors/pr-composition-phase-executor.ts
@@ -135,7 +135,46 @@ export class PRCompositionPhaseExecutor implements PhaseExecutor {
 
   /** Strip cadre artefacts, push, and open the pull request. */
   private async createPullRequest(ctx: PhaseContext, prContent: PRContent, originalDiff: string): Promise<void> {
-    await ctx.io.commitManager.stripCadreFiles(ctx.worktree.baseCommit);
+    await ctx.io.commitManager.stripCadreFiles(
+      ctx.worktree.baseCommit,
+      async (conflictedFiles: string[], commitSha: string) => {
+        ctx.services.logger.warn(
+          `stripCadreFiles encountered merge conflicts while replaying ${commitSha.slice(0, 8)}; launching conflict-resolver`,
+          {
+            issueNumber: ctx.issue.number,
+            data: { conflictedFiles },
+          },
+        );
+
+        const contextPath = await ctx.services.contextBuilder.build('conflict-resolver', {
+          issueNumber: ctx.issue.number,
+          worktreePath: ctx.worktree.path,
+          conflictedFiles,
+          progressDir: ctx.io.progressDir,
+        });
+
+        const resolverResult = await launchWithRetry(ctx, 'conflict-resolver', {
+          agent: 'conflict-resolver',
+          issueNumber: ctx.issue.number,
+          phase: 5,
+          contextPath,
+          outputPath: join(ctx.io.progressDir, 'conflict-resolution-report.md'),
+        });
+
+        if (!resolverResult.success) {
+          const detail = resolverResult.timedOut
+            ? `timed out after ${resolverResult.duration}ms`
+            : `exit ${resolverResult.exitCode}`;
+          throw new Error(`Conflict-resolver agent failed during PR composition (${detail})`);
+        }
+
+        if (!resolverResult.outputExists) {
+          throw new Error(
+            `Conflict-resolver agent exited successfully but produced no output at ${resolverResult.outputPath}`,
+          );
+        }
+      },
+    );
 
     // Guard: if stripping removed all content from a non-empty diff, abort before pushing.
     const postStripDiff = await ctx.io.commitManager.getDiff(ctx.worktree.baseCommit);

--- a/src/git/commit.ts
+++ b/src/git/commit.ts
@@ -162,7 +162,10 @@ export class CommitManager {
    *
    * This preserves individual commit granularity in the PR, unlike a squash approach.
    */
-  async stripCadreFiles(baseCommit: string): Promise<void> {
+  async stripCadreFiles(
+    baseCommit: string,
+    resolveConflicts?: (conflictedFiles: string[], commitSha: string) => Promise<void>,
+  ): Promise<void> {
     const logOutput = (
       await this.git.raw(['log', '--format=%H', '--reverse', `${baseCommit}..HEAD`])
     ).trim();
@@ -194,7 +197,25 @@ export class CommitManager {
         await this.git.raw(['restore', '--', pattern]).catch(() => {});
       }
 
-      const status = await this.git.status();
+      let status = await this.git.status();
+      const conflictedFiles = this.getConflictedFiles(status);
+      if (conflictedFiles.length > 0) {
+        if (!resolveConflicts) {
+          throw new Error(
+            `stripCadreFiles encountered unresolved merge conflicts while replaying ${sha.slice(0, 8)}: ${conflictedFiles.join(', ')}`,
+          );
+        }
+
+        await resolveConflicts(conflictedFiles, sha);
+        status = await this.git.status();
+        const remainingConflicts = this.getConflictedFiles(status);
+        if (remainingConflicts.length > 0) {
+          throw new Error(
+            `stripCadreFiles conflict resolution incomplete for ${sha.slice(0, 8)}: ${remainingConflicts.join(', ')}`,
+          );
+        }
+      }
+
       if (status.staged.length === 0) {
         // Commit consisted entirely of cadre files — drop it and clean up.
         await this.git.reset(['--hard', 'HEAD']).catch(() => {});
@@ -213,6 +234,21 @@ export class CommitManager {
     this.logger.info(
       `stripCadreFiles: rewrote ${rewritten} commit(s), dropped ${dropped} cadre-only commit(s)`,
     );
+  }
+
+  private getConflictedFiles(status: Awaited<ReturnType<SimpleGit['status']>>): string[] {
+    const fromStatus = Array.isArray(status.conflicted)
+      ? status.conflicted.filter((file): file is string => typeof file === 'string' && file.length > 0)
+      : [];
+
+    const fromFiles = Array.isArray(status.files)
+      ? status.files
+          .filter((file) => file.index === 'U' || file.working_dir === 'U')
+          .map((file) => file.path)
+          .filter((file): file is string => typeof file === 'string' && file.length > 0)
+      : [];
+
+    return [...new Set([...fromStatus, ...fromFiles])];
   }
 
   /**

--- a/tests/git-commit.test.ts
+++ b/tests/git-commit.test.ts
@@ -381,6 +381,47 @@ describe('CommitManager', () => {
 
       await expect(manager.stripCadreFiles('base123')).resolves.toBeUndefined();
     });
+
+    it('should call resolveConflicts callback when strip replay detects unmerged files', async () => {
+      mockGit.raw
+        .mockResolvedValueOnce('deadbeef\n')
+        .mockResolvedValue('');
+
+      mockGit.status
+        .mockResolvedValueOnce({
+          isClean: () => false,
+          staged: ['src/index.ts'],
+          conflicted: ['package-lock.json'],
+          files: [{ path: 'package-lock.json', index: 'U', working_dir: 'U' }],
+        })
+        .mockResolvedValueOnce({
+          isClean: () => false,
+          staged: ['src/index.ts'],
+          conflicted: [],
+          files: [{ path: 'src/index.ts' }],
+        });
+
+      const resolveConflicts = vi.fn().mockResolvedValue(undefined);
+
+      await manager.stripCadreFiles('base123', resolveConflicts);
+
+      expect(resolveConflicts).toHaveBeenCalledWith(['package-lock.json'], 'deadbeef');
+    });
+
+    it('should throw when unmerged files exist and no resolver callback is provided', async () => {
+      mockGit.raw
+        .mockResolvedValueOnce('deadbeef\n')
+        .mockResolvedValue('');
+
+      mockGit.status.mockResolvedValue({
+        isClean: () => false,
+        staged: ['src/index.ts'],
+        conflicted: ['package-lock.json'],
+        files: [{ path: 'package-lock.json', index: 'U', working_dir: 'U' }],
+      });
+
+      await expect(manager.stripCadreFiles('base123')).rejects.toThrow(/unresolved merge conflicts/);
+    });
   });
 
   describe('commit with sign', () => {

--- a/tests/pr-composition-phase-executor.test.ts
+++ b/tests/pr-composition-phase-executor.test.ts
@@ -325,7 +325,7 @@ describe('PRCompositionPhaseExecutor', () => {
       await executor.execute(ctx);
       expect(
         (ctx.io.commitManager as never as { stripCadreFiles: ReturnType<typeof vi.fn> }).stripCadreFiles,
-      ).toHaveBeenCalledWith('abc123');
+      ).toHaveBeenCalledWith('abc123', expect.any(Function));
     });
 
     it('should call stripCadreFiles even when squashBeforePR is true', async () => {
@@ -340,7 +340,7 @@ describe('PRCompositionPhaseExecutor', () => {
       await executor.execute(ctx);
       expect(
         (ctx.io.commitManager as never as { stripCadreFiles: ReturnType<typeof vi.fn> }).stripCadreFiles,
-      ).toHaveBeenCalledWith('abc123');
+      ).toHaveBeenCalledWith('abc123', expect.any(Function));
     });
 
     it('should use issue title as stripCadreFiles message fallback when PR title is empty', async () => {
@@ -353,7 +353,67 @@ describe('PRCompositionPhaseExecutor', () => {
       await executor.execute(ctx);
       expect(
         (ctx.io.commitManager as never as { stripCadreFiles: ReturnType<typeof vi.fn> }).stripCadreFiles,
-      ).toHaveBeenCalledWith('abc123');
+      ).toHaveBeenCalledWith('abc123', expect.any(Function));
+    });
+
+    it('should launch conflict-resolver when stripCadreFiles reports conflicts', async () => {
+      const stripCadreFiles = vi.fn().mockImplementation(async (_baseCommit: string, resolver: (files: string[], sha: string) => Promise<void>) => {
+        await resolver(['package-lock.json'], 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef');
+      });
+
+      const contextBuilder = {
+        build: vi.fn()
+          .mockResolvedValueOnce('/progress/composer-ctx.json')
+          .mockResolvedValueOnce('/progress/conflict-ctx.json'),
+      };
+
+      const launcher = {
+        launchAgent: vi.fn(async (invocation: { agent: string }) => {
+          if (invocation.agent === 'conflict-resolver') {
+            return makeSuccessAgentResult('conflict-resolver');
+          }
+          return makeSuccessAgentResult('pr-composer');
+        }),
+      };
+
+      const ctx = makeAutoCreateCtx({
+        services: {
+          contextBuilder: contextBuilder as never,
+          launcher: launcher as never,
+        } as never,
+        io: {
+          progressDir: '/tmp/progress',
+          progressWriter: {} as never,
+          checkpoint: {} as never,
+          commitManager: {
+            getDiff: vi.fn().mockResolvedValue('diff content'),
+            squash: vi.fn().mockResolvedValue(undefined),
+            stripCadreFiles,
+            push: vi.fn().mockResolvedValue(undefined),
+          } as never,
+        },
+      });
+
+      await executor.execute(ctx);
+
+      expect(contextBuilder.build).toHaveBeenCalledWith(
+        'conflict-resolver',
+        expect.objectContaining({
+          issueNumber: 42,
+          worktreePath: '/tmp/worktree',
+          conflictedFiles: ['package-lock.json'],
+          progressDir: '/tmp/progress',
+        }),
+      );
+      expect(launcher.launchAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: 'conflict-resolver',
+          phase: 5,
+          contextPath: '/progress/conflict-ctx.json',
+          outputPath: join('/tmp/progress', 'conflict-resolution-report.md'),
+        }),
+        '/tmp/worktree',
+      );
     });
 
     it('should append issue link suffix when linkIssue is true', async () => {


### PR DESCRIPTION
## Summary
- launch `conflict-resolver` during PR composition when `stripCadreFiles` replay leaves unmerged files
- add conflict detection in `CommitManager.stripCadreFiles` and fail if conflicts remain unresolved
- add tests for callback invocation and PR-phase conflict resolver launch

## Validation
- `npm run test -- tests/pr-composition-phase-executor.test.ts tests/git-commit.test.ts`

Closes #273