### PR TITLE
fix(pr): add conflict auto-resolution to PR completion queue

### DIFF
--- a/src/core/fleet-orchestrator.ts
+++ b/src/core/fleet-orchestrator.ts
@@ -1,4 +1,6 @@
 import { join } from 'node:path';
+import { writeFile } from 'node:fs/promises';
+import { simpleGit } from 'simple-git';
 import type { RuntimeConfig } from '../config/loader.js';
 import type { IssueDetail, PullRequestInfo } from '../platform/provider.js';
 import type { PlatformProvider } from '../platform/provider.js';
@@ -16,7 +18,7 @@ import { ensureDir } from '../util/fs.js';
 import type { DependencyMergeConflictContext } from '../git/dependency-branch-merger.js';
 import { FleetReporter } from './fleet-reporter.js';
 import { FleetScheduler } from './fleet-scheduler.js';
-import { PullRequestCompletionQueue, type CompletionFailure } from './pr-completion-queue.js';
+import { PullRequestCompletionQueue, type CompletionFailure, type MergeConflictResolverFn } from './pr-completion-queue.js';
 import type { PullRequestMergeMethod } from '../platform/provider.js';
 
 export interface FleetResult {
@@ -87,6 +89,7 @@ export class FleetOrchestrator {
         return status === 'completed';
       },
       this.config.options.maxParallelIssues,
+      autoComplete.enabled ? this.buildCompletionQueueConflictResolver() : undefined,
     );
   }
 
@@ -182,6 +185,91 @@ export class FleetOrchestrator {
       enabled: autoComplete.enabled ?? false,
       mergeMethod: autoComplete.merge_method ?? 'squash',
     };
+  }
+
+  /**
+   * Build a conflict resolver callback for the PR completion queue.
+   *
+   * When a pre-existing PR cannot merge due to dirty state, this callback
+   * resolves the conflict using the same approach as the PR composition phase:
+   * fetch base, attempt merge, detect conflicted files, launch conflict-resolver
+   * agent, commit, and push.
+   */
+  private buildCompletionQueueConflictResolver(): MergeConflictResolverFn {
+    return async (item, errorDetails) => {
+      const worktreePath = this.worktreeManager.getWorktreePath(item.issueNumber);
+      const progressDir = join(this.cadreDir, 'issues', String(item.issueNumber));
+      await ensureDir(progressDir);
+
+      const git = simpleGit(worktreePath);
+      await git.fetch('origin', this.config.baseBranch);
+
+      try {
+        await git.merge([`origin/${this.config.baseBranch}`, '--no-edit']);
+      } catch {
+        const conflictedFiles = await this.getConflictedFiles(git);
+        if (conflictedFiles.length === 0) {
+          this.logger.warn(
+            `PR #${item.prNumber} reported dirty merge state, but no conflicted files were detected`,
+            { issueNumber: item.issueNumber },
+          );
+          return false;
+        }
+
+        const conflictDetailsPath = join(progressDir, 'merge-conflict-details.txt');
+        await writeFile(conflictDetailsPath, errorDetails, 'utf-8');
+
+        const contextPath = await this.contextBuilder.build('conflict-resolver', {
+          issueNumber: item.issueNumber,
+          worktreePath,
+          conflictedFiles,
+          progressDir,
+        });
+
+        const resolverResult = await this.launcher.launchAgent(
+          {
+            agent: 'conflict-resolver',
+            issueNumber: item.issueNumber,
+            phase: 5,
+            contextPath,
+            outputPath: join(progressDir, 'merge-conflict-resolution-report.md'),
+          },
+          worktreePath,
+        );
+
+        if (!resolverResult.success) {
+          this.logger.warn(
+            `conflict-resolver failed for existing PR #${item.prNumber}`,
+            { issueNumber: item.issueNumber },
+          );
+          return false;
+        }
+
+        await git.add(['-A']);
+        await git.raw(['commit', '--no-edit']);
+      }
+
+      // Push the resolved merge
+      await git.push('origin', item.branch, ['--force-with-lease']);
+      this.logger.info(
+        `Resolved merge conflicts for existing PR #${item.prNumber} and pushed`,
+        { issueNumber: item.issueNumber },
+      );
+      return true;
+    };
+  }
+
+  private async getConflictedFiles(git: ReturnType<typeof simpleGit>): Promise<string[]> {
+    try {
+      const output = await git.raw(['diff', '--name-only', '--diff-filter=U']);
+      return output
+        .trim()
+        .split('\n')
+        .map((file) => file.trim())
+        .filter((file) => file.length > 0);
+    } catch {
+      return [];
+    }
   }
 
   /**

--- a/src/core/pr-completion-queue.ts
+++ b/src/core/pr-completion-queue.ts
@@ -13,6 +13,15 @@ interface QueueItem {
 
 type DependencySatisfiedFn = (dependencyIssueNumber: number) => boolean | Promise<boolean>;
 
+/**
+ * Callback invoked when a PR merge fails due to conflicts (dirty state).
+ * Should attempt to resolve the conflicts and return `true` if resolved.
+ */
+export type MergeConflictResolverFn = (
+  item: QueueItem,
+  errorDetails: string,
+) => Promise<boolean>;
+
 export interface CompletionFailure {
   issueNumber: number;
   issueTitle: string;
@@ -21,6 +30,9 @@ export interface CompletionFailure {
   branch: string;
   error: string;
 }
+
+/** Maximum merge + resolve attempts per PR when a conflict resolver is provided. */
+const MAX_MERGE_RESOLUTION_ATTEMPTS = 2;
 
 /**
  * Dedicated subsystem that queues and processes PR auto-completion work.
@@ -46,6 +58,7 @@ export class PullRequestCompletionQueue {
     private readonly enabled: boolean,
     private readonly isDependencySatisfied: DependencySatisfiedFn,
     concurrency: number,
+    private readonly conflictResolver?: MergeConflictResolverFn,
   ) {
     this.limit = pLimit(Math.max(1, concurrency));
   }
@@ -117,28 +130,65 @@ export class PullRequestCompletionQueue {
     }
 
     await this.limit(async () => {
-      try {
-        await this.platform.mergePullRequest(item.prNumber, this.baseBranch, this.mergeMethod);
-        this.logger.info(
-          `Auto-completed existing PR #${item.prNumber} into ${this.baseBranch} using ${this.mergeMethod} merge`,
-          {
-            issueNumber: item.issueNumber,
-            data: { prUrl: item.prUrl, branch: item.branch },
-          },
-        );
-      } catch (err) {
-        const error = String(err);
-        this.failedIssueNumbers.add(item.issueNumber);
-        this.failures.push({ ...item, error });
-        this.logger.warn(
-          `Auto-complete failed for existing PR #${item.prNumber}: ${error}`,
-          {
-            issueNumber: item.issueNumber,
-            data: { prUrl: item.prUrl, branch: item.branch },
-          },
-        );
+      const maxAttempts = this.conflictResolver ? MAX_MERGE_RESOLUTION_ATTEMPTS : 1;
+
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          await this.platform.mergePullRequest(item.prNumber, this.baseBranch, this.mergeMethod);
+          this.logger.info(
+            `Auto-completed existing PR #${item.prNumber} into ${this.baseBranch} using ${this.mergeMethod} merge`,
+            {
+              issueNumber: item.issueNumber,
+              data: { prUrl: item.prUrl, branch: item.branch },
+            },
+          );
+          return;
+        } catch (err) {
+          const error = String(err);
+          const isDirty = this.isMergeConflict(error);
+
+          if (isDirty && this.conflictResolver && attempt < maxAttempts) {
+            this.logger.info(
+              `PR #${item.prNumber} merge blocked (dirty); launching auto-resolution (attempt ${attempt}/${maxAttempts})`,
+              {
+                issueNumber: item.issueNumber,
+                data: { prUrl: item.prUrl, branch: item.branch },
+              },
+            );
+
+            try {
+              const resolved = await this.conflictResolver(item, error);
+              if (resolved) continue;
+            } catch (resolveErr) {
+              this.logger.warn(
+                `Conflict resolver failed for PR #${item.prNumber}: ${String(resolveErr)}`,
+                { issueNumber: item.issueNumber },
+              );
+            }
+          }
+
+          this.failedIssueNumbers.add(item.issueNumber);
+          this.failures.push({ ...item, error });
+          this.logger.warn(
+            `Auto-complete failed for existing PR #${item.prNumber}: ${error}`,
+            {
+              issueNumber: item.issueNumber,
+              data: { prUrl: item.prUrl, branch: item.branch },
+            },
+          );
+          return;
+        }
       }
     });
+  }
+
+  private isMergeConflict(message: string): boolean {
+    const lower = message.toLowerCase();
+    return (
+      lower.includes('mergeable_state=dirty')
+      || lower.includes('has merge conflicts')
+      || lower.includes('merge conflicts')
+    );
   }
 
   private recordDependencyBlockedFailure(item: QueueItem, dependencyIssueNumber: number): void {

--- a/tests/pr-completion-queue.test.ts
+++ b/tests/pr-completion-queue.test.ts
@@ -220,4 +220,149 @@ describe('PullRequestCompletionQueue', () => {
     expect(logger.warn).not.toHaveBeenCalled();
     expect(queue.getFailures()).toEqual([]);
   });
+
+  describe('merge conflict resolution', () => {
+    it('invokes conflictResolver on dirty merge error and retries merge', async () => {
+      const conflictResolver = vi.fn().mockResolvedValue(true);
+      let callCount = 0;
+      mergePullRequest.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error('PR #101 has merge conflicts (mergeable_state=dirty)');
+        }
+      });
+
+      const queue = new PullRequestCompletionQueue(
+        platform,
+        logger,
+        'main',
+        'squash',
+        true,
+        vi.fn().mockResolvedValue(true),
+        1,
+        conflictResolver,
+      );
+
+      queue.enqueue(makeItem({ issueNumber: 60, prNumber: 601 }));
+      await queue.drain();
+
+      expect(conflictResolver).toHaveBeenCalledTimes(1);
+      expect(conflictResolver).toHaveBeenCalledWith(
+        expect.objectContaining({ issueNumber: 60, prNumber: 601 }),
+        expect.stringContaining('merge conflicts'),
+      );
+      expect(mergePullRequest).toHaveBeenCalledTimes(2);
+      expect(queue.getFailures()).toEqual([]);
+    });
+
+    it('records failure when conflictResolver returns false', async () => {
+      const conflictResolver = vi.fn().mockResolvedValue(false);
+      mergePullRequest.mockRejectedValue(
+        new Error('PR #701 has merge conflicts (mergeable_state=dirty)'),
+      );
+
+      const queue = new PullRequestCompletionQueue(
+        platform,
+        logger,
+        'main',
+        'squash',
+        true,
+        vi.fn().mockResolvedValue(true),
+        1,
+        conflictResolver,
+      );
+
+      queue.enqueue(makeItem({ issueNumber: 70, prNumber: 701 }));
+      await queue.drain();
+
+      expect(conflictResolver).toHaveBeenCalledTimes(1);
+      expect(queue.getFailures()).toEqual([
+        expect.objectContaining({
+          issueNumber: 70,
+          prNumber: 701,
+          error: expect.stringContaining('merge conflicts'),
+        }),
+      ]);
+    });
+
+    it('records failure when conflictResolver throws', async () => {
+      const conflictResolver = vi.fn().mockRejectedValue(new Error('resolver crashed'));
+      mergePullRequest.mockRejectedValue(
+        new Error('PR #801 has merge conflicts (mergeable_state=dirty)'),
+      );
+
+      const queue = new PullRequestCompletionQueue(
+        platform,
+        logger,
+        'main',
+        'squash',
+        true,
+        vi.fn().mockResolvedValue(true),
+        1,
+        conflictResolver,
+      );
+
+      queue.enqueue(makeItem({ issueNumber: 80, prNumber: 801 }));
+      await queue.drain();
+
+      expect(conflictResolver).toHaveBeenCalledTimes(1);
+      expect(queue.getFailures()).toEqual([
+        expect.objectContaining({ issueNumber: 80, prNumber: 801 }),
+      ]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Conflict resolver failed for PR #801'),
+        expect.any(Object),
+      );
+    });
+
+    it('does not invoke conflictResolver for non-dirty merge errors', async () => {
+      const conflictResolver = vi.fn().mockResolvedValue(true);
+      mergePullRequest.mockRejectedValue(new Error('some other merge error'));
+
+      const queue = new PullRequestCompletionQueue(
+        platform,
+        logger,
+        'main',
+        'squash',
+        true,
+        vi.fn().mockResolvedValue(true),
+        1,
+        conflictResolver,
+      );
+
+      queue.enqueue(makeItem({ issueNumber: 90, prNumber: 901 }));
+      await queue.drain();
+
+      expect(conflictResolver).not.toHaveBeenCalled();
+      expect(queue.getFailures()).toEqual([
+        expect.objectContaining({ issueNumber: 90, prNumber: 901 }),
+      ]);
+    });
+
+    it('does not attempt conflict resolution without a resolver even on dirty errors', async () => {
+      mergePullRequest.mockRejectedValue(
+        new Error('PR has merge conflicts (mergeable_state=dirty)'),
+      );
+
+      const queue = new PullRequestCompletionQueue(
+        platform,
+        logger,
+        'main',
+        'squash',
+        true,
+        vi.fn().mockResolvedValue(true),
+        1,
+        // no conflictResolver
+      );
+
+      queue.enqueue(makeItem({ issueNumber: 100, prNumber: 1001 }));
+      await queue.drain();
+
+      // Should fail immediately without retry
+      expect(mergePullRequest).toHaveBeenCalledTimes(1);
+      expect(queue.getFailures()).toEqual([
+        expect.objectContaining({ issueNumber: 100, prNumber: 1001 }),
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

When cadre resumes and finds existing open PRs, the `PullRequestCompletionQueue` attempted `mergePullRequest` but had **no conflict resolution** — it just recorded a failure and blocked all dependent issues. This meant PRs created in earlier runs that developed merge conflicts against `main` could never be auto-completed on resume.

The PR composition phase already had this capability (added in #336), but the completion queue — used for pre-existing PRs on resume — was missing it.

## Solution

- **`PullRequestCompletionQueue`**: Added an optional `MergeConflictResolverFn` callback, a retry loop (max 2 attempts) with dirty-merge detection via `isMergeConflict()`, and invocation of the resolver on conflict before retrying merge.

- **`FleetOrchestrator`**: Added `buildCompletionQueueConflictResolver()` that fetches base, attempts merge, detects conflicted files, launches the `conflict-resolver` agent, commits, and pushes — same approach as the PR composition phase. Wired into the `PullRequestCompletionQueue` constructor when auto-complete is enabled.

- **Tests**: 5 new test cases covering: successful resolution + retry, resolver returning false, resolver throwing, non-dirty errors skipping resolver, and no resolver provided. All 74 tests pass (12 completion queue + 62 fleet orchestrator).