### PR TITLE
fix(pr): auto-resolve dirty merge blockers during auto-complete

### DIFF
--- a/src/executors/pr-composition-phase-executor.ts
+++ b/src/executors/pr-composition-phase-executor.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
 import { writeFile } from 'node:fs/promises';
+import { simpleGit } from 'simple-git';
 import type { PhaseExecutor, PhaseContext } from '../core/phase-executor.js';
 import { launchWithRetry } from './helpers.js';
 import { isCadreSelfRun } from '../util/cadre-self-run.js';
@@ -10,6 +11,9 @@ import { formatPullRequestTitle } from '../util/title-format.js';
 
 /** Maximum total invocations (initial + retries) when pr-content.md fails to parse. */
 const MAX_ATTEMPTS = 2;
+const MAX_MERGE_RESOLUTION_ATTEMPTS = 2;
+
+type MergeBlockReason = 'dirty' | 'checks-failed' | 'blocked';
 
 export class PRCompositionPhaseExecutor implements PhaseExecutor {
   readonly phaseId = 5;
@@ -183,17 +187,162 @@ export class PRCompositionPhaseExecutor implements PhaseExecutor {
         ? 'squash'
         : (autoComplete.merge_method ?? 'squash');
 
+    for (let attempt = 1; attempt <= MAX_MERGE_RESOLUTION_ATTEMPTS; attempt++) {
+      try {
+        await ctx.platform.mergePullRequest(prNumber, ctx.config.baseBranch, mergeMethod);
+        ctx.services.logger.info(
+          `Auto-completed PR #${prNumber} into ${ctx.config.baseBranch} using ${mergeMethod} merge`,
+          { issueNumber: ctx.issue.number },
+        );
+        return;
+      } catch (err) {
+        const reason = this.detectMergeBlockReason(err);
+        if (reason == null || attempt >= MAX_MERGE_RESOLUTION_ATTEMPTS) {
+          ctx.services.logger.warn(
+            `Auto-complete failed for PR #${prNumber}: ${String(err)}`,
+            { issueNumber: ctx.issue.number },
+          );
+          return;
+        }
+
+        ctx.services.logger.info(
+          `PR #${prNumber} merge blocked (${reason}); launching auto-resolution (attempt ${attempt}/${MAX_MERGE_RESOLUTION_ATTEMPTS})`,
+          { issueNumber: ctx.issue.number },
+        );
+        await this.autoResolveMergeBlock(ctx, prNumber, reason, String(err));
+      }
+    }
+  }
+
+  private detectMergeBlockReason(err: unknown): MergeBlockReason | null {
+    const message = String(err).toLowerCase();
+    if (
+      message.includes('mergeable_state=dirty')
+      || message.includes('has merge conflicts')
+      || message.includes('merge conflicts')
+    ) {
+      return 'dirty';
+    }
+    if (message.includes('checks failed')) {
+      return 'checks-failed';
+    }
+    if (message.includes('mergeable_state=blocked') || message.includes('blocked')) {
+      return 'blocked';
+    }
+    return null;
+  }
+
+  private async autoResolveMergeBlock(
+    ctx: PhaseContext,
+    prNumber: number,
+    reason: MergeBlockReason,
+    details: string,
+  ): Promise<void> {
+    if (reason === 'dirty') {
+      await this.resolveMergeConflicts(ctx, prNumber, details);
+      return;
+    }
+
+    await this.resolveCheckOrPolicyBlock(ctx, reason, details);
+  }
+
+  private async resolveMergeConflicts(ctx: PhaseContext, prNumber: number, details: string): Promise<void> {
+    const git = simpleGit(ctx.worktree.path);
+    await git.fetch('origin', ctx.config.baseBranch);
+
     try {
-      await ctx.platform.mergePullRequest(prNumber, ctx.config.baseBranch, mergeMethod);
-      ctx.services.logger.info(
-        `Auto-completed PR #${prNumber} into ${ctx.config.baseBranch} using ${mergeMethod} merge`,
-        { issueNumber: ctx.issue.number },
-      );
-    } catch (err) {
-      ctx.services.logger.warn(
-        `Auto-complete failed for PR #${prNumber}: ${String(err)}`,
-        { issueNumber: ctx.issue.number },
-      );
+      await git.merge([`origin/${ctx.config.baseBranch}`, '--no-edit']);
+    } catch {
+      const conflictedFiles = await this.getConflictedFiles(git);
+      if (conflictedFiles.length === 0) {
+        throw new Error(`PR #${prNumber} reported dirty merge state, but no conflicted files were detected`);
+      }
+
+      const conflictDetailsPath = join(ctx.io.progressDir, 'merge-conflict-details.txt');
+      await writeFile(conflictDetailsPath, details, 'utf-8');
+
+      const contextPath = await ctx.services.contextBuilder.build('conflict-resolver', {
+        issueNumber: ctx.issue.number,
+        worktreePath: ctx.worktree.path,
+        conflictedFiles,
+        progressDir: ctx.io.progressDir,
+      });
+
+      const resolverResult = await launchWithRetry(ctx, 'conflict-resolver', {
+        agent: 'conflict-resolver',
+        issueNumber: ctx.issue.number,
+        phase: 5,
+        contextPath,
+        outputPath: join(ctx.io.progressDir, 'merge-conflict-resolution-report.md'),
+      });
+
+      if (!resolverResult.success) {
+        throw new Error(`conflict-resolver failed while resolving PR #${prNumber} merge conflicts`);
+      }
+
+      if (!resolverResult.outputExists) {
+        throw new Error('conflict-resolver completed without producing merge conflict report output');
+      }
+
+      await git.add(['-A']);
+      await git.raw(['commit', '--no-edit']);
+    }
+
+    await ctx.io.commitManager.push(true, ctx.worktree.branch);
+  }
+
+  private async resolveCheckOrPolicyBlock(
+    ctx: PhaseContext,
+    reason: MergeBlockReason,
+    details: string,
+  ): Promise<void> {
+    const feedbackPath = join(ctx.io.progressDir, 'merge-blocker-feedback.txt');
+    await writeFile(
+      feedbackPath,
+      `PR merge blocked: ${reason}\n\n${details}\n`,
+      'utf-8',
+    );
+
+    const changedFiles = await ctx.io.commitManager.getChangedFiles();
+    const contextPath = await ctx.services.contextBuilder.build('fix-surgeon', {
+      issueNumber: ctx.issue.number,
+      worktreePath: ctx.worktree.path,
+      sessionId: `merge-block-${reason}`,
+      feedbackPath,
+      changedFiles: changedFiles.map((f) => join(ctx.worktree.path, f)),
+      progressDir: ctx.io.progressDir,
+      issueType: 'test-failure',
+      phase: 5,
+    });
+
+    const fixResult = await launchWithRetry(ctx, 'fix-surgeon', {
+      agent: 'fix-surgeon',
+      issueNumber: ctx.issue.number,
+      phase: 5,
+      contextPath,
+      outputPath: ctx.worktree.path,
+    });
+
+    if (!fixResult.success) {
+      throw new Error(`fix-surgeon failed while resolving merge blocker (${reason})`);
+    }
+
+    if (!(await ctx.io.commitManager.isClean())) {
+      await ctx.io.commitManager.commit('address merge blocker', ctx.issue.number, 'fix');
+      await ctx.io.commitManager.push(true, ctx.worktree.branch);
+    }
+  }
+
+  private async getConflictedFiles(git: ReturnType<typeof simpleGit>): Promise<string[]> {
+    try {
+      const output = await git.raw(['diff', '--name-only', '--diff-filter=U']);
+      return output
+        .trim()
+        .split('\n')
+        .map((file) => file.trim())
+        .filter((file) => file.length > 0);
+    } catch {
+      return [];
     }
   }
 

--- a/src/platform/github-provider.ts
+++ b/src/platform/github-provider.ts
@@ -346,6 +346,12 @@ export class GitHubProvider implements PlatformProvider {
           this.logger.warn(`Could not update PR #${prNumber} branch from base: ${String(err)}`);
         }
       }
+      if (mergeableState === 'dirty') {
+        throw new Error(`PR #${prNumber} has merge conflicts (mergeable_state=dirty)`);
+      }
+      if (mergeableState === 'blocked' && pr.mergeable === false) {
+        throw new Error(`PR #${prNumber} is blocked (mergeable_state=blocked)`);
+      }
 
       const checks = await this.getCheckHealth(oct, headSha);
       if (checks.failed.length > 0) {

--- a/tests/github-provider-parsing.test.ts
+++ b/tests/github-provider-parsing.test.ts
@@ -1272,6 +1272,33 @@ describe('GitHubProvider – mergePullRequest', () => {
     expect(mergeMock).toHaveBeenCalledTimes(2);
   });
 
+  it('fails fast when mergeable_state is dirty', async () => {
+    const mergeMock = vi.fn().mockRejectedValueOnce({ status: 409 });
+    const mockOctokit = {
+      rest: {
+        pulls: {
+          merge: mergeMock,
+          get: vi.fn().mockResolvedValue({
+            data: {
+              merged: false,
+              state: 'open',
+              head: { sha: 'deadbeef' },
+              mergeable: false,
+              mergeable_state: 'dirty',
+            },
+          }),
+          updateBranch: vi.fn(),
+        },
+        repos: { getCombinedStatusForRef: vi.fn() },
+        checks: { listForRef: vi.fn() },
+      },
+    };
+
+    const provider = new GitHubProvider('owner/repo', mockLogger, mockOctokit as any);
+
+    await expect(provider.mergePullRequest(151, 'main')).rejects.toThrow('mergeable_state=dirty');
+  });
+
   it('throws when combined commit statuses are failing with no named contexts', async () => {
     const mergeMock = vi.fn().mockRejectedValueOnce({ status: 409 });
     const mockOctokit = {

--- a/tests/pr-composition-phase-executor.test.ts
+++ b/tests/pr-composition-phase-executor.test.ts
@@ -8,6 +8,17 @@ vi.mock('node:fs/promises', () => ({
   writeFile: vi.fn().mockResolvedValue(undefined),
 }));
 
+const mockGit = {
+  fetch: vi.fn().mockResolvedValue(undefined),
+  merge: vi.fn().mockResolvedValue(undefined),
+  raw: vi.fn().mockResolvedValue(''),
+  add: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('simple-git', () => ({
+  simpleGit: vi.fn(() => mockGit),
+}));
+
 import { writeFile } from 'node:fs/promises';
 
 function makeSuccessAgentResult(agent: string): AgentResult {
@@ -59,6 +70,9 @@ function makeCtx(overrides: Partial<PhaseContext> = {}): PhaseContext {
     getDiff: vi.fn().mockResolvedValue('diff content'),
     squash: vi.fn().mockResolvedValue(undefined),
     stripCadreFiles: vi.fn().mockResolvedValue(undefined),
+    getChangedFiles: vi.fn().mockResolvedValue([]),
+    isClean: vi.fn().mockResolvedValue(true),
+    commit: vi.fn().mockResolvedValue(''),
     push: vi.fn().mockResolvedValue(undefined),
   };
 
@@ -133,6 +147,10 @@ describe('PRCompositionPhaseExecutor', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGit.fetch.mockResolvedValue(undefined);
+    mockGit.merge.mockResolvedValue(undefined);
+    mockGit.raw.mockResolvedValue('');
+    mockGit.add.mockResolvedValue(undefined);
     executor = new PRCompositionPhaseExecutor();
   });
 
@@ -380,6 +398,100 @@ describe('PRCompositionPhaseExecutor', () => {
       await executor.execute(ctx);
 
       expect(platform.mergePullRequest).toHaveBeenCalledWith(101, 'main', 'squash');
+    });
+
+    it('should auto-resolve dirty merge blockers and retry auto-complete', async () => {
+      const prInfo = { number: 105, url: 'https://github.com/owner/repo/pull/105', title: 'Fix' };
+      const platform = {
+        issueLinkSuffix: vi.fn().mockReturnValue(''),
+        createPullRequest: vi.fn().mockResolvedValue(prInfo),
+        updatePullRequest: vi.fn().mockResolvedValue(undefined),
+        findOpenPR: vi.fn().mockResolvedValue(null),
+        mergePullRequest: vi
+          .fn()
+          .mockRejectedValueOnce(new Error('PR #105 has merge conflicts (mergeable_state=dirty)'))
+          .mockResolvedValueOnce(undefined),
+      };
+      mockGit.fetch.mockResolvedValue(undefined);
+      mockGit.merge.mockRejectedValueOnce(new Error('conflict'));
+      mockGit.raw.mockImplementation(async (args: string[]) => {
+        if (args.join(' ').includes('--diff-filter=U')) {
+          return 'packages/api/tests/index.test.ts\n';
+        }
+        return '';
+      });
+
+      const ctx = makeAutoCreateCtx({
+        config: {
+          options: { maxRetriesPerTask: 3 },
+          pullRequest: { autoCreate: true, autoComplete: true, linkIssue: false, draft: false, labels: [], reviewers: [] },
+          commits: { squashBeforePR: false },
+          baseBranch: 'main',
+        } as never,
+        platform: platform as never,
+      });
+
+      await executor.execute(ctx);
+
+      expect(platform.mergePullRequest).toHaveBeenCalledTimes(2);
+      expect(
+        (ctx.services.contextBuilder as never as { build: ReturnType<typeof vi.fn> }).build,
+      ).toHaveBeenCalledWith(
+        'conflict-resolver',
+        expect.objectContaining({
+          issueNumber: 42,
+          conflictedFiles: ['packages/api/tests/index.test.ts'],
+        }),
+      );
+      expect(mockGit.add).toHaveBeenCalledWith(['-A']);
+    });
+
+    it('should auto-resolve failed checks with fix-surgeon and retry auto-complete', async () => {
+      const prInfo = { number: 106, url: 'https://github.com/owner/repo/pull/106', title: 'Fix' };
+      const platform = {
+        issueLinkSuffix: vi.fn().mockReturnValue(''),
+        createPullRequest: vi.fn().mockResolvedValue(prInfo),
+        updatePullRequest: vi.fn().mockResolvedValue(undefined),
+        findOpenPR: vi.fn().mockResolvedValue(null),
+        mergePullRequest: vi
+          .fn()
+          .mockRejectedValueOnce(new Error('PR #106 checks failed: build'))
+          .mockResolvedValueOnce(undefined),
+      };
+
+      const ctx = makeAutoCreateCtx({
+        config: {
+          options: { maxRetriesPerTask: 3 },
+          pullRequest: { autoCreate: true, autoComplete: true, linkIssue: false, draft: false, labels: [], reviewers: [] },
+          commits: { squashBeforePR: false },
+          baseBranch: 'main',
+        } as never,
+        platform: platform as never,
+      });
+
+      const commitManager = ctx.io.commitManager as never as {
+        getChangedFiles: ReturnType<typeof vi.fn>;
+        isClean: ReturnType<typeof vi.fn>;
+        commit: ReturnType<typeof vi.fn>;
+        push: ReturnType<typeof vi.fn>;
+      };
+      commitManager.getChangedFiles.mockResolvedValue(['packages/api/src/index.ts']);
+      commitManager.isClean.mockResolvedValue(false);
+
+      await executor.execute(ctx);
+
+      expect(platform.mergePullRequest).toHaveBeenCalledTimes(2);
+      expect(
+        (ctx.services.contextBuilder as never as { build: ReturnType<typeof vi.fn> }).build,
+      ).toHaveBeenCalledWith(
+        'fix-surgeon',
+        expect.objectContaining({
+          sessionId: 'merge-block-checks-failed',
+          issueType: 'test-failure',
+          phase: 5,
+        }),
+      );
+      expect(commitManager.commit).toHaveBeenCalledWith('address merge blocker', 42, 'fix');
     });
 
     it('should not auto-complete PR when pullRequest.autoComplete is false', async () => {


### PR DESCRIPTION
## Summary
- fail fast when GitHub readiness polling reports merge conflicts or blocked mergeability
- auto-resolve merge blockers during PR auto-complete by launching agents and retrying merge
- use conflict-resolver for dirty conflicts (merge base branch, resolve, commit, push)
- use fix-surgeon for failed checks/policy blockers, then commit/push and retry
- add test coverage for dirty-state fail-fast and remediation retries

## Validation
- npm run test -- tests/pr-composition-phase-executor.test.ts tests/github-provider-parsing.test.ts