### PR TITLE
fix(merge): poll mergeable state after conflict resolution instead of fixed delay

### DIFF
--- a/src/core/merge-retry.ts
+++ b/src/core/merge-retry.ts
@@ -7,6 +7,12 @@ export const MERGE_MAX_ATTEMPTS = 3;
 /** Base delay (ms) after a branch update before retrying merge. Doubled per attempt for exponential backoff. */
 export const MERGE_BASE_DELAY_MS = 15_000;
 
+/** Maximum time (ms) to poll GitHub for mergeable state to settle after a push. */
+const MERGEABLE_POLL_TIMEOUT_MS = 90_000;
+
+/** Interval (ms) between mergeable-state polls. */
+const MERGEABLE_POLL_INTERVAL_MS = 10_000;
+
 /** Context passed to each merge attempt for logging and identification. */
 export interface MergeAttemptContext {
   prNumber: number;
@@ -36,6 +42,9 @@ export interface MergeRetryOptions {
   mergeMethod?: PullRequestMergeMethod;
   /** Optional agent-based fallback when updateBranch alone does not suffice. */
   conflictResolver?: ConflictResolverCallback;
+  /** Timeout (ms) for polling mergeable state after conflict resolution push.
+   *  Set to 0 to skip polling entirely. Defaults to {@link MERGEABLE_POLL_TIMEOUT_MS}. */
+  mergeablePollTimeoutMs?: number;
 }
 
 /**
@@ -67,6 +76,7 @@ export class MergeRetryHelper {
   ): Promise<boolean> {
     const maxAttempts = opts.maxAttempts ?? MERGE_MAX_ATTEMPTS;
     const baseDelayMs = opts.baseDelayMs ?? MERGE_BASE_DELAY_MS;
+    const mergeablePollTimeoutMs = opts.mergeablePollTimeoutMs ?? MERGEABLE_POLL_TIMEOUT_MS;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
@@ -98,8 +108,10 @@ export class MergeRetryHelper {
             try {
               const resolved = await opts.conflictResolver(ctx, error);
               if (resolved) {
-                const delay = baseDelayMs * Math.pow(2, attempt - 1);
-                await new Promise((r) => setTimeout(r, delay));
+                // After a conflict-resolver push, poll GitHub until mergeable_state
+                // settles (typically 30-60s after force-push).  This avoids wasting
+                // a retry attempt on stale dirty state.
+                await this.waitForMergeableState(ctx, mergeablePollTimeoutMs);
                 continue;
               }
             } catch (resolveErr) {
@@ -120,6 +132,41 @@ export class MergeRetryHelper {
       }
     }
     return false;
+  }
+
+  /**
+   * Poll the PR's mergeable_state until it's no longer 'unknown' or until
+   * the timeout expires.  After a force-push, GitHub takes 30-60s to
+   * recalculate merge status.  Polling avoids wasting an attempt on stale
+   * dirty state.
+   */
+  private async waitForMergeableState(ctx: MergeAttemptContext, timeoutMs: number): Promise<void> {
+    if (timeoutMs <= 0) return;
+    const deadline = Date.now() + timeoutMs;
+    // Initial wait — GitHub needs a few seconds after push to even start recalculating
+    await new Promise((r) => setTimeout(r, MERGEABLE_POLL_INTERVAL_MS));
+
+    while (Date.now() < deadline) {
+      try {
+        const pr = await this.platform.getPullRequest(ctx.prNumber);
+        const state = pr.mergeableState ?? 'unknown';
+        if (state !== 'unknown') {
+          this.logger.info(
+            `PR #${ctx.prNumber} mergeable state settled: ${state}`,
+            { issueNumber: ctx.issueNumber },
+          );
+          return;
+        }
+      } catch {
+        // Ignore transient API errors during polling
+      }
+      await new Promise((r) => setTimeout(r, MERGEABLE_POLL_INTERVAL_MS));
+    }
+
+    this.logger.info(
+      `PR #${ctx.prNumber} mergeable state poll timed out after ${timeoutMs / 1000}s; proceeding with merge attempt`,
+      { issueNumber: ctx.issueNumber },
+    );
   }
 }
 

--- a/src/core/pr-completion-queue.ts
+++ b/src/core/pr-completion-queue.ts
@@ -178,6 +178,8 @@ export class PullRequestCompletionQueue {
         baseDelayMs: this.basePostResolveDelayMs,
         mergeMethod: this.mergeMethod,
         conflictResolver: conflictResolverCb,
+        // When basePostResolveDelayMs is 0 (tests), skip polling too.
+        mergeablePollTimeoutMs: this.basePostResolveDelayMs === 0 ? 0 : undefined,
       },
     );
 

--- a/src/platform/github-provider.ts
+++ b/src/platform/github-provider.ts
@@ -135,6 +135,10 @@ export class GitHubProvider implements PlatformProvider {
     const result = await this.getAPI().getPullRequest(prNumber);
     const ghState = asString(result.state);
     const merged = !!(result.merged || result.merged_at);
+    const rawMergeableState = asString((result as Record<string, unknown>).mergeable_state);
+    const mergeableState = (['clean', 'dirty', 'behind', 'blocked', 'unstable'].includes(rawMergeableState)
+      ? rawMergeableState
+      : 'unknown') as PullRequestInfo['mergeableState'];
     return {
       number: asNumber(result.number),
       url: asString(result.html_url) || asString(result.url),
@@ -142,6 +146,7 @@ export class GitHubProvider implements PlatformProvider {
       headBranch: asString(asRecord(result.head).ref),
       baseBranch: asString(asRecord(result.base).ref),
       state: merged ? 'merged' : ghState === 'closed' ? 'closed' : 'open',
+      mergeableState,
     };
   }
 

--- a/src/platform/provider.ts
+++ b/src/platform/provider.ts
@@ -37,6 +37,8 @@ export interface PullRequestInfo {
   baseBranch: string;
   /** Lifecycle state of the PR. */
   state: 'open' | 'closed' | 'merged';
+  /** GitHub mergeable state (only populated by getPullRequest). */
+  mergeableState?: 'clean' | 'dirty' | 'behind' | 'blocked' | 'unknown' | 'unstable';
 }
 
 /**

--- a/tests/pr-completion-queue.test.ts
+++ b/tests/pr-completion-queue.test.ts
@@ -35,7 +35,11 @@ describe('PullRequestCompletionQueue', () => {
     } as unknown as Logger;
 
     mergePullRequest = vi.fn().mockResolvedValue(undefined);
-    platform = { mergePullRequest, updatePullRequestBranch: vi.fn().mockResolvedValue(false) } as unknown as PlatformProvider;
+    platform = {
+      mergePullRequest,
+      updatePullRequestBranch: vi.fn().mockResolvedValue(false),
+      getPullRequest: vi.fn().mockResolvedValue({ mergeableState: 'clean' }),
+    } as unknown as PlatformProvider;
   });
 
   it('skips enqueue and drain work when disabled', async () => {


### PR DESCRIPTION
## Problem

After the conflict-resolver agent successfully pushes resolved conflicts, the `MergeRetryHelper` waits a fixed 15s delay before retrying the merge. GitHub typically needs 30-60s to recalculate `mergeable_state` after a force-push, so the retry sees stale `dirty` state and wastes an entire conflict-resolver invocation (2-12 minutes per attempt).

Observed in TAAD: PR #61 conflicts resolved and pushed at 22:34:51, merge retry at 22:35:07 (16s later) — GitHub still reported dirty, triggering attempt 2.

## Fix

After a conflict-resolver push, poll the PR's `mergeable_state` via `getPullRequest()` instead of sleeping a fixed delay. Polls every 10s, up to 90s timeout. Only proceeds once the state transitions from `unknown` to a definitive state (`clean`, `dirty`, `behind`, etc.).

### Changes
- **`PullRequestInfo`**: Added optional `mergeableState` field
- **`github-provider.ts`**: Populate `mergeableState` from `mergeable_state` in `getPullRequest()`
- **`merge-retry.ts`**: Added `waitForMergeableState()` polling method; replaced fixed delay after conflict resolution with polling; added `mergeablePollTimeoutMs` option to `MergeRetryOptions` (set to 0 in tests to skip)
- **`pr-completion-queue.ts`**: Pass `mergeablePollTimeoutMs: 0` when `basePostResolveDelayMs` is 0 (test mode)