### PR TITLE
fix(config): namespace default stateDir by projectName to prevent checkpoint collisions

### DIFF
--- a/packages/framework/__tests__/engine/checkpoint/checkpoint.test.ts
+++ b/packages/framework/__tests__/engine/checkpoint/checkpoint.test.ts
@@ -3,7 +3,7 @@ import { mkdir, writeFile, readFile, access, rename, readdir, stat, rm } from 'n
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { CheckpointManager, FleetCheckpointManager } from '../../../src/engine/checkpoint/checkpoint.js';
-import type { CheckpointState, FleetIssueStatus } from '../../../src/engine/checkpoint/checkpoint.js';
+import type { CheckpointState, FleetCheckpointState, FleetIssueStatus } from '../../../src/engine/checkpoint/checkpoint.js';
 import type { CheckpointStore } from '../../../src/engine/checkpoint/checkpoint.js';
 import { Logger } from '../../../src/core/logger.js';
 import type { GateResult } from '../../../src/engine/types.js';
@@ -766,5 +766,76 @@ describe('FleetCheckpointManager', () => {
   it('getAllIssueStatuses returns empty array before load', () => {
     const manager = new FleetCheckpointManager(tempDir, 'my-project', mockLogger);
     expect(manager.getAllIssueStatuses()).toEqual([]);
+  });
+
+  it('should migrate a legacy checkpoint from the parent directory when projectName matches', async () => {
+    // Write a legacy checkpoint at the parent directory (old unsegmented path)
+    const parentDir = join(tempDir, '..');
+    const legacyPath = join(parentDir, 'fleet-checkpoint.json');
+    const legacyState: FleetCheckpointState = {
+      projectName: 'my-project',
+      version: 1,
+      issues: {
+        42: {
+          status: 'completed',
+          issueTitle: 'Legacy issue',
+          worktreePath: '/old/path',
+          branchName: 'cadre/issue-42',
+          lastPhase: 5,
+        },
+      },
+      tokenUsage: { total: 1000, byIssue: { 42: 1000 } },
+      startedAt: '2026-01-01T00:00:00.000Z',
+      lastCheckpoint: '2026-01-01T01:00:00.000Z',
+      resumeCount: 3,
+    };
+    await writeFile(legacyPath, JSON.stringify(legacyState));
+
+    // Load from the namespaced directory — should discover and migrate the legacy file
+    const manager = new FleetCheckpointManager(tempDir, 'my-project', mockLogger);
+    const state = await manager.load();
+
+    expect(state.projectName).toBe('my-project');
+    expect(state.issues[42]?.status).toBe('completed');
+    expect(state.issues[42]?.issueTitle).toBe('Legacy issue');
+    expect(state.resumeCount).toBe(4); // incremented from 3
+
+    // Clean up
+    await rm(legacyPath, { force: true });
+  });
+
+  it('should NOT migrate a legacy checkpoint when projectName does not match', async () => {
+    // Write a legacy checkpoint at the parent directory with a different project name
+    const parentDir = join(tempDir, '..');
+    const legacyPath = join(parentDir, 'fleet-checkpoint.json');
+    const legacyState: FleetCheckpointState = {
+      projectName: 'other-project',
+      version: 1,
+      issues: {
+        99: {
+          status: 'completed',
+          issueTitle: 'Other project issue',
+          worktreePath: '/other/path',
+          branchName: 'cadre/issue-99',
+          lastPhase: 5,
+        },
+      },
+      tokenUsage: { total: 500, byIssue: { 99: 500 } },
+      startedAt: '2026-01-01T00:00:00.000Z',
+      lastCheckpoint: '2026-01-01T01:00:00.000Z',
+      resumeCount: 1,
+    };
+    await writeFile(legacyPath, JSON.stringify(legacyState));
+
+    // Load from the namespaced directory — should NOT migrate the mismatched file
+    const manager = new FleetCheckpointManager(tempDir, 'my-project', mockLogger);
+    const state = await manager.load();
+
+    expect(state.projectName).toBe('my-project');
+    expect(state.issues).toEqual({});
+    expect(state.resumeCount).toBe(0);
+
+    // Clean up
+    await rm(legacyPath, { force: true });
   });
 });

--- a/packages/framework/src/engine/checkpoint/checkpoint.ts
+++ b/packages/framework/src/engine/checkpoint/checkpoint.ts
@@ -2,7 +2,7 @@
  * Checkpoint management for per-issue and fleet-level pipeline state.
  */
 
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import { atomicWriteJSON, readJSON, exists, ensureDir, copyFile } from '../util/fs.js';
 import type { Logger, GateResult, TokenRecord } from '../types.js';
 
@@ -470,6 +470,27 @@ export class FleetCheckpointManager {
         return this.state;
       } catch {
         this.logger.warn('Failed to load fleet checkpoint, starting fresh');
+      }
+    }
+
+    // Migration: check for a legacy checkpoint at the parent directory
+    // (before stateDir was namespaced by projectName). If it exists and
+    // belongs to this project, copy it to the new location.
+    const legacyPath = join(dirname(this.cadreDir), 'fleet-checkpoint.json');
+    if (legacyPath !== this.checkpointPath && (await this.store.exists(legacyPath))) {
+      try {
+        const legacy = await this.store.readJSON<FleetCheckpointState>(legacyPath);
+        if (legacy.projectName === this.projectName) {
+          this.logger.info(
+            `Migrating legacy fleet checkpoint from ${legacyPath} to ${this.checkpointPath}`,
+          );
+          this.state = legacy;
+          this.state.resumeCount += 1;
+          await this.save();
+          return this.state;
+        }
+      } catch {
+        // Legacy file is unreadable — ignore and start fresh
       }
     }
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -65,12 +65,15 @@ export async function loadConfig(configPath: string): Promise<RuntimeConfig> {
     ? config.repoPath
     : resolve(configDir, config.repoPath);
 
-  // stateDir: all cadre state lives outside the target repo so it never pollutes git
+  // stateDir: all cadre state lives outside the target repo so it never pollutes git.
+  // When no stateDir is specified, default to ~/.cadre/{projectName} so each
+  // project gets its own checkpoint, logs, and worktree directories — preventing
+  // concurrent runs from clobbering each other's state.
   const resolvedStateDir = config.stateDir
     ? isAbsolute(config.stateDir)
       ? config.stateDir
       : resolve(configDir, config.stateDir)
-    : join(homedir(), '.cadre');
+    : join(homedir(), '.cadre', config.projectName);
 
   const resolvedWorktreeRoot = config.worktreeRoot
     ? isAbsolute(config.worktreeRoot)

--- a/tests/config-loader-paths.test.ts
+++ b/tests/config-loader-paths.test.ts
@@ -164,14 +164,14 @@ describe('loadConfig – stateDir resolution', () => {
     vi.clearAllMocks();
   });
 
-  it('defaults stateDir to ~/.cadre when absent from config', async () => {
+  it('defaults stateDir to ~/.cadre/{projectName} when absent from config', async () => {
     const cfg = makeConfig();
     // Remove stateDir
     delete (cfg as Record<string, unknown>).stateDir;
     setupFs(cfg);
 
     const config = await loadConfig('/tmp/cadre.config.json');
-    const expected = join(homedir(), '.cadre');
+    const expected = join(homedir(), '.cadre', 'test-project');
     expect(config.stateDir).toBe(expected);
   });
 
@@ -226,7 +226,7 @@ describe('loadConfig – worktreeRoot resolution', () => {
     setupFs(cfg);
 
     const config = await loadConfig('/tmp/cadre.config.json');
-    const expectedStateDir = join(homedir(), '.cadre');
+    const expectedStateDir = join(homedir(), '.cadre', 'test-project');
     expect(config.worktreeRoot).toBe(join(expectedStateDir, 'worktrees'));
   });
 });


### PR DESCRIPTION
## Problem

When `stateDir` is not explicitly set in a cadre config, the default was `~/.cadre` for **all** projects. This caused concurrent or sequential runs of different projects (e.g. `aamf-108` and `lore`) to share the same `fleet-checkpoint.json`, `logs/`, and `worktrees/` directories — one project's checkpoint data would silently overwrite another's.

This manifested as:
- AAMF issue #108 completing all 4 implementation sessions + integration verification, but its checkpoint being wiped by a concurrent Lore run
- On re-run, cadre saw Lore's issue #108 (a different issue entirely) as already handled, causing immediate no-op exits
- Worktree and log collisions between projects sharing issue numbers

## Fix

### 1. Namespace default stateDir by projectName (`src/config/loader.ts`)
- Default `stateDir` changed from `~/.cadre` to `~/.cadre/{projectName}`
- Explicit `stateDir` values are unchanged (no breaking change)

### 2. Legacy checkpoint migration (`packages/framework/src/engine/checkpoint/checkpoint.ts`)
- `FleetCheckpointManager.load()` now checks for a legacy checkpoint at the parent directory when the namespaced path doesn't exist
- If the legacy file's `projectName` matches, it's automatically migrated to the new location
- Mismatched project names are ignored (fresh start)

## Testing
- Updated config loader tests to expect `~/.cadre/{projectName}` as the default
- Added migration tests: matching projectName migrates, mismatched projectName starts fresh
- All existing tests pass