### PR TITLE
fix(pr): rewrite completion queue to be truly serial

### DIFF
--- a/src/core/pr-completion-queue.ts
+++ b/src/core/pr-completion-queue.ts
@@ -1,4 +1,3 @@
-import pLimit from 'p-limit';
 import type { Logger } from '@cadre/framework/core';
 import type { PlatformProvider, PullRequestMergeMethod } from '../platform/provider.js';
 
@@ -44,16 +43,14 @@ const POST_RESOLVE_DELAY_MS = 15_000;
  * without blocking per-issue scheduling, while still awaiting completion before
  * final fleet reporting.
  *
- * Merges are always serial (concurrency 1) because each merge into the base
- * branch changes it, and subsequent PRs need the updated base to avoid
- * cascading conflicts.
+ * Merges are always **serial** because each merge into the base branch changes
+ * it, and subsequent PRs need the updated base to avoid cascading conflicts.
+ * Items are processed in enqueue order, respecting DAG dependencies.
  */
 export class PullRequestCompletionQueue {
-  private readonly limit: ReturnType<typeof pLimit>;
-  private readonly tasks: Array<Promise<void>> = [];
+  private readonly items: QueueItem[] = [];
   private readonly queued = new Set<number>();
-  private readonly itemsByIssueNumber = new Map<number, QueueItem>();
-  private readonly executionByIssueNumber = new Map<number, Promise<void>>();
+  private readonly completedIssueNumbers = new Set<number>();
   private readonly failedIssueNumbers = new Set<number>();
   private readonly failures: CompletionFailure[] = [];
 
@@ -66,17 +63,13 @@ export class PullRequestCompletionQueue {
     private readonly isDependencySatisfied: DependencySatisfiedFn,
     private readonly conflictResolver?: MergeConflictResolverFn,
     private readonly postResolveDelayMs: number = POST_RESOLVE_DELAY_MS,
-  ) {
-    // Always serial — merging into base must be sequential so each PR
-    // sees the updated base after the previous merge.
-    this.limit = pLimit(1);
-  }
+  ) {}
 
   enqueue(item: QueueItem): void {
     if (!this.enabled) return;
     if (this.queued.has(item.prNumber)) return;
     this.queued.add(item.prNumber);
-    this.itemsByIssueNumber.set(item.issueNumber, item);
+    this.items.push(item);
 
     this.logger.info(
       `Queued existing open PR #${item.prNumber} for auto-completion`,
@@ -89,15 +82,20 @@ export class PullRequestCompletionQueue {
         },
       },
     );
-
-    this.tasks.push(this.ensureExecution(item.issueNumber));
   }
 
+  /**
+   * Process all queued items sequentially. Respects DAG dependencies:
+   * an item whose dependency failed is marked dep-blocked and skipped.
+   * Idempotent — already-processed items are skipped on subsequent calls.
+   */
   async drain(): Promise<void> {
-    for (const issueNumber of this.itemsByIssueNumber.keys()) {
-      this.ensureExecution(issueNumber);
+    for (const item of this.items) {
+      if (this.completedIssueNumbers.has(item.issueNumber) || this.failedIssueNumbers.has(item.issueNumber)) {
+        continue;
+      }
+      await this.executeItem(item);
     }
-    await Promise.all(this.tasks);
   }
 
   getQueuedCount(): number {
@@ -108,90 +106,79 @@ export class PullRequestCompletionQueue {
     return [...this.failures];
   }
 
-  private ensureExecution(issueNumber: number): Promise<void> {
-    const existing = this.executionByIssueNumber.get(issueNumber);
-    if (existing) return existing;
-
-    const task = this.executeItem(issueNumber);
-    this.executionByIssueNumber.set(issueNumber, task);
-    return task;
-  }
-
-  private async executeItem(issueNumber: number): Promise<void> {
-    const item = this.itemsByIssueNumber.get(issueNumber);
-    if (!item) return;
-
-    for (const dependencyIssueNumber of item.dependencyIssueNumbers) {
-      if (this.itemsByIssueNumber.has(dependencyIssueNumber)) {
-        await this.ensureExecution(dependencyIssueNumber);
-        if (this.failedIssueNumbers.has(dependencyIssueNumber)) {
-          this.recordDependencyBlockedFailure(item, dependencyIssueNumber);
-          return;
-        }
-        continue;
+  private async executeItem(item: QueueItem): Promise<void> {
+    // Check all dependencies first
+    for (const depIssueNumber of item.dependencyIssueNumbers) {
+      // If dep was queued and failed, block this item
+      if (this.failedIssueNumbers.has(depIssueNumber)) {
+        this.recordDependencyBlockedFailure(item, depIssueNumber);
+        return;
       }
 
-      const satisfied = await this.isDependencySatisfied(dependencyIssueNumber);
-      if (!satisfied) {
-        this.recordDependencyBlockedFailure(item, dependencyIssueNumber);
-        return;
+      // If dep was not queued (handled elsewhere), check external status
+      if (!this.completedIssueNumbers.has(depIssueNumber) && !this.queued.has(depIssueNumber)) {
+        const satisfied = await this.isDependencySatisfied(depIssueNumber);
+        if (!satisfied) {
+          this.recordDependencyBlockedFailure(item, depIssueNumber);
+          return;
+        }
       }
     }
 
-    await this.limit(async () => {
-      const maxAttempts = this.conflictResolver ? MAX_MERGE_RESOLUTION_ATTEMPTS : 1;
+    // Attempt merge with conflict resolution retry loop
+    const maxAttempts = this.conflictResolver ? MAX_MERGE_RESOLUTION_ATTEMPTS : 1;
 
-      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-        try {
-          await this.platform.mergePullRequest(item.prNumber, this.baseBranch, this.mergeMethod);
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await this.platform.mergePullRequest(item.prNumber, this.baseBranch, this.mergeMethod);
+        this.completedIssueNumbers.add(item.issueNumber);
+        this.logger.info(
+          `Auto-completed existing PR #${item.prNumber} into ${this.baseBranch} using ${this.mergeMethod} merge`,
+          {
+            issueNumber: item.issueNumber,
+            data: { prUrl: item.prUrl, branch: item.branch },
+          },
+        );
+        return;
+      } catch (err) {
+        const error = String(err);
+        const isDirty = this.isMergeConflict(error);
+
+        if (isDirty && this.conflictResolver && attempt < maxAttempts) {
           this.logger.info(
-            `Auto-completed existing PR #${item.prNumber} into ${this.baseBranch} using ${this.mergeMethod} merge`,
+            `PR #${item.prNumber} merge blocked (dirty); launching auto-resolution (attempt ${attempt}/${maxAttempts})`,
             {
               issueNumber: item.issueNumber,
               data: { prUrl: item.prUrl, branch: item.branch },
             },
           );
-          return;
-        } catch (err) {
-          const error = String(err);
-          const isDirty = this.isMergeConflict(error);
 
-          if (isDirty && this.conflictResolver && attempt < maxAttempts) {
-            this.logger.info(
-              `PR #${item.prNumber} merge blocked (dirty); launching auto-resolution (attempt ${attempt}/${maxAttempts})`,
-              {
-                issueNumber: item.issueNumber,
-                data: { prUrl: item.prUrl, branch: item.branch },
-              },
-            );
-
-            try {
-              const resolved = await this.conflictResolver(item, error);
-              if (resolved) {
-                await new Promise((r) => setTimeout(r, this.postResolveDelayMs));
-                continue;
-              }
-            } catch (resolveErr) {
-              this.logger.warn(
-                `Conflict resolver failed for PR #${item.prNumber}: ${String(resolveErr)}`,
-                { issueNumber: item.issueNumber },
-              );
+          try {
+            const resolved = await this.conflictResolver(item, error);
+            if (resolved) {
+              await new Promise((r) => setTimeout(r, this.postResolveDelayMs));
+              continue;
             }
+          } catch (resolveErr) {
+            this.logger.warn(
+              `Conflict resolver failed for PR #${item.prNumber}: ${String(resolveErr)}`,
+              { issueNumber: item.issueNumber },
+            );
           }
-
-          this.failedIssueNumbers.add(item.issueNumber);
-          this.failures.push({ ...item, error });
-          this.logger.warn(
-            `Auto-complete failed for existing PR #${item.prNumber}: ${error}`,
-            {
-              issueNumber: item.issueNumber,
-              data: { prUrl: item.prUrl, branch: item.branch },
-            },
-          );
-          return;
         }
+
+        this.failedIssueNumbers.add(item.issueNumber);
+        this.failures.push({ ...item, error });
+        this.logger.warn(
+          `Auto-complete failed for existing PR #${item.prNumber}: ${error}`,
+          {
+            issueNumber: item.issueNumber,
+            data: { prUrl: item.prUrl, branch: item.branch },
+          },
+        );
+        return;
       }
-    });
+    }
   }
 
   private isMergeConflict(message: string): boolean {

--- a/tests/pr-completion-queue.test.ts
+++ b/tests/pr-completion-queue.test.ts
@@ -198,23 +198,6 @@ describe('PullRequestCompletionQueue', () => {
     );
   });
 
-  it('returns without side effects when executeItem is invoked for an unknown issue', async () => {
-    const queue = new PullRequestCompletionQueue(
-      platform,
-      logger,
-      'main',
-      'squash',
-      true,
-      vi.fn().mockResolvedValue(true),
-    );
-
-    await (queue as unknown as { executeItem: (issueNumber: number) => Promise<void> }).executeItem(99999);
-
-    expect(mergePullRequest).not.toHaveBeenCalled();
-    expect(logger.warn).not.toHaveBeenCalled();
-    expect(queue.getFailures()).toEqual([]);
-  });
-
   describe('merge conflict resolution', () => {
     it('invokes conflictResolver on dirty merge error and retries merge', async () => {
       const conflictResolver = vi.fn().mockResolvedValue(true);


### PR DESCRIPTION
## Problem

PR #339 set `p-limit(1)` expecting serial execution, but `executeItem` calls were still spawned concurrently via `enqueue() → ensureExecution()`. The p-limit only gated the inner merge block, so multiple PRs would still fire their initial merge attempts simultaneously. This caused PR #18 to fail immediately (before #16's conflict resolution even started), and the completion queue appeared hung.

## Root Cause

```
enqueue(#16) → ensureExecution(#16) → executeItem(#16) ─┐
enqueue(#18) → ensureExecution(#18) → executeItem(#18) ─┤ both run concurrently
                                                          └─> p-limit(1) only gates merge portion
```

## Fix

Replaced the entire concurrent task model with a simple sequential `drain()` loop:
- `enqueue()` now just collects items into an array
- `drain()` iterates items one at a time, running the full resolve → wait → retry cycle for each before moving to the next
- Each PR sees the fully updated base branch after the prior merge
- DAG deps are checked via completed/failed sets instead of awaiting in-flight promises
- Idempotent: drain() skips already-processed items