### PR TITLE
fix(resume): reconcile dep-merge-conflict and dep-blocked as non-terminal on resume

### DIFF
--- a/packages/framework/src/engine/checkpoint/checkpoint.ts
+++ b/packages/framework/src/engine/checkpoint/checkpoint.ts
@@ -558,6 +558,18 @@ export class FleetCheckpointManager {
     // resolved since the last run, so the scheduler must re-evaluate.
   }
 
+  /**
+   * Remove an issue's checkpoint entry entirely so it will be scheduled for
+   * fresh processing on the next run.  Used during reconciliation to clear
+   * transient failure states (e.g. dep-blocked) when their blockers have been
+   * resolved.
+   */
+  async clearIssueStatus(issueNumber: number): Promise<void> {
+    if (!this.state) throw new Error('Fleet checkpoint not loaded');
+    delete this.state.issues[issueNumber];
+    await this.save();
+  }
+
   private async save(): Promise<void> {
     if (!this.state) return;
     this.state.lastCheckpoint = new Date().toISOString();

--- a/src/core/fleet-orchestrator.ts
+++ b/src/core/fleet-orchestrator.ts
@@ -19,6 +19,7 @@ import type { DependencyMergeConflictContext } from '../git/dependency-branch-me
 import { FleetReporter } from './fleet-reporter.js';
 import { FleetScheduler } from './fleet-scheduler.js';
 import { PullRequestCompletionQueue, type CompletionFailure, type MergeConflictResolverFn } from './pr-completion-queue.js';
+import { MergeRetryHelper } from './merge-retry.js';
 import type { PullRequestMergeMethod } from '../platform/provider.js';
 
 export interface FleetResult {
@@ -203,14 +204,18 @@ export class FleetOrchestrator {
    * On resume, the checkpoint may contain failure statuses (dep-merge-conflict,
    * dep-blocked, failed, etc.) that are no longer accurate — for example, a PR
    * may have been merged manually, or a retry succeeded after the checkpoint was
-   * written.  This method queries the platform for each such issue and promotes
-   * it to 'completed' when a merged PR is found, so that the scheduler doesn't
-   * re-process the issue or incorrectly block its dependents.
+   * written.
    *
-   * Issues with `dep-blocked` status are left as-is since they have no branch
-   * or PR; the scheduler will naturally re-evaluate them once their dependencies
-   * are resolved (dep-blocked is no longer treated as "completed" in
-   * {@link FleetCheckpointManager.isIssueCompleted}).
+   * Phase 1 — Promote merged PRs:  For each reconcilable issue with a branch,
+   *   query the platform.  If a merged PR is found, promote to 'completed'.
+   *
+   * Phase 2 — Retry merge for dep-merge-conflict:  For dep-merge-conflict issues
+   *   whose PRs are still open, attempt to merge again (upstream changes may have
+   *   resolved the conflict).  Only promote on success.
+   *
+   * Phase 3 — Clear dep-blocked:  For dep-blocked issues, check whether all
+   *   dependencies are now completed.  If so, delete the checkpoint entry so the
+   *   issue is scheduled for fresh processing.
    */
   private async reconcileCheckpoint(): Promise<void> {
     const reconcilableStatuses = new Set([
@@ -220,27 +225,80 @@ export class FleetOrchestrator {
       'failed',
     ]);
 
-    const toReconcile = this.fleetCheckpoint.getAllIssueStatuses().filter(
+    const allStatuses = this.fleetCheckpoint.getAllIssueStatuses();
+
+    const toReconcile = allStatuses.filter(
       ([_, s]) => reconcilableStatuses.has(s.status) && s.branchName,
     );
 
-    if (toReconcile.length === 0) return;
-
-    this.logger.info(
-      `Resume reconciliation: checking ${toReconcile.length} failed issues against actual PR state`,
-    );
-
+    // ── Phase 1: Promote issues whose PRs have been merged ──
     let promoted = 0;
-    for (const [issueNumber, issueStatus] of toReconcile) {
+    if (toReconcile.length > 0) {
+      this.logger.info(
+        `Resume reconciliation: checking ${toReconcile.length} failed issues against actual PR state`,
+      );
+
+      for (const [issueNumber, issueStatus] of toReconcile) {
+        try {
+          const prs = await this.platform.listPullRequests({
+            head: issueStatus.branchName,
+            state: 'all',
+          });
+          const merged = prs.find((pr) => pr.state === 'merged');
+          if (merged) {
+            this.logger.info(
+              `Reconciliation: issue #${issueNumber} has merged PR #${merged.number} — promoting '${issueStatus.status}' → 'completed'`,
+              { issueNumber },
+            );
+            await this.fleetCheckpoint.setIssueStatus(
+              issueNumber,
+              'completed',
+              issueStatus.worktreePath,
+              issueStatus.branchName,
+              issueStatus.lastPhase,
+              issueStatus.issueTitle,
+            );
+            promoted++;
+          }
+        } catch (err) {
+          this.logger.warn(
+            `Reconciliation: could not check PR state for issue #${issueNumber}: ${err}`,
+            { issueNumber },
+          );
+        }
+      }
+    }
+
+    // ── Phase 2: Retry merge for dep-merge-conflict issues with open PRs ──
+    const conflictIssues = allStatuses.filter(
+      ([_, s]) => s.status === 'dep-merge-conflict' && s.branchName,
+    );
+    let mergeRetried = 0;
+    for (const [issueNumber, issueStatus] of conflictIssues) {
+      // Skip if already promoted in Phase 1
+      if (this.fleetCheckpoint.isIssueCompleted(issueNumber)) continue;
       try {
         const prs = await this.platform.listPullRequests({
           head: issueStatus.branchName,
-          state: 'all',
+          state: 'open',
         });
-        const merged = prs.find((pr) => pr.state === 'merged');
+        const openPR = prs[0];
+        if (!openPR) continue;
+
+        this.logger.info(
+          `Reconciliation: retrying merge for issue #${issueNumber} PR #${openPR.number}`,
+          { issueNumber },
+        );
+        const helper = new MergeRetryHelper(this.platform, this.logger, this.config.baseBranch);
+        const merged = await helper.mergeWithRetry({
+          prNumber: openPR.number,
+          prUrl: openPR.url,
+          branch: issueStatus.branchName,
+          issueNumber,
+        });
         if (merged) {
           this.logger.info(
-            `Reconciliation: issue #${issueNumber} has merged PR #${merged.number} — promoting '${issueStatus.status}' → 'completed'`,
+            `Reconciliation: merge succeeded for issue #${issueNumber} PR #${openPR.number} — promoting to 'completed'`,
             { issueNumber },
           );
           await this.fleetCheckpoint.setIssueStatus(
@@ -252,18 +310,44 @@ export class FleetOrchestrator {
             issueStatus.issueTitle,
           );
           promoted++;
+          mergeRetried++;
+        } else {
+          this.logger.info(
+            `Reconciliation: merge still failing for issue #${issueNumber} PR #${openPR.number}; will re-process`,
+            { issueNumber },
+          );
         }
       } catch (err) {
         this.logger.warn(
-          `Reconciliation: could not check PR state for issue #${issueNumber}: ${err}`,
+          `Reconciliation: could not retry merge for issue #${issueNumber}: ${err}`,
           { issueNumber },
         );
       }
     }
 
-    if (promoted > 0) {
+    // ── Phase 3: Clear dep-blocked when dependencies are resolved ──
+    const depBlockedIssues = allStatuses.filter(
+      ([_, s]) => s.status === 'dep-blocked',
+    );
+    let cleared = 0;
+    if (depBlockedIssues.length > 0 && this.dagDepMap) {
+      for (const [issueNumber] of depBlockedIssues) {
+        const deps = this.dagDepMap[issueNumber] ?? [];
+        const allDepsCompleted = deps.every((dep) => this.fleetCheckpoint.isIssueCompleted(dep));
+        if (allDepsCompleted) {
+          this.logger.info(
+            `Reconciliation: clearing dep-blocked for issue #${issueNumber} — all dependencies now completed`,
+            { issueNumber },
+          );
+          await this.fleetCheckpoint.clearIssueStatus(issueNumber);
+          cleared++;
+        }
+      }
+    }
+
+    if (promoted > 0 || cleared > 0) {
       this.logger.info(
-        `Resume reconciliation complete: promoted ${promoted}/${toReconcile.length} issues to 'completed'`,
+        `Resume reconciliation complete: promoted ${promoted} issues to 'completed'${mergeRetried > 0 ? ` (${mergeRetried} via merge retry)` : ''}, cleared ${cleared} dep-blocked`,
       );
     }
   }
@@ -571,7 +655,7 @@ export class FleetOrchestrator {
                 issue.number,
                 'dep-merge-conflict',
                 '',
-                '',
+                branchName,
                 0,
                 issue.title,
                 error,

--- a/src/core/fleet-scheduler.ts
+++ b/src/core/fleet-scheduler.ts
@@ -195,12 +195,14 @@ export class FleetScheduler {
     });
 
     if (!merged) {
+      // Preserve the branch name so reconciliation can find the PR on next resume
+      const existing = this.fleetCheckpoint.getIssueStatus(issueNumber);
       await this.fleetCheckpoint.setIssueStatus(
         issueNumber,
         'dep-merge-conflict',
-        '',
-        '',
-        0,
+        existing?.worktreePath ?? '',
+        pr.headBranch,
+        existing?.lastPhase ?? 0,
         issueTitle,
         `Merge failed after retries for PR #${pr.number}`,
       );

--- a/tests/fleet-orchestrator.test.ts
+++ b/tests/fleet-orchestrator.test.ts
@@ -1657,6 +1657,7 @@ describe('FleetOrchestrator — DAG per-dependency execution', () => {
       load: vi.fn().mockResolvedValue(undefined),
       isIssueCompleted: vi.fn().mockReturnValue(false),
       setIssueStatus: vi.fn().mockResolvedValue(undefined),
+      clearIssueStatus: vi.fn().mockResolvedValue(undefined),
       recordTokenUsage: vi.fn().mockResolvedValue(undefined),
       getIssueStatus: vi.fn().mockReturnValue(null),
       setDag: vi.fn().mockResolvedValue(undefined),
@@ -2420,6 +2421,7 @@ describe('FleetOrchestrator — resume reconciliation', () => {
       load: vi.fn().mockResolvedValue(undefined),
       isIssueCompleted: vi.fn().mockReturnValue(false),
       setIssueStatus: vi.fn().mockResolvedValue(undefined),
+      clearIssueStatus: vi.fn().mockResolvedValue(undefined),
       recordTokenUsage: vi.fn().mockResolvedValue(undefined),
       getIssueStatus: vi.fn().mockReturnValue(null),
       setDag: vi.fn().mockResolvedValue(undefined),
@@ -2622,16 +2624,34 @@ describe('FleetOrchestrator — resume reconciliation', () => {
     expect(reconcileLogCalls).toHaveLength(0);
   });
 
-  it('skips dep-blocked issues in reconciliation (no branch to check)', async () => {
+  it('clears dep-blocked issues when all dependencies are now completed', async () => {
     const { FleetCheckpointManager } = await import('@cadre/framework/engine');
     const setIssueStatus = vi.fn().mockResolvedValue(undefined);
+    const clearIssueStatus = vi.fn().mockResolvedValue(undefined);
+    const isIssueCompleted = vi.fn().mockImplementation((num: number) => num === 16);
     const mockCheckpoint = makeMockFleetCheckpointForReconcile({
       setIssueStatus,
+      clearIssueStatus,
+      isIssueCompleted,
       getAllIssueStatuses: vi.fn().mockReturnValue([
+        [16, { status: 'completed', branchName: 'cadre/issue-16', worktreePath: '', lastPhase: 0, issueTitle: 'Issue 16' }],
         [17, { status: 'dep-blocked', branchName: '', worktreePath: '', lastPhase: 0, issueTitle: 'Issue 17' }],
       ]),
     });
     (FleetCheckpointManager as ReturnType<typeof vi.fn>).mockImplementationOnce(() => mockCheckpoint);
+
+    const { IssueOrchestrator } = await import('../src/core/issue-orchestrator.js');
+    (IssueOrchestrator as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      run: vi.fn().mockResolvedValue({
+        issueNumber: 17,
+        issueTitle: 'Issue 17',
+        success: true,
+        codeComplete: false,
+        phases: [],
+        totalDuration: 100,
+        tokenUsage: 500,
+      }),
+    }));
 
     const config = makeRuntimeConfig({
       branchTemplate: 'cadre/issue-{issue}',
@@ -2662,13 +2682,175 @@ describe('FleetOrchestrator — resume reconciliation', () => {
     const issue17 = makeIssue(17);
     const { worktreeManager, launcher, platform, logger } = makeMockDeps();
     const notifications = { dispatch: vi.fn().mockResolvedValue(undefined) } as any;
-
-    // listPullRequests should NOT be called for dep-blocked issues with no branch
     (platform as any).listPullRequests = vi.fn().mockResolvedValue([]);
 
+    // Provide dagDepMap so reconciliation knows issue 17 depends on 16
     const fleet = new FleetOrchestrator(
       config,
       [issue17],
+      worktreeManager as any,
+      launcher as any,
+      platform as any,
+      logger as any,
+      notifications,
+      undefined, // no DAG object
+      { 17: [16] }, // dagDepMap
+    );
+
+    await fleet.run();
+
+    // Should have cleared the dep-blocked status for issue 17
+    expect(clearIssueStatus).toHaveBeenCalledWith(17);
+
+    // Should have logged the clearing
+    const clearLogCalls = (logger.info as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([msg]: [string]) => typeof msg === 'string' && msg.includes('clearing dep-blocked'),
+    );
+    expect(clearLogCalls).toHaveLength(1);
+  });
+
+  it('does not clear dep-blocked when dependencies are still unresolved', async () => {
+    const { FleetCheckpointManager } = await import('@cadre/framework/engine');
+    const clearIssueStatus = vi.fn().mockResolvedValue(undefined);
+    const isIssueCompleted = vi.fn().mockReturnValue(false); // dep 16 NOT completed
+    const mockCheckpoint = makeMockFleetCheckpointForReconcile({
+      clearIssueStatus,
+      isIssueCompleted,
+      getAllIssueStatuses: vi.fn().mockReturnValue([
+        [16, { status: 'dep-merge-conflict', branchName: 'cadre/issue-16', worktreePath: '', lastPhase: 0, issueTitle: 'Issue 16' }],
+        [17, { status: 'dep-blocked', branchName: '', worktreePath: '', lastPhase: 0, issueTitle: 'Issue 17' }],
+      ]),
+    });
+    (FleetCheckpointManager as ReturnType<typeof vi.fn>).mockImplementationOnce(() => mockCheckpoint);
+
+    const config = makeRuntimeConfig({
+      branchTemplate: 'cadre/issue-{issue}',
+      issues: { ids: [16, 17] },
+      commits: { conventional: true, sign: false, commitPerPhase: true, squashBeforePR: false },
+      pullRequest: { autoCreate: true, autoComplete: false, draft: true, labels: [], reviewers: [], linkIssue: true },
+      options: {
+        maxParallelIssues: 3,
+        maxParallelAgents: 3,
+        maxRetriesPerTask: 3,
+        dryRun: false,
+        resume: true,
+        invocationDelayMs: 0,
+        buildVerification: false,
+        testVerification: false,
+        perTaskBuildCheck: true,
+        maxBuildFixRounds: 2,
+        skipValidation: false,
+        maxIntegrationFixRounds: 1,
+        ambiguityThreshold: 5,
+        haltOnAmbiguity: false,
+        respondToReviews: false,
+        maxWholePrReviewRetries: 1,
+        postCostComment: false,
+      },
+    });
+
+    const issue16 = makeIssue(16);
+    const issue17 = makeIssue(17);
+    const { worktreeManager, launcher, platform, logger } = makeMockDeps();
+    const notifications = { dispatch: vi.fn().mockResolvedValue(undefined) } as any;
+    (platform as any).listPullRequests = vi.fn().mockResolvedValue([]);
+    (platform as any).mergePullRequest = vi.fn().mockRejectedValue(new Error('merge conflict'));
+
+    const fleet = new FleetOrchestrator(
+      config,
+      [issue16, issue17],
+      worktreeManager as any,
+      launcher as any,
+      platform as any,
+      logger as any,
+      notifications,
+      undefined,
+      { 17: [16] },
+    );
+
+    await fleet.run();
+
+    // dep-blocked should NOT have been cleared (dep 16 is still not completed)
+    expect(clearIssueStatus).not.toHaveBeenCalledWith(17);
+  });
+
+  it('retries merge for dep-merge-conflict issues with open PRs during reconciliation', async () => {
+    const { FleetCheckpointManager } = await import('@cadre/framework/engine');
+    const setIssueStatus = vi.fn().mockResolvedValue(undefined);
+    const isIssueCompleted = vi.fn().mockReturnValue(false);
+    const mockCheckpoint = makeMockFleetCheckpointForReconcile({
+      setIssueStatus,
+      isIssueCompleted,
+      getAllIssueStatuses: vi.fn().mockReturnValue([
+        [16, { status: 'dep-merge-conflict', branchName: 'cadre/issue-16', worktreePath: '/tmp/wt/16', lastPhase: 5, issueTitle: 'Issue 16' }],
+      ]),
+    });
+    // After merge retry succeeds in Phase 2, isIssueCompleted should return true on re-check
+    isIssueCompleted.mockImplementation((num: number) => {
+      const calls = setIssueStatus.mock.calls;
+      return calls.some(([n, s]: [number, string]) => n === num && s === 'completed');
+    });
+    (FleetCheckpointManager as ReturnType<typeof vi.fn>).mockImplementationOnce(() => mockCheckpoint);
+
+    const { IssueOrchestrator } = await import('../src/core/issue-orchestrator.js');
+    (IssueOrchestrator as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      run: vi.fn().mockResolvedValue({
+        issueNumber: 16,
+        issueTitle: 'Issue 16',
+        success: true,
+        codeComplete: false,
+        phases: [],
+        totalDuration: 100,
+        tokenUsage: 500,
+      }),
+    }));
+
+    const config = makeRuntimeConfig({
+      branchTemplate: 'cadre/issue-{issue}',
+      issues: { ids: [16] },
+      commits: { conventional: true, sign: false, commitPerPhase: true, squashBeforePR: false },
+      pullRequest: { autoCreate: true, autoComplete: false, draft: true, labels: [], reviewers: [], linkIssue: true },
+      options: {
+        maxParallelIssues: 3,
+        maxParallelAgents: 3,
+        maxRetriesPerTask: 3,
+        dryRun: false,
+        resume: true,
+        invocationDelayMs: 0,
+        buildVerification: false,
+        testVerification: false,
+        perTaskBuildCheck: true,
+        maxBuildFixRounds: 2,
+        skipValidation: false,
+        maxIntegrationFixRounds: 1,
+        ambiguityThreshold: 5,
+        haltOnAmbiguity: false,
+        respondToReviews: false,
+        maxWholePrReviewRetries: 1,
+        postCostComment: false,
+      },
+    });
+
+    const issue16 = makeIssue(16);
+    const { worktreeManager, launcher, platform, logger } = makeMockDeps();
+    const notifications = { dispatch: vi.fn().mockResolvedValue(undefined) } as any;
+
+    // Phase 1: no merged PR found
+    // Phase 2: open PR found, merge succeeds
+    (platform as any).listPullRequests = vi.fn()
+      // Phase 1 call (state: 'all') — no merged PR
+      .mockResolvedValueOnce([
+        { number: 49, url: 'https://github.com/owner/repo/pull/49', title: 'PR 49', headBranch: 'cadre/issue-16', baseBranch: 'main', state: 'open' },
+      ])
+      // Phase 2 call (state: 'open') — open PR for merge retry
+      .mockResolvedValueOnce([
+        { number: 49, url: 'https://github.com/owner/repo/pull/49', title: 'PR 49', headBranch: 'cadre/issue-16', baseBranch: 'main', state: 'open' },
+      ]);
+    (platform as any).mergePullRequest = vi.fn().mockResolvedValue(undefined);
+
+    const fleet = new FleetOrchestrator(
+      config,
+      [issue16],
       worktreeManager as any,
       launcher as any,
       platform as any,
@@ -2678,13 +2860,20 @@ describe('FleetOrchestrator — resume reconciliation', () => {
 
     await fleet.run();
 
-    // listPullRequests should not have been called during reconciliation
-    // (dep-blocked has no branch, and it's not in the reconcilable statuses set)
-    // Any calls would be from processIssue's merged-PR check, not from reconciliation
-    const reconcileLogCalls = (logger.info as ReturnType<typeof vi.fn>).mock.calls.filter(
-      ([msg]: [string]) => typeof msg === 'string' && msg.includes('Resume reconciliation: checking'),
+    // Should have attempted to merge the PR during reconciliation
+    expect((platform as any).mergePullRequest).toHaveBeenCalledWith(49, 'main', undefined);
+
+    // Should have promoted to completed
+    const promotionCall = setIssueStatus.mock.calls.find(
+      ([num, status]: [number, string]) => num === 16 && status === 'completed',
     );
-    expect(reconcileLogCalls).toHaveLength(0);
+    expect(promotionCall).toBeDefined();
+
+    // Should have logged the merge retry
+    const retryLogCalls = (logger.info as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([msg]: [string]) => typeof msg === 'string' && msg.includes('retrying merge'),
+    );
+    expect(retryLogCalls).toHaveLength(1);
   });
 
   it('processIssue detects already-merged PRs and skips re-processing', async () => {

--- a/tests/fleet-scheduler.test.ts
+++ b/tests/fleet-scheduler.test.ts
@@ -225,7 +225,7 @@ describe('FleetScheduler', () => {
 
       const processIssue: ProcessIssueFn = vi.fn().mockResolvedValue({
         ...makeResult(1),
-        pr: { number: 10, url: 'https://github.com/pull/10', title: 'PR 10', branch: 'cadre/issue-1' },
+        pr: { number: 10, url: 'https://github.com/pull/10', title: 'PR 10', headBranch: 'cadre/issue-1', baseBranch: 'main', state: 'open' },
       });
       const markDepBlocked: MarkDepBlockedFn = vi.fn();
 
@@ -238,7 +238,7 @@ describe('FleetScheduler', () => {
       const results = await scheduler.schedule(issues, processIssue, markDepBlocked, dag);
 
       expect(fleetCheckpoint.setIssueStatus).toHaveBeenCalledWith(
-        1, 'dep-merge-conflict', '', '', 0, 'Issue 1', expect.stringContaining('Merge failed after retries'),
+        1, 'dep-merge-conflict', '', 'cadre/issue-1', 0, 'Issue 1', expect.stringContaining('Merge failed after retries'),
       );
       expect(results).toHaveLength(1);
     });
@@ -335,9 +335,9 @@ describe('FleetScheduler', () => {
         // 3 attempts total (first + 2 retries)
         expect(platform.mergePullRequest).toHaveBeenCalledTimes(3);
         expect(platform.updatePullRequestBranch).toHaveBeenCalledTimes(2);
-        // Should record dep-merge-conflict
+        // Should record dep-merge-conflict (with preserved branchName)
         expect(fleetCheckpoint.setIssueStatus).toHaveBeenCalledWith(
-          1, 'dep-merge-conflict', '', '', 0, 'Issue 1', expect.stringContaining('Merge failed after retries'),
+          1, 'dep-merge-conflict', '', 'cadre/issue-1', 0, 'Issue 1', expect.stringContaining('Merge failed after retries'),
         );
       } finally {
         vi.useRealTimers();


### PR DESCRIPTION
## Summary

On resume, `dep-merge-conflict` and `dep-blocked` were effectively terminal — cadre would exit immediately without retrying. This PR makes them non-terminal by enhancing the reconciliation phase.

## Changes

### `reconcileCheckpoint()` — 3-phase reconciliation

- **Phase 1** (existing): Promote issues whose PRs merged since last run
- **Phase 2** (new): For `dep-merge-conflict` issues with open PRs, actively retry the merge via `MergeRetryHelper` — upstream changes may have resolved the conflict
- **Phase 3** (new): For `dep-blocked` issues, check if all dependencies are now completed using `dagDepMap`; if so, clear the checkpoint entry so the scheduler processes them fresh

### Branch name preservation

- `tryMergeWithRetry` (scheduler) now preserves `pr.headBranch` and existing `worktreePath`/`lastPhase` when setting `dep-merge-conflict` status
- `processIssue` dep-merge-conflict catch now preserves the computed `branchName`

### New `clearIssueStatus()`

Added to `FleetCheckpointManager` — removes a checkpoint entry entirely so the issue gets fresh scheduling on next run.

## Tests

- Updated scheduler tests to verify branch name preservation in `dep-merge-conflict` status
- Added tests for dep-blocked clearing when dependencies resolve
- Added tests for dep-blocked NOT clearing when dependencies are still unresolved
- Added test for merge retry during reconciliation