### PR TITLE
fix(pipeline): re-sync agent files after stripCadreFiles so Phase 5 can invoke agents

### DIFF
--- a/src/core/fleet-orchestrator.ts
+++ b/src/core/fleet-orchestrator.ts
@@ -780,6 +780,7 @@ export class FleetOrchestrator {
         this.platform,
         this.logger.child(issue.number, join(this.cadreDir, 'logs')),
         this.notifications,
+        () => this.worktreeManager.resyncAgentFiles(worktree.path, issue.number).then(() => {}),
       );
 
       // 6. Run the 5-phase pipeline

--- a/src/core/issue-orchestrator.ts
+++ b/src/core/issue-orchestrator.ts
@@ -72,6 +72,7 @@ export class IssueOrchestrator {
     private readonly platform: PlatformProvider,
     private readonly logger: Logger,
     notificationManager?: NotificationManager,
+    private readonly resyncAgentFiles?: () => Promise<void>,
   ) {
     this.progressDir = join(
       worktree.path,
@@ -430,6 +431,12 @@ export class IssueOrchestrator {
     // Fix 7: stripCadreFiles now uses a squash approach that doesn't produce
     // cherry-pick conflicts, so no conflict resolver callback is needed.
     await this.commitManager.stripCadreFiles(this.worktree.baseCommit);
+
+    // Re-sync agent symlinks: stripCadreFiles removes them (they're cadre
+    // artifacts), but Phase 5 (PR Composition) still needs to invoke agents.
+    if (this.resyncAgentFiles) {
+      await this.resyncAgentFiles();
+    }
   }
 
   private async commitPhase(phase: PhaseDefinition): Promise<void> {

--- a/src/git/worktree-provisioner.ts
+++ b/src/git/worktree-provisioner.ts
@@ -77,6 +77,15 @@ export class WorktreeProvisioner {
   }
 
   /**
+   * Re-sync agent files into an existing worktree.  Used after
+   * `stripCadreFiles` removes agent symlinks so that subsequent
+   * phases (e.g. PR Composition) can still invoke agents.
+   */
+  async resyncAgentFiles(worktreePath: string, issueNumber: number): Promise<string[]> {
+    return this.agentFileSync.syncAgentFiles(worktreePath, issueNumber);
+  }
+
+  /**
    * Create a worktree for an issue.
    * If the worktree already exists, validate and return info.
    * When `resume` is true and the worktree is absent, check the remote branch and

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -37,6 +37,10 @@ export class WorktreeManager {
     return this.provisioner.buildAgentCache();
   }
 
+  async resyncAgentFiles(...args: Parameters<WorktreeProvisioner['resyncAgentFiles']>) {
+    return this.provisioner.resyncAgentFiles(...args);
+  }
+
   async provision(...args: Parameters<WorktreeProvisioner['provision']>) {
     return this.provisioner.provision(...args);
   }


### PR DESCRIPTION
`stripCadreFiles` (end of Phase 4 – Integration Verification) removes agent symlinks from the worktree since they're cadre artifacts that shouldn't go into the PR. However, Phase 5 (PR Composition) still needs to invoke agents like `pr-composer`, which fails with `No such agent: pr-composer, available:` because the symlinks are gone.\n\n**Root cause:** The agent symlinks in `.github/agents/` are cleaned by `git clean -fd` during the squash-and-strip operation, leaving the directory empty. Phase 5 then can't find any agents.\n\n**Fix:** Pass a `resyncAgentFiles` callback from `FleetOrchestrator` → `IssueOrchestrator`. After `stripCadreFiles` completes, the callback re-creates the symlinks from the shared agent cache (`~/.cadre/agents-cache-copilot/`), restoring agent availability for Phase 5.\n\nChanges:\n- `WorktreeProvisioner.resyncAgentFiles()` – new method exposing the existing `AgentFileSync.syncAgentFiles`\n- `WorktreeManager.resyncAgentFiles()` – facade delegation\n- `IssueOrchestrator` – optional `resyncAgentFiles` callback parameter (no test breakage)\n- `FleetOrchestrator` – passes the callback when constructing `IssueOrchestrator`\n- `stripCadreFilesAfterIntegration()` – calls the callback after stripping"