### PR TITLE
fix(resume): derive branchName from worktreeManager when checkpoint has empty value

### DIFF
--- a/src/core/fleet-orchestrator.ts
+++ b/src/core/fleet-orchestrator.ts
@@ -227,8 +227,16 @@ export class FleetOrchestrator {
 
     const allStatuses = this.fleetCheckpoint.getAllIssueStatuses();
 
+    // Helper: resolve branchName from checkpoint or derive from issue metadata
+    const issueMap = new Map(this.issues.map((i) => [i.number, i]));
+    const resolveBranch = (issueNumber: number, stored: string): string => {
+      if (stored) return stored;
+      const issue = issueMap.get(issueNumber);
+      return this.worktreeManager.resolveBranchName(issueNumber, issue?.title);
+    };
+
     const toReconcile = allStatuses.filter(
-      ([_, s]) => reconcilableStatuses.has(s.status) && s.branchName,
+      ([num, s]) => reconcilableStatuses.has(s.status) && resolveBranch(num, s.branchName),
     );
 
     // ── Phase 1: Promote issues whose PRs have been merged ──
@@ -239,9 +247,10 @@ export class FleetOrchestrator {
       );
 
       for (const [issueNumber, issueStatus] of toReconcile) {
+        const branch = resolveBranch(issueNumber, issueStatus.branchName);
         try {
           const prs = await this.platform.listPullRequests({
-            head: issueStatus.branchName,
+            head: branch,
             state: 'all',
           });
           const merged = prs.find((pr) => pr.state === 'merged');
@@ -254,7 +263,7 @@ export class FleetOrchestrator {
               issueNumber,
               'completed',
               issueStatus.worktreePath,
-              issueStatus.branchName,
+              branch,
               issueStatus.lastPhase,
               issueStatus.issueTitle,
             );
@@ -271,15 +280,16 @@ export class FleetOrchestrator {
 
     // ── Phase 2: Retry merge for dep-merge-conflict issues with open PRs ──
     const conflictIssues = allStatuses.filter(
-      ([_, s]) => s.status === 'dep-merge-conflict' && s.branchName,
+      ([num, s]) => s.status === 'dep-merge-conflict' && resolveBranch(num, s.branchName),
     );
     let mergeRetried = 0;
     for (const [issueNumber, issueStatus] of conflictIssues) {
       // Skip if already promoted in Phase 1
       if (this.fleetCheckpoint.isIssueCompleted(issueNumber)) continue;
+      const branch = resolveBranch(issueNumber, issueStatus.branchName);
       try {
         const prs = await this.platform.listPullRequests({
-          head: issueStatus.branchName,
+          head: branch,
           state: 'open',
         });
         const openPR = prs[0];
@@ -293,7 +303,7 @@ export class FleetOrchestrator {
         const merged = await helper.mergeWithRetry({
           prNumber: openPR.number,
           prUrl: openPR.url,
-          branch: issueStatus.branchName,
+          branch,
           issueNumber,
         });
         if (merged) {
@@ -305,7 +315,7 @@ export class FleetOrchestrator {
             issueNumber,
             'completed',
             issueStatus.worktreePath,
-            issueStatus.branchName,
+            branch,
             issueStatus.lastPhase,
             issueStatus.issueTitle,
           );
@@ -316,6 +326,18 @@ export class FleetOrchestrator {
             `Reconciliation: merge still failing for issue #${issueNumber} PR #${openPR.number}; will re-process`,
             { issueNumber },
           );
+          // Backfill the resolved branchName into the checkpoint so future
+          // reconciliation cycles don't need to re-derive it.
+          if (!issueStatus.branchName && branch) {
+            await this.fleetCheckpoint.setIssueStatus(
+              issueNumber,
+              issueStatus.status,
+              issueStatus.worktreePath,
+              branch,
+              issueStatus.lastPhase,
+              issueStatus.issueTitle,
+            );
+          }
         }
       } catch (err) {
         this.logger.warn(

--- a/tests/fleet-orchestrator.test.ts
+++ b/tests/fleet-orchestrator.test.ts
@@ -2876,6 +2876,96 @@ describe('FleetOrchestrator — resume reconciliation', () => {
     expect(retryLogCalls).toHaveLength(1);
   });
 
+  it('derives branchName from worktreeManager when checkpoint has empty branchName', async () => {
+    const { FleetCheckpointManager } = await import('@cadre/framework/engine');
+    const setIssueStatus = vi.fn().mockResolvedValue(undefined);
+    const mockCheckpoint = makeMockFleetCheckpointForReconcile({
+      setIssueStatus,
+      getAllIssueStatuses: vi.fn().mockReturnValue([
+        // branchName is empty — simulates pre-fix checkpoint data
+        [20, { status: 'dep-merge-conflict', branchName: '', worktreePath: '', lastPhase: 0, issueTitle: 'Issue 20' }],
+      ]),
+      isIssueCompleted: vi.fn().mockReturnValue(false),
+    });
+    (FleetCheckpointManager as ReturnType<typeof vi.fn>).mockImplementationOnce(() => mockCheckpoint);
+
+    const { IssueOrchestrator } = await import('../src/core/issue-orchestrator.js');
+    (IssueOrchestrator as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      run: vi.fn().mockResolvedValue({
+        issueNumber: 20,
+        issueTitle: 'Issue 20',
+        success: true,
+        codeComplete: false,
+        phases: [],
+        totalDuration: 100,
+        tokenUsage: 500,
+      }),
+    }));
+
+    const config = makeRuntimeConfig({
+      branchTemplate: 'cadre/issue-{issue}',
+      issues: { ids: [20] },
+      commits: { conventional: true, sign: false, commitPerPhase: true, squashBeforePR: false },
+      pullRequest: { autoCreate: true, autoComplete: false, draft: true, labels: [], reviewers: [], linkIssue: true },
+      options: {
+        maxParallelIssues: 3,
+        maxParallelAgents: 3,
+        maxRetriesPerTask: 3,
+        dryRun: false,
+        resume: true,
+        invocationDelayMs: 0,
+        buildVerification: false,
+        testVerification: false,
+        perTaskBuildCheck: true,
+        maxBuildFixRounds: 2,
+        skipValidation: false,
+        maxIntegrationFixRounds: 1,
+        ambiguityThreshold: 5,
+        haltOnAmbiguity: false,
+        respondToReviews: false,
+        maxWholePrReviewRetries: 1,
+        postCostComment: false,
+      },
+    });
+
+    const issue20 = makeIssue(20);
+    const { worktreeManager, launcher, platform, logger } = makeMockDeps();
+    const notifications = { dispatch: vi.fn().mockResolvedValue(undefined) } as any;
+
+    // worktreeManager.resolveBranchName should derive the branch
+    (worktreeManager.resolveBranchName as ReturnType<typeof vi.fn>).mockImplementation(
+      (num: number, title?: string) => `cadre/issue-${num}-issue-${num}`,
+    );
+
+    // Phase 1 call (state: 'all') — merged PR found via derived branch
+    (platform as any).listPullRequests = vi.fn().mockResolvedValue([
+      { number: 61, url: 'https://github.com/owner/repo/pull/61', title: 'PR 61', headBranch: 'cadre/issue-20-issue-20', baseBranch: 'main', state: 'merged' },
+    ]);
+
+    const fleet = new FleetOrchestrator(
+      config,
+      [issue20],
+      worktreeManager as any,
+      launcher as any,
+      platform as any,
+      logger as any,
+      notifications,
+    );
+
+    await fleet.run();
+
+    // Should have used resolveBranchName to derive the branch
+    expect(worktreeManager.resolveBranchName).toHaveBeenCalledWith(20, 'Issue 20');
+
+    // Should have promoted #20 to completed using the derived branchName
+    const promotionCall = setIssueStatus.mock.calls.find(
+      ([num, status]: [number, string]) => num === 20 && status === 'completed',
+    );
+    expect(promotionCall).toBeDefined();
+    // The branchName in the setIssueStatus call should be the derived one
+    expect(promotionCall![3]).toBe('cadre/issue-20-issue-20');
+  });
+
   it('processIssue detects already-merged PRs and skips re-processing', async () => {
     const { FleetCheckpointManager } = await import('@cadre/framework/engine');
     const setIssueStatus = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Problem

The previous fix (PR #350) preserved `branchName` when setting dep-merge-conflict status going forward, but checkpoint entries created *before* the fix have empty `branchName`. This causes reconciliation Phase 1 and Phase 2 to skip those issues entirely (filtered out by `&& s.branchName`), so cadre exits immediately without retrying them.

## Fix

Add a `resolveBranch` helper in `reconcileCheckpoint()` that falls back to `worktreeManager.resolveBranchName(issueNumber, issue.title)` when the stored branchName is empty. This uses the same branch-template derivation logic as the rest of cadre.

Also backfills the resolved branchName into the checkpoint when Phase 2 merge retry fails, so future runs don't need to re-derive it.

## Test

Added test: "derives branchName from worktreeManager when checkpoint has empty branchName" — verifies that an issue with empty branchName in checkpoint still gets its PR found and promoted to completed.