### PR TITLE
fix(pr): add delay after conflict resolution before retrying merge

### DIFF
--- a/src/core/pr-completion-queue.ts
+++ b/src/core/pr-completion-queue.ts
@@ -32,7 +32,10 @@ export interface CompletionFailure {
 }
 
 /** Maximum merge + resolve attempts per PR when a conflict resolver is provided. */
-const MAX_MERGE_RESOLUTION_ATTEMPTS = 2;
+const MAX_MERGE_RESOLUTION_ATTEMPTS = 3;
+
+/** Delay (ms) after pushing conflict resolution before retrying merge, to let GitHub recalculate mergeable state. */
+const POST_RESOLVE_DELAY_MS = 15_000;
 
 /**
  * Dedicated subsystem that queues and processes PR auto-completion work.
@@ -59,6 +62,7 @@ export class PullRequestCompletionQueue {
     private readonly isDependencySatisfied: DependencySatisfiedFn,
     concurrency: number,
     private readonly conflictResolver?: MergeConflictResolverFn,
+    private readonly postResolveDelayMs: number = POST_RESOLVE_DELAY_MS,
   ) {
     this.limit = pLimit(Math.max(1, concurrency));
   }
@@ -158,7 +162,10 @@ export class PullRequestCompletionQueue {
 
             try {
               const resolved = await this.conflictResolver(item, error);
-              if (resolved) continue;
+              if (resolved) {
+                await new Promise((r) => setTimeout(r, this.postResolveDelayMs));
+                continue;
+              }
             } catch (resolveErr) {
               this.logger.warn(
                 `Conflict resolver failed for PR #${item.prNumber}: ${String(resolveErr)}`,

--- a/src/executors/pr-composition-phase-executor.ts
+++ b/src/executors/pr-composition-phase-executor.ts
@@ -11,7 +11,10 @@ import { formatPullRequestTitle } from '../util/title-format.js';
 
 /** Maximum total invocations (initial + retries) when pr-content.md fails to parse. */
 const MAX_ATTEMPTS = 2;
-const MAX_MERGE_RESOLUTION_ATTEMPTS = 2;
+const MAX_MERGE_RESOLUTION_ATTEMPTS = 3;
+
+/** Delay (ms) after pushing conflict resolution before retrying merge, to let GitHub recalculate mergeable state. */
+const POST_RESOLVE_DELAY_MS = 15_000;
 
 type MergeBlockReason = 'dirty' | 'checks-failed' | 'blocked';
 
@@ -210,6 +213,7 @@ export class PRCompositionPhaseExecutor implements PhaseExecutor {
           { issueNumber: ctx.issue.number },
         );
         await this.autoResolveMergeBlock(ctx, prNumber, reason, String(err));
+        await new Promise((r) => setTimeout(r, POST_RESOLVE_DELAY_MS));
       }
     }
   }

--- a/tests/pr-completion-queue.test.ts
+++ b/tests/pr-completion-queue.test.ts
@@ -241,6 +241,7 @@ describe('PullRequestCompletionQueue', () => {
         vi.fn().mockResolvedValue(true),
         1,
         conflictResolver,
+        0,
       );
 
       queue.enqueue(makeItem({ issueNumber: 60, prNumber: 601 }));
@@ -270,6 +271,7 @@ describe('PullRequestCompletionQueue', () => {
         vi.fn().mockResolvedValue(true),
         1,
         conflictResolver,
+        0,
       );
 
       queue.enqueue(makeItem({ issueNumber: 70, prNumber: 701 }));
@@ -300,6 +302,7 @@ describe('PullRequestCompletionQueue', () => {
         vi.fn().mockResolvedValue(true),
         1,
         conflictResolver,
+        0,
       );
 
       queue.enqueue(makeItem({ issueNumber: 80, prNumber: 801 }));
@@ -328,6 +331,7 @@ describe('PullRequestCompletionQueue', () => {
         vi.fn().mockResolvedValue(true),
         1,
         conflictResolver,
+        0,
       );
 
       queue.enqueue(makeItem({ issueNumber: 90, prNumber: 901 }));

--- a/tests/pr-composition-phase-executor.test.ts
+++ b/tests/pr-composition-phase-executor.test.ts
@@ -400,7 +400,7 @@ describe('PRCompositionPhaseExecutor', () => {
       expect(platform.mergePullRequest).toHaveBeenCalledWith(101, 'main', 'squash');
     });
 
-    it('should auto-resolve dirty merge blockers and retry auto-complete', async () => {
+    it('should auto-resolve dirty merge blockers and retry auto-complete', { timeout: 20_000 }, async () => {
       const prInfo = { number: 105, url: 'https://github.com/owner/repo/pull/105', title: 'Fix' };
       const platform = {
         issueLinkSuffix: vi.fn().mockReturnValue(''),
@@ -446,7 +446,7 @@ describe('PRCompositionPhaseExecutor', () => {
       expect(mockGit.add).toHaveBeenCalledWith(['-A']);
     });
 
-    it('should auto-resolve failed checks with fix-surgeon and retry auto-complete', async () => {
+    it('should auto-resolve failed checks with fix-surgeon and retry auto-complete', { timeout: 20_000 }, async () => {
       const prInfo = { number: 106, url: 'https://github.com/owner/repo/pull/106', title: 'Fix' };
       const platform = {
         issueLinkSuffix: vi.fn().mockReturnValue(''),


### PR DESCRIPTION
## Problem

After the conflict-resolver agent resolves merge conflicts and pushes, the retry merge call happens immediately. GitHub needs ~10-30 seconds to recalculate `mergeable_state` after a push, so the retry sees stale `dirty` state and fails — even though conflicts are actually resolved.

## Solution

- Add a 15-second delay (`POST_RESOLVE_DELAY_MS`) after pushing conflict resolution before retrying merge, in both `PullRequestCompletionQueue` and `PRCompositionPhaseExecutor`
- Bump `MAX_MERGE_RESOLUTION_ATTEMPTS` from 2 to 3 in both locations to give more headroom
- Make the delay configurable in `PullRequestCompletionQueue` constructor so tests can pass `0`
- Update test timeouts for the `PRCompositionPhaseExecutor` auto-resolve tests