### PR TITLE
fix(fleet): mark code-complete until PR merge confirmed, handle no-commits error

### DIFF
--- a/src/core/fleet-orchestrator.ts
+++ b/src/core/fleet-orchestrator.ts
@@ -59,6 +59,7 @@ export class FleetOrchestrator {
   private eventBus!: FleetEventBus;
   private reporter!: FleetReporter;
   private readonly prCompletionQueue: PullRequestCompletionQueue;
+  private readonly autoCompleteEnabled: boolean;
 
   constructor(
     private readonly config: RuntimeConfig,
@@ -79,6 +80,7 @@ export class FleetOrchestrator {
     this.contextBuilder = new ContextBuilder(config, logger);
 
     const autoComplete = this.resolveAutoCompleteConfig();
+    this.autoCompleteEnabled = autoComplete.enabled;
     this.prCompletionQueue = new PullRequestCompletionQueue(
       this.platform,
       this.logger,
@@ -155,6 +157,28 @@ export class FleetOrchestrator {
       this.logger.info(
         `PR completion subsystem finished: ${this.prCompletionQueue.getQueuedCount()} queued, ${completionFailures.length} failed`,
       );
+    }
+
+    // Promote issues whose PRs were successfully merged by the completion queue
+    // from 'code-complete' to 'completed'.  Issues whose merges failed stay as
+    // 'code-complete' so the next resume run can retry them.
+    const mergedIssueNumbers = this.prCompletionQueue.getCompletedIssueNumbers();
+    for (const issueNumber of mergedIssueNumbers) {
+      const current = this.fleetCheckpoint.getIssueStatus(issueNumber);
+      if (current && current.status === 'code-complete') {
+        await this.fleetCheckpoint.setIssueStatus(
+          issueNumber,
+          'completed',
+          current.worktreePath,
+          current.branchName,
+          current.lastPhase,
+          current.issueTitle,
+        );
+        this.logger.info(
+          `Promoted issue #${issueNumber} from code-complete to completed after PR merge`,
+          { issueNumber },
+        );
+      }
     }
 
     // Aggregate results
@@ -597,9 +621,13 @@ export class FleetOrchestrator {
             branch: branchName,
             dependencyIssueNumbers: dag ? dag.getDirectDeps(issue.number) : [],
           });
+          // Mark code-complete (not completed) — the completion queue will
+          // promote to 'completed' only after the PR is actually merged.
+          // If auto-complete is disabled the queue is a no-op and the PR
+          // stays open, so code-complete is still the correct status.
           await this.fleetCheckpoint.setIssueStatus(
             issue.number,
-            'completed',
+            'code-complete',
             '',
             branchName,
             0,
@@ -753,10 +781,14 @@ export class FleetOrchestrator {
       const result = await issueOrchestrator.run();
 
       // 7. Update fleet checkpoint
+      // When auto-complete is enabled and a PR was created, mark 'code-complete'
+      // instead of 'completed' — the completion queue promotes to 'completed'
+      // only after the PR is actually merged.
+      const willEnqueueForCompletion = this.autoCompleteEnabled && result.pr?.number != null && result.success;
       const status = result.budgetExceeded
         ? 'budget-exceeded'
         : result.success
-          ? 'completed'
+          ? (willEnqueueForCompletion ? 'code-complete' : 'completed')
           : result.codeComplete
             ? 'code-complete'
             : 'failed';

--- a/src/core/pr-completion-queue.ts
+++ b/src/core/pr-completion-queue.ts
@@ -133,6 +133,10 @@ export class PullRequestCompletionQueue {
     return this.queued.size;
   }
 
+  getCompletedIssueNumbers(): ReadonlySet<number> {
+    return this.completedIssueNumbers;
+  }
+
   getFailures(): CompletionFailure[] {
     return [...this.failures];
   }

--- a/src/executors/pr-composition-phase-executor.ts
+++ b/src/executors/pr-composition-phase-executor.ts
@@ -174,7 +174,38 @@ export class PRCompositionPhaseExecutor implements PhaseExecutor {
       draft: ctx.config.pullRequest.draft,
       labels,
       reviewers: ctx.config.pullRequest.reviewers,
+    }).catch((err: Error) => {
+      // "No commits between base and head" means the branch content was
+      // already merged into the base (e.g. via squash-merge of earlier PRs
+      // that included the same dependency commits).  Check for a merged PR.
+      if (err.message?.includes('No commits between')) {
+        ctx.services.logger.warn(
+          `PR creation failed (no unique commits) for issue #${ctx.issue.number}; checking for already-merged PR`,
+          { issueNumber: ctx.issue.number },
+        );
+        return null;
+      }
+      throw err;
     });
+
+    if (pr === null) {
+      // Branch has no unique commits — look for a merged PR that covers it.
+      const allPRs = await ctx.platform.listPullRequests({ head: ctx.worktree.branch, state: 'all' });
+      const mergedPR = allPRs.find((p) => p.state === 'merged');
+      if (mergedPR) {
+        ctx.services.logger.info(
+          `Issue #${ctx.issue.number} branch already merged via PR #${mergedPR.number}`,
+          { issueNumber: ctx.issue.number },
+        );
+        ctx.callbacks.setPR?.(mergedPR);
+        return;
+      }
+      // No merged PR found — the branch genuinely has no changes.
+      throw new Error(
+        `No commits between ${ctx.config.baseBranch} and ${ctx.worktree.branch} and no merged PR found`,
+      );
+    }
+
     ctx.callbacks.setPR?.(pr);
     // Fix 2: Do not merge inline — the fleet orchestrator's completion queue handles serial merge.
   }

--- a/tests/fleet-orchestrator.test.ts
+++ b/tests/fleet-orchestrator.test.ts
@@ -1067,7 +1067,7 @@ describe('FleetOrchestrator — skip issues with existing open PRs', () => {
     expect(infoCall).toBeDefined();
   });
 
-  it('records the issue as completed in the fleet checkpoint when skipping', async () => {
+  it('records the issue as code-complete in the fleet checkpoint when skipping (PR not yet merged)', async () => {
     const { FleetCheckpointManager } = await import('@cadre/framework/engine');
     const setIssueStatusMock = vi.fn().mockResolvedValue(undefined);
     (FleetCheckpointManager as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
@@ -1098,10 +1098,16 @@ describe('FleetOrchestrator — skip issues with existing open PRs', () => {
 
     await fleet.run();
 
+    // Should be code-complete, not completed — the PR hasn't been merged yet
+    const codeCompleteCall = setIssueStatusMock.mock.calls.find(
+      (args: unknown[]) => args[0] === 1 && args[1] === 'code-complete',
+    );
+    expect(codeCompleteCall).toBeDefined();
+    // Should NOT have been marked completed
     const completedCall = setIssueStatusMock.mock.calls.find(
       (args: unknown[]) => args[0] === 1 && args[1] === 'completed',
     );
-    expect(completedCall).toBeDefined();
+    expect(completedCall).toBeUndefined();
   });
 
   it('proceeds normally (provisions worktree) when findOpenPR() throws an error', async () => {
@@ -1203,7 +1209,27 @@ describe('FleetOrchestrator — skip issues with existing open PRs', () => {
     expect(result.failedIssues).toHaveLength(0);
   });
 
-  it('on resume, queues and auto-completes existing open PRs', async () => {
+  it('on resume, queues and auto-completes existing open PRs and promotes to completed', async () => {
+    const { FleetCheckpointManager } = await import('@cadre/framework/engine');
+    const setIssueStatusMock = vi.fn().mockResolvedValue(undefined);
+    const issueStatuses: Record<number, any> = {};
+    // Track setIssueStatus calls to feed back into getIssueStatus
+    setIssueStatusMock.mockImplementation(async (num: number, status: string, wt: string, branch: string, phase: number, title: string) => {
+      issueStatuses[num] = { status, worktreePath: wt, branchName: branch, lastPhase: phase, issueTitle: title };
+    });
+    (FleetCheckpointManager as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      load: vi.fn().mockResolvedValue(undefined),
+      isIssueCompleted: vi.fn().mockReturnValue(false),
+      setIssueStatus: setIssueStatusMock,
+      clearIssueStatus: vi.fn().mockResolvedValue(undefined),
+      recordTokenUsage: vi.fn().mockResolvedValue(undefined),
+      getIssueStatus: vi.fn().mockImplementation((num: number) => issueStatuses[num] ?? null),
+      setDag: vi.fn().mockResolvedValue(undefined),
+      markWaveComplete: vi.fn().mockResolvedValue(undefined),
+      getState: vi.fn().mockReturnValue({ completedWaves: [] }),
+      getAllIssueStatuses: vi.fn().mockReturnValue([]),
+    }));
+
     const config = makeRuntimeConfig({
       branchTemplate: 'cadre/issue-{issue}',
       issues: { ids: [1, 2, 3] },
@@ -1258,11 +1284,24 @@ describe('FleetOrchestrator — skip issues with existing open PRs', () => {
 
     await fleet.run();
 
+    // PRs should have been merged
     expect(platform.mergePullRequest).toHaveBeenCalledTimes(3);
     expect(platform.mergePullRequest).toHaveBeenCalledWith(201, config.baseBranch, 'squash');
     expect(platform.mergePullRequest).toHaveBeenCalledWith(202, config.baseBranch, 'squash');
     expect(platform.mergePullRequest).toHaveBeenCalledWith(203, config.baseBranch, 'squash');
     expect(worktreeManager.provision).not.toHaveBeenCalled();
+
+    // All three issues should first be set to code-complete, then promoted to completed
+    for (const issueNum of [1, 2, 3]) {
+      const codeCompleteCall = setIssueStatusMock.mock.calls.find(
+        (args: unknown[]) => args[0] === issueNum && args[1] === 'code-complete',
+      );
+      expect(codeCompleteCall).toBeDefined();
+      const completedCall = setIssueStatusMock.mock.calls.find(
+        (args: unknown[]) => args[0] === issueNum && args[1] === 'completed',
+      );
+      expect(completedCall).toBeDefined();
+    }
   });
 
   it('does not auto-complete existing open PRs when not resuming', async () => {


### PR DESCRIPTION
## Problem

Two bugs causing incorrect checkpoint state:

### Bug 1: Issues marked `completed` before PR is merged
When `processIssue` finds an existing open PR, it immediately marks the issue as `completed` and enqueues the PR for auto-completion. If the completion queue fails to merge (e.g. dirty/conflicting state), the checkpoint permanently says `completed` while the PR remains open and unmerged.

**Affected TAAD issues:** #20, #21, #24, #25, #27 — all had open PRs with `mergeable_state=dirty`, checkpoint said `completed`.

### Bug 2: "No commits between" error on PR creation
When a branch's content has already been merged into main via other PRs (squash merges of dependency branches), the branch has 0 unique commits. PR creation fails with "No commits between main and branch", leaving the issue stuck as `code-complete` with an error.

**Affected TAAD issue:** #26

## Fix

### Bug 1: `code-complete` until merge confirmed
- **Existing open PR path**: Mark `code-complete` instead of `completed` when enqueuing a PR
- **Normal pipeline**: When auto-complete is enabled and a PR will be enqueued, mark `code-complete` instead of `completed`
- **After `drain()`**: New promotion loop queries `getCompletedIssueNumbers()` from the completion queue and promotes `code-complete` → `completed` only for issues whose PRs were actually merged
- Added `getCompletedIssueNumbers()` API to `PullRequestCompletionQueue`

### Bug 2: Handle "No commits between" gracefully
- `createPullRequest` in pr-composition-phase-executor now catches "No commits between" errors
- Checks for an already-merged PR on the same branch and treats it as success
- If no merged PR exists, throws a clear error

## Tests
- Updated test: "records the issue as code-complete when skipping (PR not yet merged)"
- Updated test: "on resume, queues and auto-completes existing open PRs and promotes to completed" — verifies `code-complete` → `completed` promotion flow with stateful mock