### PR TITLE
chore: publish @jafreck/cadre to npm with trusted publishing CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write  # Required for OIDC trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+      # Trusted publishing: OIDC auth, no NPM_TOKEN needed.
+      # Provenance attestations are generated automatically.
+      # Configure at: npmjs.com → @jafreck/cadre → Settings → Trusted Publisher
+      #   Organization/user: jafreck
+      #   Repository: CADRE
+      #   Workflow filename: publish.yml
+      - run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -1,22 +1,34 @@
 {
-  "name": "cadre",
+  "name": "@jafreck/cadre",
   "version": "0.1.0",
   "description": "Coordinated Agent Development Runtime Engine",
   "license": "MIT",
   "author": "Jacob Freck",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jafreck/CADRE.git"
+  },
   "type": "module",
   "workspaces": [
     "packages/*"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "dist/",
     "src/agents/templates/"
+  ],
+  "bundledDependencies": [
+    "@cadre/framework",
+    "@cadre/runtime-provider-docker",
+    "@cadre/runtime-provider-kata"
   ],
   "bin": {
     "cadre": "dist/index.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "npm run build --workspaces --if-present && tsc",
     "postbuild": "mkdir -p dist/agents && rm -rf dist/agents/templates && cp -r src/agents/templates dist/agents/templates",
     "dev": "tsx src/index.ts",
     "test": "vitest run",


### PR DESCRIPTION
## Changes

- **Rename package** from `cadre` to `@jafreck/cadre` for npm publication
- **Add `publishConfig`** with `access: public` for scoped package
- **Add `repository` field** linking to `jafreck/CADRE` (required for provenance)
- **Add `bundledDependencies`** so workspace packages (`@cadre/framework`, runtime providers) are bundled into the published tarball — no need to publish them separately
- **Update build script** to build workspace packages before root: `npm run build --workspaces --if-present && tsc`
- **Add `.github/workflows/publish.yml`** for automated releases:
  - Triggers on GitHub Release creation
  - Uses **npm trusted publishing** (OIDC) — no `NPM_TOKEN` secret needed
  - Provenance attestations generated automatically
  - Runs build + tests before publishing

## npm Trusted Publisher Setup

After merging, configure on npmjs.com → `@jafreck/cadre` → Settings → Trusted Publisher:
- **Organization/user**: `jafreck`
- **Repository**: `CADRE`
- **Workflow filename**: `publish.yml`

## Initial Publish

v0.1.0 has been published manually: `npm install -g @jafreck/cadre`