### PR TITLE
fix(pr): enforce serial merge order in PR completion queue

### DIFF
--- a/src/core/fleet-orchestrator.ts
+++ b/src/core/fleet-orchestrator.ts
@@ -88,7 +88,6 @@ export class FleetOrchestrator {
         const status = this.fleetCheckpoint.getIssueStatus(dependencyIssueNumber)?.status;
         return status === 'completed';
       },
-      this.config.options.maxParallelIssues,
       autoComplete.enabled ? this.buildCompletionQueueConflictResolver() : undefined,
     );
   }

--- a/src/core/pr-completion-queue.ts
+++ b/src/core/pr-completion-queue.ts
@@ -43,6 +43,10 @@ const POST_RESOLVE_DELAY_MS = 15_000;
  * This lets FleetOrchestrator enqueue many existing open PRs (e.g. on resume)
  * without blocking per-issue scheduling, while still awaiting completion before
  * final fleet reporting.
+ *
+ * Merges are always serial (concurrency 1) because each merge into the base
+ * branch changes it, and subsequent PRs need the updated base to avoid
+ * cascading conflicts.
  */
 export class PullRequestCompletionQueue {
   private readonly limit: ReturnType<typeof pLimit>;
@@ -60,11 +64,12 @@ export class PullRequestCompletionQueue {
     private readonly mergeMethod: PullRequestMergeMethod,
     private readonly enabled: boolean,
     private readonly isDependencySatisfied: DependencySatisfiedFn,
-    concurrency: number,
     private readonly conflictResolver?: MergeConflictResolverFn,
     private readonly postResolveDelayMs: number = POST_RESOLVE_DELAY_MS,
   ) {
-    this.limit = pLimit(Math.max(1, concurrency));
+    // Always serial — merging into base must be sequential so each PR
+    // sees the updated base after the previous merge.
+    this.limit = pLimit(1);
   }
 
   enqueue(item: QueueItem): void {

--- a/tests/pr-completion-queue.test.ts
+++ b/tests/pr-completion-queue.test.ts
@@ -46,7 +46,6 @@ describe('PullRequestCompletionQueue', () => {
       'squash',
       false,
       vi.fn().mockResolvedValue(true),
-      2,
     );
 
     queue.enqueue(makeItem());
@@ -67,7 +66,6 @@ describe('PullRequestCompletionQueue', () => {
       'squash',
       true,
       vi.fn().mockResolvedValue(true),
-      2,
     );
 
     queue.enqueue(makeItem({ issueNumber: 10, prNumber: 210 }));
@@ -88,7 +86,6 @@ describe('PullRequestCompletionQueue', () => {
       'squash',
       true,
       vi.fn().mockResolvedValue(true),
-      1,
     );
 
     queue.enqueue(makeItem({ issueNumber: 20, prNumber: 220 }));
@@ -114,7 +111,6 @@ describe('PullRequestCompletionQueue', () => {
       'merge',
       true,
       vi.fn().mockResolvedValue(true),
-      3,
     );
 
     queue.enqueue(makeItem({ issueNumber: 30, prNumber: 301, dependencyIssueNumbers: [] }));
@@ -173,7 +169,6 @@ describe('PullRequestCompletionQueue', () => {
       'squash',
       true,
       vi.fn().mockResolvedValue(true),
-      2,
     );
 
     queue.enqueue(makeItem({ issueNumber: 50, prNumber: 501, dependencyIssueNumbers: [] }));
@@ -211,7 +206,6 @@ describe('PullRequestCompletionQueue', () => {
       'squash',
       true,
       vi.fn().mockResolvedValue(true),
-      1,
     );
 
     await (queue as unknown as { executeItem: (issueNumber: number) => Promise<void> }).executeItem(99999);
@@ -239,7 +233,6 @@ describe('PullRequestCompletionQueue', () => {
         'squash',
         true,
         vi.fn().mockResolvedValue(true),
-        1,
         conflictResolver,
         0,
       );
@@ -269,7 +262,6 @@ describe('PullRequestCompletionQueue', () => {
         'squash',
         true,
         vi.fn().mockResolvedValue(true),
-        1,
         conflictResolver,
         0,
       );
@@ -300,7 +292,6 @@ describe('PullRequestCompletionQueue', () => {
         'squash',
         true,
         vi.fn().mockResolvedValue(true),
-        1,
         conflictResolver,
         0,
       );
@@ -329,7 +320,6 @@ describe('PullRequestCompletionQueue', () => {
         'squash',
         true,
         vi.fn().mockResolvedValue(true),
-        1,
         conflictResolver,
         0,
       );
@@ -355,7 +345,6 @@ describe('PullRequestCompletionQueue', () => {
         'squash',
         true,
         vi.fn().mockResolvedValue(true),
-        1,
         // no conflictResolver
       );
 


### PR DESCRIPTION
## Problem

When cadre resumes with multiple existing open PRs (e.g., Wave 0: #16, #18, #19, #22), they all attempt to merge into main **in parallel**. Since each merge changes main, all the other concurrent PRs immediately conflict with the updated base — even after conflict resolution, the retry sees stale dirty state from the other parallel merges.

## Root Cause

The completion queue used `p-limit(maxParallelIssues)` (typically 8), allowing multiple PRs to merge concurrently. But merging into a shared base branch is inherently sequential: each merge changes the base, and the next PR must see that updated state.

## Fix

- Force completion queue to **serial execution** (`p-limit(1)`) — this is always correct for merging into a shared base branch
- Remove the configurable `concurrency` constructor parameter since it should always be 1
- PRs still respect DAG dependency ordering via `ensureExecution()`, now they also respect the implicit ordering that merging into main requires