### PR TITLE
refactor(test): extract shared IssueOrchestrator test helpers and ensure stateDir

### DIFF
--- a/tests/helpers/make-mock-checkpoint.ts
+++ b/tests/helpers/make-mock-checkpoint.ts
@@ -1,0 +1,53 @@
+import { vi } from 'vitest';
+import type { CheckpointManager } from '@cadre/framework/engine';
+
+/**
+ * Create a mock CheckpointManager.
+ *
+ * @param completedPhaseIds - Phase IDs to report as already completed.
+ *   `isPhaseCompleted()` dynamically returns true for these IDs.
+ * @param overrides - Additional method overrides spread onto the mock.
+ */
+export function makeMockCheckpoint(
+  completedPhaseIds: number[] = [],
+  overrides: Record<string, unknown> = {},
+): CheckpointManager {
+  const completedSubTasks = new Set<string>();
+
+  return {
+    load: vi.fn().mockResolvedValue({}),
+    getState: vi.fn().mockReturnValue({
+      issueNumber: 42,
+      currentPhase: 1,
+      completedPhases: completedPhaseIds,
+      completedTasks: [],
+      blockedTasks: [],
+      failedTasks: [],
+      phaseOutputs: {},
+      gateResults: {},
+      tokenUsage: { total: 0, byPhase: {}, byAgent: {} },
+      worktreePath: '/tmp/worktree-42',
+      branchName: 'cadre/issue-42',
+      baseCommit: 'abc123',
+      resumeCount: 0,
+    }),
+    getResumePoint: vi.fn().mockReturnValue({ phase: 1, task: null }),
+    isPhaseCompleted: vi.fn().mockImplementation((phaseId: number) =>
+      completedPhaseIds.includes(phaseId),
+    ),
+    isTaskCompleted: vi.fn().mockReturnValue(false),
+    startPhase: vi.fn().mockResolvedValue(undefined),
+    completePhase: vi.fn().mockResolvedValue(undefined),
+    startTask: vi.fn().mockResolvedValue(undefined),
+    completeTask: vi.fn().mockResolvedValue(undefined),
+    failTask: vi.fn().mockResolvedValue(undefined),
+    blockTask: vi.fn().mockResolvedValue(undefined),
+    recordTokenUsage: vi.fn().mockResolvedValue(undefined),
+    recordGateResult: vi.fn().mockResolvedValue(undefined),
+    setWorktreeInfo: vi.fn().mockResolvedValue(undefined),
+    startSubTask: vi.fn().mockResolvedValue(undefined),
+    completeSubTask: vi.fn(async (id: string) => { completedSubTasks.add(id); }),
+    isSubTaskCompleted: vi.fn((id: string) => completedSubTasks.has(id)),
+    ...overrides,
+  } as unknown as CheckpointManager;
+}

--- a/tests/helpers/make-mock-issue.ts
+++ b/tests/helpers/make-mock-issue.ts
@@ -1,0 +1,21 @@
+import type { IssueDetail } from '../../src/platform/provider.js';
+
+/**
+ * Create a mock IssueDetail with sensible defaults.
+ * All fields satisfy the IssueDetail interface without `as unknown` casts.
+ */
+export function makeMockIssue(overrides: Partial<IssueDetail> = {}): IssueDetail {
+  return {
+    number: 42,
+    title: 'Test Issue',
+    body: 'Test body',
+    labels: [],
+    assignees: [],
+    comments: [],
+    state: 'open',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    linkedPRs: [],
+    ...overrides,
+  };
+}

--- a/tests/helpers/make-mock-logger.ts
+++ b/tests/helpers/make-mock-logger.ts
@@ -1,0 +1,21 @@
+import { vi } from 'vitest';
+import type { Logger } from '@cadre/framework/core';
+
+/**
+ * Create a mock Logger with all methods stubbed via vi.fn().
+ * Includes `.child()` which returns another mock logger.
+ */
+export function makeMockLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnValue({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  } as unknown as Logger;
+}

--- a/tests/helpers/make-mock-worktree.ts
+++ b/tests/helpers/make-mock-worktree.ts
@@ -1,0 +1,17 @@
+import type { WorktreeInfo } from '../../src/git/worktree.js';
+
+/**
+ * Create a mock WorktreeInfo with sensible defaults.
+ * All fields satisfy the WorktreeInfo interface without `as unknown` casts.
+ */
+export function makeMockWorktree(overrides: Partial<WorktreeInfo> = {}): WorktreeInfo {
+  return {
+    issueNumber: 42,
+    path: '/tmp/worktree-42',
+    branch: 'cadre/issue-42',
+    exists: true,
+    baseCommit: 'abc123',
+    syncedAgentFiles: [],
+    ...overrides,
+  };
+}

--- a/tests/issue-orchestrator-ambiguity.test.ts
+++ b/tests/issue-orchestrator-ambiguity.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { IssueOrchestrator } from '../src/core/issue-orchestrator.js';
 import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
-import type { CheckpointManager } from '@cadre/framework/engine';
+import { makeMockCheckpoint } from './helpers/make-mock-checkpoint.js';
+import { makeMockIssue } from './helpers/make-mock-issue.js';
+import { makeMockWorktree } from './helpers/make-mock-worktree.js';
+import { makeMockLogger } from './helpers/make-mock-logger.js';
 import type { AgentLauncher } from '../src/core/agent-launcher.js';
-import type { PlatformProvider, IssueDetail } from '../src/platform/provider.js';
-import type { WorktreeInfo } from '../src/git/worktree.js';
+import type { PlatformProvider } from '../src/platform/provider.js';
 
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 
@@ -199,64 +201,11 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
   });
 }
 
-function makeIssue(): IssueDetail {
-  return {
-    number: 42,
-    title: 'Test Issue',
-    body: 'Test body',
-    labels: [],
-    assignees: [],
-    comments: [],
-    state: 'open',
-    createdAt: '2024-01-01T00:00:00Z',
-    updatedAt: '2024-01-01T00:00:00Z',
-    linkedPRs: [],
-  };
-}
-
-function makeWorktree(): WorktreeInfo {
-  return {
-    issueNumber: 42,
-    path: '/tmp/worktree-42',
-    branch: 'cadre/issue-42',
-    exists: true,
-    baseCommit: 'abc123',
-    syncedAgentFiles: [],
-  };
-}
+const makeIssue = () => makeMockIssue();
+const makeWorktree = () => makeMockWorktree();
 
 /** Checkpoint where phases 2–5 are already complete so only phase 1 runs. */
-function makeCheckpointPhase1Only(): CheckpointManager {
-  const completedPhaseIds = [2, 3, 4, 5];
-  return {
-    load: vi.fn().mockResolvedValue({}),
-    getState: vi.fn().mockReturnValue({
-      issueNumber: 42,
-      currentPhase: 1,
-      completedPhases: completedPhaseIds,
-      completedTasks: [],
-      blockedTasks: [],
-      failedTasks: [],
-      phaseOutputs: {},
-      gateResults: {},
-      tokenUsage: { total: 0, byPhase: {}, byAgent: {} },
-      worktreePath: '/tmp/worktree-42',
-      branchName: 'cadre/issue-42',
-      baseCommit: 'abc123',
-    }),
-    getResumePoint: vi.fn().mockReturnValue({ phase: 1, task: null }),
-    isPhaseCompleted: vi.fn().mockImplementation((id: number) => completedPhaseIds.includes(id)),
-    startPhase: vi.fn().mockResolvedValue(undefined),
-    completePhase: vi.fn().mockResolvedValue(undefined),
-    isTaskCompleted: vi.fn().mockReturnValue(false),
-    startTask: vi.fn().mockResolvedValue(undefined),
-    completeTask: vi.fn().mockResolvedValue(undefined),
-    failTask: vi.fn().mockResolvedValue(undefined),
-    blockTask: vi.fn().mockResolvedValue(undefined),
-    recordTokenUsage: vi.fn().mockResolvedValue(undefined),
-    recordGateResult: vi.fn().mockResolvedValue(undefined),
-  } as unknown as CheckpointManager;
-}
+const makeCheckpointPhase1Only = () => makeMockCheckpoint([2, 3, 4, 5]);
 
 function makeMockLauncher(): AgentLauncher {
   return {
@@ -284,14 +233,7 @@ function makeMockPlatform(): PlatformProvider {
   } as unknown as PlatformProvider;
 }
 
-function makeLogger() {
-  return {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  };
-}
+const makeLogger = () => makeMockLogger();
 
 function makeOrchestrator(configOverrides: Record<string, unknown> = {}, logger = makeLogger()) {
   return new IssueOrchestrator(

--- a/tests/issue-orchestrator-budget-delegation.test.ts
+++ b/tests/issue-orchestrator-budget-delegation.test.ts
@@ -84,74 +84,23 @@ import { IssueOrchestrator } from '../src/core/issue-orchestrator.js';
 import { IssueBudgetGuard, BudgetExceededError } from '../src/core/issue-budget-guard.js';
 import { IssueNotifier } from '../src/core/issue-notifier.js';
 import { CommitManager } from '../src/git/commit.js';
-import type { CheckpointManager } from '@cadre/framework/engine';
-import type { AgentLauncher } from '../src/core/agent-launcher.js';
-import type { PlatformProvider } from '../src/platform/provider.js';
-import type { Logger } from '@cadre/framework/core';
-import type { CadreConfig } from '../src/config/schema.js';
-import type { IssueDetail, WorktreeInfo } from '../src/platform/provider.js';
 import type { PhaseContext } from '../src/core/phase-executor.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
+import { makeMockLogger } from './helpers/make-mock-logger.js';
+import { makeMockCheckpoint } from './helpers/make-mock-checkpoint.js';
+import { makeMockIssue } from './helpers/make-mock-issue.js';
+import { makeMockWorktree } from './helpers/make-mock-worktree.js';
 
 // ── Helpers ──
 
-function makeLogger(): Logger {
-  return {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    child: vi.fn().mockReturnThis(),
-  } as unknown as Logger;
-}
-
-function makeCpState(worktreePath: string) {
-  return {
-    issueNumber: 42,
-    version: 1,
-    currentPhase: 0,
-    currentTask: null,
-    completedPhases: [],
-    completedTasks: [],
-    failedTasks: [],
-    blockedTasks: [],
-    phaseOutputs: {},
-    tokenUsage: { total: 0, byPhase: {}, byAgent: {} },
-    worktreePath,
-    branchName: 'cadre/issue-42',
-    baseCommit: 'abc123',
-    startedAt: new Date().toISOString(),
-    lastCheckpoint: new Date().toISOString(),
-    resumeCount: 0,
-  };
-}
-
-function makeCheckpoint(worktreePath: string, overrides: Partial<CheckpointManager> = {}): CheckpointManager {
-  const state = makeCpState(worktreePath);
-  return {
-    getState: vi.fn(() => state),
-    getResumePoint: vi.fn(() => ({ phase: 1, taskId: null })),
-    isPhaseCompleted: vi.fn(() => false),
-    isTaskCompleted: vi.fn(() => false),
-    startPhase: vi.fn(async () => {}),
-    completePhase: vi.fn(async () => {}),
-    startTask: vi.fn(async () => {}),
-    completeTask: vi.fn(async () => {}),
-    blockTask: vi.fn(async () => {}),
-    failTask: vi.fn(async () => {}),
-    recordTokenUsage: vi.fn(async () => {}),
-    recordGateResult: vi.fn(async () => {}),
-    ...overrides,
-  } as unknown as CheckpointManager;
-}
-
-function makePlatform(): PlatformProvider {
+function makePlatform() {
   return {
     issueLinkSuffix: vi.fn(() => 'Closes #42'),
     createPullRequest: vi.fn(async () => ({ number: 1, url: 'https://github.com/test/pr/1' })),
-  } as unknown as PlatformProvider;
+  } as any;
 }
 
-function makeLauncher(): AgentLauncher {
+function makeLauncher() {
   return {
     launchAgent: vi.fn(async () => ({
       agent: 'test-agent',
@@ -165,19 +114,15 @@ function makeLauncher(): AgentLauncher {
       outputPath: '',
       outputExists: false,
     })),
-  } as unknown as AgentLauncher;
+  } as any;
 }
 
-function makeConfig(overrides: Partial<CadreConfig['options']> = {}, commitOverrides: Partial<CadreConfig['commits']> = {}): CadreConfig {
-  return {
-    projectName: 'test-project',
-    platform: 'github',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    stateDir: '/tmp/.cadre/test-project',
-    baseBranch: 'main',
+function makeConfig(
+  overrides: Record<string, unknown> = {},
+  commitOverrides: Record<string, unknown> = {},
+) {
+  return makeRuntimeConfig({
     issues: { ids: [42] },
-    branchTemplate: 'cadre/issue-{issue}',
     commits: {
       conventional: true,
       sign: false,
@@ -187,6 +132,7 @@ function makeConfig(overrides: Partial<CadreConfig['options']> = {}, commitOverr
     },
     pullRequest: {
       autoCreate: false,
+      autoComplete: false,
       draft: true,
       labels: [],
       reviewers: [],
@@ -196,7 +142,6 @@ function makeConfig(overrides: Partial<CadreConfig['options']> = {}, commitOverr
       maxParallelIssues: 1,
       maxParallelAgents: 1,
       maxRetriesPerTask: 1,
-      tokenBudget: undefined,
       dryRun: false,
       resume: false,
       invocationDelayMs: 0,
@@ -205,33 +150,8 @@ function makeConfig(overrides: Partial<CadreConfig['options']> = {}, commitOverr
       ambiguityThreshold: 5,
       haltOnAmbiguity: false,
       ...overrides,
-    },
-    commands: {},
-    copilot: {
-      cliCommand: 'copilot',
-      model: 'claude-sonnet-4.6',
-      agentDir: '.github/agents',
-      timeout: 300000,
-    },
-    environment: {
-      inheritShellPath: true,
-      extraPath: [],
-    },
-  } as CadreConfig;
-}
-
-function makeIssue(): IssueDetail {
-  return {
-    number: 42,
-    title: 'Test issue',
-    body: 'Test body',
-    labels: [],
-    assignees: [],
-    state: 'open',
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-    url: 'https://github.com/owner/repo/issues/42',
-  };
+    } as any,
+  });
 }
 
 function makeExecutorMock(phaseId: number, name: string) {
@@ -294,13 +214,8 @@ describe('IssueOrchestrator – budget callback delegation (session-003 refactor
     vi.restoreAllMocks();
   });
 
-  function makeWorktree(): WorktreeInfo {
-    return {
-      path: worktreePath,
-      branch: 'cadre/issue-42',
-      baseCommit: 'abc123',
-      issueNumber: 42,
-    } as unknown as WorktreeInfo;
+  function makeWorktree() {
+    return makeMockWorktree({ path: worktreePath });
   }
 
   it('should construct IssueBudgetGuard with the configured tokenBudget', async () => {
@@ -316,12 +231,12 @@ describe('IssueOrchestrator – budget callback delegation (session-003 refactor
     const config = makeConfig({ tokenBudget: 50_000 });
     const orchestrator = new IssueOrchestrator(
       config,
-      makeIssue(),
+      makeMockIssue(),
       makeWorktree(),
-      makeCheckpoint(worktreePath),
+      makeMockCheckpoint(),
       makeLauncher(),
       makePlatform(),
-      makeLogger(),
+      makeMockLogger(),
     );
 
     await orchestrator.run();
@@ -353,12 +268,12 @@ describe('IssueOrchestrator – budget callback delegation (session-003 refactor
 
     const orchestrator = new IssueOrchestrator(
       makeConfig(),
-      makeIssue(),
+      makeMockIssue(),
       makeWorktree(),
-      makeCheckpoint(worktreePath),
+      makeMockCheckpoint(),
       makeLauncher(),
       makePlatform(),
-      makeLogger(),
+      makeMockLogger(),
     );
 
     await orchestrator.run();
@@ -388,12 +303,12 @@ describe('IssueOrchestrator – budget callback delegation (session-003 refactor
 
     const orchestrator = new IssueOrchestrator(
       makeConfig(),
-      makeIssue(),
+      makeMockIssue(),
       makeWorktree(),
-      makeCheckpoint(worktreePath),
+      makeMockCheckpoint(),
       makeLauncher(),
       makePlatform(),
-      makeLogger(),
+      makeMockLogger(),
     );
 
     await orchestrator.run();
@@ -416,16 +331,16 @@ describe('IssueOrchestrator – budget callback delegation (session-003 refactor
     ];
     setupExecutorMocks(execs);
 
-    const checkpoint = makeCheckpoint(worktreePath);
+    const checkpoint = makeMockCheckpoint();
 
     const orchestrator = new IssueOrchestrator(
       makeConfig({ tokenBudget: 100 }),
-      makeIssue(),
+      makeMockIssue(),
       makeWorktree(),
       checkpoint,
       makeLauncher(),
       makePlatform(),
-      makeLogger(),
+      makeMockLogger(),
     );
 
     const result = await orchestrator.run();
@@ -450,21 +365,22 @@ describe('IssueOrchestrator – budget callback delegation (session-003 refactor
     ];
     setupExecutorMocks(execs);
 
-    const checkpoint = makeCheckpoint(worktreePath);
+    const checkpoint = makeMockCheckpoint();
     // Ensure budgetExceeded flag can be set in checkpoint state
     (checkpoint.getState as ReturnType<typeof vi.fn>).mockReturnValue({
-      ...makeCpState(worktreePath),
+      ...checkpoint.getState(),
+      worktreePath,
       budgetExceeded: false,
     });
 
     const orchestrator = new IssueOrchestrator(
       makeConfig({ tokenBudget: 100 }),
-      makeIssue(),
+      makeMockIssue(),
       makeWorktree(),
       checkpoint,
       makeLauncher(),
       makePlatform(),
-      makeLogger(),
+      makeMockLogger(),
     );
 
     await orchestrator.run();
@@ -505,13 +421,8 @@ describe('IssueOrchestrator – commitPerPhase delegation (session-003 refactor)
     vi.restoreAllMocks();
   });
 
-  function makeWorktree(): WorktreeInfo {
-    return {
-      path: worktreePath,
-      branch: 'cadre/issue-42',
-      baseCommit: 'abc123',
-      issueNumber: 42,
-    } as unknown as WorktreeInfo;
+  function makeWorktree() {
+    return makeMockWorktree({ path: worktreePath });
   }
 
   it('should call CommitManager.commit after each phase when commitPerPhase is true', async () => {
@@ -537,12 +448,12 @@ describe('IssueOrchestrator – commitPerPhase delegation (session-003 refactor)
 
     const orchestrator = new IssueOrchestrator(
       makeConfig({}, { commitPerPhase: true }),
-      makeIssue(),
+      makeMockIssue(),
       makeWorktree(),
-      makeCheckpoint(worktreePath),
+      makeMockCheckpoint(),
       makeLauncher(),
       makePlatform(),
-      makeLogger(),
+      makeMockLogger(),
     );
 
     await orchestrator.run();
@@ -574,12 +485,12 @@ describe('IssueOrchestrator – commitPerPhase delegation (session-003 refactor)
 
     const orchestrator = new IssueOrchestrator(
       makeConfig({}, { commitPerPhase: false }),
-      makeIssue(),
+      makeMockIssue(),
       makeWorktree(),
-      makeCheckpoint(worktreePath),
+      makeMockCheckpoint(),
       makeLauncher(),
       makePlatform(),
-      makeLogger(),
+      makeMockLogger(),
     );
 
     await orchestrator.run();
@@ -610,12 +521,12 @@ describe('IssueOrchestrator – commitPerPhase delegation (session-003 refactor)
 
     const orchestrator = new IssueOrchestrator(
       makeConfig({}, { commitPerPhase: true }),
-      makeIssue(),
+      makeMockIssue(),
       makeWorktree(),
-      makeCheckpoint(worktreePath),
+      makeMockCheckpoint(),
       makeLauncher(),
       makePlatform(),
-      makeLogger(),
+      makeMockLogger(),
     );
 
     await orchestrator.run();

--- a/tests/issue-orchestrator-gates.test.ts
+++ b/tests/issue-orchestrator-gates.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { IssueOrchestrator } from '../src/core/issue-orchestrator.js';
 import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
+import { makeMockCheckpoint } from './helpers/make-mock-checkpoint.js';
+import { makeMockIssue } from './helpers/make-mock-issue.js';
+import { makeMockWorktree } from './helpers/make-mock-worktree.js';
 import type { CheckpointManager } from '@cadre/framework/engine';
 import type { AgentLauncher } from '../src/core/agent-launcher.js';
 import type { PlatformProvider } from '../src/platform/provider.js';
-import type { IssueDetail } from '../src/platform/provider.js';
-import type { WorktreeInfo } from '../src/git/worktree.js';
 
 // ── Module-level mock functions (hoisted so vi.mock factories can reference them) ──
 
@@ -263,64 +264,8 @@ function makeConfig() {
   });
 }
 
-function makeIssue(): IssueDetail {
-  return {
-    number: 42,
-    title: 'Test Issue',
-    body: 'Test body',
-    labels: [],
-    assignees: [],
-    comments: [],
-    state: 'open',
-    createdAt: '2024-01-01T00:00:00Z',
-    updatedAt: '2024-01-01T00:00:00Z',
-    linkedPRs: [],
-  };
-}
-
-function makeWorktree(): WorktreeInfo {
-  return {
-    issueNumber: 42,
-    path: '/tmp/worktree-42',
-    branch: 'cadre/issue-42',
-    exists: true,
-    baseCommit: 'abc123',
-    syncedAgentFiles: [],
-  };
-}
-
-function makeMockCheckpoint(completedPhaseIds: number[] = []): CheckpointManager {
-  return {
-    load: vi.fn().mockResolvedValue({}),
-    getState: vi.fn().mockReturnValue({
-      issueNumber: 42,
-      currentPhase: 1,
-      completedPhases: completedPhaseIds,
-      completedTasks: [],
-      blockedTasks: [],
-      failedTasks: [],
-      phaseOutputs: {},
-      gateResults: {},
-      tokenUsage: { total: 0, byPhase: {}, byAgent: {} },
-      worktreePath: '/tmp/worktree-42',
-      branchName: 'cadre/issue-42',
-      baseCommit: 'abc123',
-    }),
-    getResumePoint: vi.fn().mockReturnValue({ phase: 1, task: null }),
-    isPhaseCompleted: vi.fn().mockImplementation((phaseId: number) =>
-      completedPhaseIds.includes(phaseId),
-    ),
-    startPhase: vi.fn().mockResolvedValue(undefined),
-    completePhase: vi.fn().mockResolvedValue(undefined),
-    isTaskCompleted: vi.fn().mockReturnValue(false),
-    startTask: vi.fn().mockResolvedValue(undefined),
-    completeTask: vi.fn().mockResolvedValue(undefined),
-    failTask: vi.fn().mockResolvedValue(undefined),
-    blockTask: vi.fn().mockResolvedValue(undefined),
-    recordTokenUsage: vi.fn().mockResolvedValue(undefined),
-    recordGateResult: vi.fn().mockResolvedValue(undefined),
-  } as unknown as CheckpointManager;
-}
+const makeIssue = () => makeMockIssue();
+const makeWorktree = () => makeMockWorktree();
 
 /** Returns a successful AgentResult-like object wrapped in RetryResult format. */
 function makeSuccessRetryResult() {

--- a/tests/issue-orchestrator-registry.test.ts
+++ b/tests/issue-orchestrator-registry.test.ts
@@ -68,74 +68,23 @@ import { ImplementationPhaseExecutor } from '../src/executors/implementation-pha
 import { IntegrationPhaseExecutor } from '../src/executors/integration-phase-executor.js';
 import { PRCompositionPhaseExecutor } from '../src/executors/pr-composition-phase-executor.js';
 import { IssueOrchestrator } from '../src/core/issue-orchestrator.js';
-import type { CheckpointManager } from '@cadre/framework/engine';
-import type { AgentLauncher } from '../src/core/agent-launcher.js';
-import type { PlatformProvider } from '../src/platform/provider.js';
-import type { Logger } from '@cadre/framework/core';
-import type { CadreConfig } from '../src/config/schema.js';
-import type { IssueDetail, WorktreeInfo } from '../src/platform/provider.js';
 import type { PhaseContext } from '../src/core/phase-executor.js';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
+import { makeMockLogger } from './helpers/make-mock-logger.js';
+import { makeMockCheckpoint } from './helpers/make-mock-checkpoint.js';
+import { makeMockIssue } from './helpers/make-mock-issue.js';
+import { makeMockWorktree } from './helpers/make-mock-worktree.js';
 
 // ── Helpers ──
 
-function makeLogger(): Logger {
-  return {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    child: vi.fn().mockReturnThis(),
-  } as unknown as Logger;
-}
-
-function makeCpState(worktreePath: string) {
-  return {
-    issueNumber: 42,
-    version: 1,
-    currentPhase: 0,
-    currentTask: null,
-    completedPhases: [],
-    completedTasks: [],
-    failedTasks: [],
-    blockedTasks: [],
-    phaseOutputs: {},
-    tokenUsage: { total: 0, byPhase: {}, byAgent: {} },
-    worktreePath,
-    branchName: 'cadre/issue-42',
-    baseCommit: 'abc123',
-    startedAt: new Date().toISOString(),
-    lastCheckpoint: new Date().toISOString(),
-    resumeCount: 0,
-  };
-}
-
-function makeCheckpoint(worktreePath: string, overrides: Partial<CheckpointManager> = {}): CheckpointManager {
-  const state = makeCpState(worktreePath);
-  return {
-    getState: vi.fn(() => state),
-    getResumePoint: vi.fn(() => ({ phase: 1, taskId: null })),
-    isPhaseCompleted: vi.fn(() => false),
-    isTaskCompleted: vi.fn(() => false),
-    startPhase: vi.fn(async () => {}),
-    completePhase: vi.fn(async () => {}),
-    startTask: vi.fn(async () => {}),
-    completeTask: vi.fn(async () => {}),
-    blockTask: vi.fn(async () => {}),
-    failTask: vi.fn(async () => {}),
-    recordTokenUsage: vi.fn(async () => {}),
-    recordGateResult: vi.fn(async () => {}),
-    ...overrides,
-  } as unknown as CheckpointManager;
-}
-
-function makePlatform(): PlatformProvider {
+function makePlatform() {
   return {
     issueLinkSuffix: vi.fn(() => 'Closes #42'),
     createPullRequest: vi.fn(async () => ({ number: 1, url: 'https://github.com/test/pr/1' })),
-  } as unknown as PlatformProvider;
+  } as any;
 }
 
-function makeLauncher(): AgentLauncher {
+function makeLauncher() {
   return {
     launchAgent: vi.fn(async () => ({
       agent: 'test-agent',
@@ -149,19 +98,12 @@ function makeLauncher(): AgentLauncher {
       outputPath: '',
       outputExists: false,
     })),
-  } as unknown as AgentLauncher;
+  } as any;
 }
 
-function makeConfig(overrides: Partial<CadreConfig['options']> = {}): CadreConfig {
-  return {
-    projectName: 'test-project',
-    platform: 'github',
-    repository: 'owner/repo',
-    repoPath: '/tmp/repo',
-    stateDir: '/tmp/.cadre/test-project',
-    baseBranch: 'main',
+function makeConfig(overrides: Record<string, unknown> = {}) {
+  return makeRuntimeConfig({
     issues: { ids: [42] },
-    branchTemplate: 'cadre/issue-{issue}',
     commits: {
       conventional: true,
       sign: false,
@@ -170,6 +112,7 @@ function makeConfig(overrides: Partial<CadreConfig['options']> = {}): CadreConfi
     },
     pullRequest: {
       autoCreate: false,
+      autoComplete: false,
       draft: true,
       labels: [],
       reviewers: [],
@@ -179,40 +122,14 @@ function makeConfig(overrides: Partial<CadreConfig['options']> = {}): CadreConfi
       maxParallelIssues: 1,
       maxParallelAgents: 1,
       maxRetriesPerTask: 1,
-      tokenBudget: undefined,
       dryRun: false,
       resume: false,
       invocationDelayMs: 0,
       buildVerification: false,
       testVerification: false,
       ...overrides,
-    },
-    commands: {},
-    copilot: {
-      cliCommand: 'copilot',
-      model: 'claude-sonnet-4.6',
-      agentDir: '.github/agents',
-      timeout: 300000,
-    },
-    environment: {
-      inheritShellPath: true,
-      extraPath: [],
-    },
-  } as CadreConfig;
-}
-
-function makeIssue(): IssueDetail {
-  return {
-    number: 42,
-    title: 'Test issue',
-    body: 'Test body',
-    labels: [],
-    assignees: [],
-    state: 'open',
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-    url: 'https://github.com/owner/repo/issues/42',
-  };
+    } as any,
+  });
 }
 
 /** Build a mock PhaseExecutor with a given phaseId that resolves successfully. */
@@ -248,13 +165,8 @@ describe('IssueOrchestrator – PhaseRegistry dispatch (task-008)', () => {
     vi.clearAllMocks();
   });
 
-  function makeWorktree(): WorktreeInfo {
-    return {
-      path: worktreePath,
-      branch: 'cadre/issue-42',
-      baseCommit: 'abc123',
-      issueNumber: 42,
-    } as unknown as WorktreeInfo;
+  function makeWorktree() {
+    return makeMockWorktree({ path: worktreePath });
   }
 
   function setupExecutorMocks(executors: ReturnType<typeof makeExecutorMock>[]) {
@@ -279,12 +191,12 @@ describe('IssueOrchestrator – PhaseRegistry dispatch (task-008)', () => {
 
       new IssueOrchestrator(
         makeConfig(),
-        makeIssue(),
+        makeMockIssue(),
         makeWorktree(),
-        makeCheckpoint(worktreePath),
+        makeMockCheckpoint(),
         makeLauncher(),
         makePlatform(),
-        makeLogger(),
+        makeMockLogger(),
       );
 
       expect(AnalysisPhaseExecutor).toHaveBeenCalledTimes(1);
@@ -310,12 +222,12 @@ describe('IssueOrchestrator – PhaseRegistry dispatch (task-008)', () => {
 
       const orchestrator = new IssueOrchestrator(
         makeConfig(),
-        makeIssue(),
+        makeMockIssue(),
         makeWorktree(),
-        makeCheckpoint(worktreePath),
+        makeMockCheckpoint(),
         makeLauncher(),
         makePlatform(),
-        makeLogger(),
+        makeMockLogger(),
       );
 
       const result = await orchestrator.run();
@@ -340,18 +252,18 @@ describe('IssueOrchestrator – PhaseRegistry dispatch (task-008)', () => {
       ];
       setupExecutorMocks(execs);
 
-      const checkpoint = makeCheckpoint(worktreePath, {
+      const checkpoint = makeMockCheckpoint([], {
         isPhaseCompleted: vi.fn(() => true),
       });
 
       const orchestrator = new IssueOrchestrator(
         makeConfig(),
-        makeIssue(),
+        makeMockIssue(),
         makeWorktree(),
         checkpoint,
         makeLauncher(),
         makePlatform(),
-        makeLogger(),
+        makeMockLogger(),
       );
 
       await orchestrator.run();
@@ -377,12 +289,12 @@ describe('IssueOrchestrator – PhaseRegistry dispatch (task-008)', () => {
 
       const orchestrator = new IssueOrchestrator(
         makeConfig({ dryRun: true }),
-        makeIssue(),
+        makeMockIssue(),
         makeWorktree(),
-        makeCheckpoint(worktreePath),
+        makeMockCheckpoint(),
         makeLauncher(),
         makePlatform(),
-        makeLogger(),
+        makeMockLogger(),
       );
 
       const result = await orchestrator.run();
@@ -412,17 +324,17 @@ describe('IssueOrchestrator – PhaseRegistry dispatch (task-008)', () => {
       setupExecutorMocks(execs);
 
       const config = makeConfig();
-      const issue = makeIssue();
+      const issue = makeMockIssue();
       const worktree = makeWorktree();
 
       const orchestrator = new IssueOrchestrator(
         config,
         issue,
         worktree,
-        makeCheckpoint(worktreePath),
+        makeMockCheckpoint(),
         makeLauncher(),
         makePlatform(),
-        makeLogger(),
+        makeMockLogger(),
       );
 
       await orchestrator.run();
@@ -459,12 +371,12 @@ describe('IssueOrchestrator – PhaseRegistry dispatch (task-008)', () => {
 
       const orchestrator = new IssueOrchestrator(
         makeConfig(),
-        makeIssue(),
+        makeMockIssue(),
         makeWorktree(),
-        makeCheckpoint(worktreePath),
+        makeMockCheckpoint(),
         makeLauncher(),
         makePlatform(),
-        makeLogger(),
+        makeMockLogger(),
       );
 
       const result = await orchestrator.run();
@@ -488,12 +400,12 @@ describe('IssueOrchestrator – PhaseRegistry dispatch (task-008)', () => {
 
       const orchestrator = new IssueOrchestrator(
         makeConfig(),
-        makeIssue(),
+        makeMockIssue(),
         makeWorktree(),
-        makeCheckpoint(worktreePath),
+        makeMockCheckpoint(),
         makeLauncher(),
         makePlatform(),
-        makeLogger(),
+        makeMockLogger(),
       );
 
       const result = await orchestrator.run();
@@ -516,12 +428,12 @@ describe('IssueOrchestrator – PhaseRegistry dispatch (task-008)', () => {
 
       const orchestrator = new IssueOrchestrator(
         makeConfig(),
-        makeIssue(),
+        makeMockIssue(),
         makeWorktree(),
-        makeCheckpoint(worktreePath),
+        makeMockCheckpoint(),
         makeLauncher(),
         makePlatform(),
-        makeLogger(),
+        makeMockLogger(),
       );
 
       const result = await orchestrator.run();
@@ -547,12 +459,12 @@ describe('IssueOrchestrator – PhaseRegistry dispatch (task-008)', () => {
 
       const orchestrator = new IssueOrchestrator(
         makeConfig(),
-        makeIssue(),
+        makeMockIssue(),
         makeWorktree(),
-        makeCheckpoint(worktreePath),
+        makeMockCheckpoint(),
         makeLauncher(),
         makePlatform(),
-        makeLogger(),
+        makeMockLogger(),
       );
 
       const result = await orchestrator.run();
@@ -580,12 +492,12 @@ describe('IssueOrchestrator – PhaseRegistry dispatch (task-008)', () => {
 
       const orchestrator = new IssueOrchestrator(
         makeConfig(),
-        makeIssue(),
+        makeMockIssue(),
         makeWorktree(),
-        makeCheckpoint(worktreePath),
+        makeMockCheckpoint(),
         makeLauncher(),
         makePlatform(),
-        makeLogger(),
+        makeMockLogger(),
       );
 
       const result = await orchestrator.run();
@@ -609,12 +521,12 @@ describe('IssueOrchestrator – PhaseRegistry dispatch (task-008)', () => {
 
       const orchestrator = new IssueOrchestrator(
         makeConfig(),
-        makeIssue(),
+        makeMockIssue(),
         makeWorktree(),
-        makeCheckpoint(worktreePath),
+        makeMockCheckpoint(),
         makeLauncher(),
         makePlatform(),
-        makeLogger(),
+        makeMockLogger(),
       );
 
       const result = await orchestrator.run();

--- a/tests/issue-orchestrator-zod-retry.test.ts
+++ b/tests/issue-orchestrator-zod-retry.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ZodError } from 'zod';
 import { IssueOrchestrator } from '../src/core/issue-orchestrator.js';
 import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
-import type { CheckpointManager } from '@cadre/framework/engine';
+import { makeMockCheckpoint } from './helpers/make-mock-checkpoint.js';
+import { makeMockIssue } from './helpers/make-mock-issue.js';
+import { makeMockWorktree } from './helpers/make-mock-worktree.js';
+import { makeMockLogger } from './helpers/make-mock-logger.js';
 import type { AgentLauncher } from '../src/core/agent-launcher.js';
-import type { PlatformProvider, IssueDetail } from '../src/platform/provider.js';
-import type { WorktreeInfo } from '../src/git/worktree.js';
-import type { Logger } from '@cadre/framework/core';
+import type { PlatformProvider } from '../src/platform/provider.js';
 
 // ── Hoisted mock functions ────────────────────────────────────────────────────
 
@@ -259,72 +260,8 @@ function makeConfig() {
   });
 }
 
-function makeIssue(): IssueDetail {
-  return {
-    number: 42,
-    title: 'Test Issue',
-    body: 'Test body',
-    labels: [],
-    assignees: [],
-    comments: [],
-    state: 'open',
-    createdAt: '2024-01-01T00:00:00Z',
-    updatedAt: '2024-01-01T00:00:00Z',
-    linkedPRs: [],
-  } as unknown as IssueDetail;
-}
-
-function makeWorktree(): WorktreeInfo {
-  return {
-    issueNumber: 42,
-    path: '/tmp/worktree-42',
-    branch: 'cadre/issue-42',
-    exists: true,
-    baseCommit: 'abc123',
-    syncedAgentFiles: [],
-  } as unknown as WorktreeInfo;
-}
-
-function makeMockCheckpoint(completedPhaseIds: number[] = []): CheckpointManager {
-  return {
-    load: vi.fn().mockResolvedValue({}),
-    getState: vi.fn().mockReturnValue({
-      issueNumber: 42,
-      currentPhase: 1,
-      completedPhases: completedPhaseIds,
-      completedTasks: [],
-      blockedTasks: [],
-      failedTasks: [],
-      phaseOutputs: {},
-      gateResults: {},
-      tokenUsage: { total: 0, byPhase: {}, byAgent: {} },
-      worktreePath: '/tmp/worktree-42',
-      branchName: 'cadre/issue-42',
-      baseCommit: 'abc123',
-    }),
-    getResumePoint: vi.fn().mockReturnValue({ phase: 1, task: null }),
-    isPhaseCompleted: vi.fn().mockImplementation((phaseId: number) =>
-      completedPhaseIds.includes(phaseId),
-    ),
-    startPhase: vi.fn().mockResolvedValue(undefined),
-    completePhase: vi.fn().mockResolvedValue(undefined),
-    isTaskCompleted: vi.fn().mockReturnValue(false),
-    startTask: vi.fn().mockResolvedValue(undefined),
-    completeTask: vi.fn().mockResolvedValue(undefined),
-    failTask: vi.fn().mockResolvedValue(undefined),
-    blockTask: vi.fn().mockResolvedValue(undefined),
-    recordTokenUsage: vi.fn().mockResolvedValue(undefined),
-    recordGateResult: vi.fn().mockResolvedValue(undefined),
-    startSubTask: vi.fn().mockResolvedValue(undefined),
-    ...(() => {
-      const completedSubTasks = new Set<string>();
-      return {
-        completeSubTask: vi.fn(async (id: string) => { completedSubTasks.add(id); }),
-        isSubTaskCompleted: vi.fn((id: string) => completedSubTasks.has(id)),
-      };
-    })(),
-  } as unknown as CheckpointManager;
-}
+const makeIssue = () => makeMockIssue();
+const makeWorktree = () => makeMockWorktree();
 
 function makeMockLauncher(): AgentLauncher {
   return {
@@ -352,20 +289,7 @@ function makeMockPlatform(): PlatformProvider {
   } as unknown as PlatformProvider;
 }
 
-function makeMockLogger(): Logger {
-  return {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    child: vi.fn().mockReturnValue({
-      debug: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    }),
-  } as unknown as Logger;
-}
+const makeLogger = () => makeMockLogger();
 
 /** Single session returned from parseImplementationPlan */
 const SAMPLE_TASK = {
@@ -417,7 +341,7 @@ describe('IssueOrchestrator – ZodError retry handling in executeTask', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    logger = makeMockLogger();
+    logger = makeLogger();
 
     // Gates all pass by default
     mockAnalysisGateValidate.mockResolvedValue({ status: 'pass', warnings: [], errors: [] });

--- a/tests/issue-orchestrator.test.ts
+++ b/tests/issue-orchestrator.test.ts
@@ -7,8 +7,10 @@ import { mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
-import type { IssueDetail } from '../src/platform/provider.js';
-import type { WorktreeInfo } from '../src/git/worktree.js';
+import { makeMockIssue } from './helpers/make-mock-issue.js';
+import { makeMockWorktree } from './helpers/make-mock-worktree.js';
+import { makeMockLogger } from './helpers/make-mock-logger.js';
+import { makeMockCheckpoint } from './helpers/make-mock-checkpoint.js';
 import type { CheckpointManager } from '@cadre/framework/engine';
 import type { AgentLauncher } from '../src/agents/types.js';
 import type { Logger } from '@cadre/framework/core';
@@ -136,30 +138,12 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 });
 
 // Default checkpoint mock – all phases are pre-completed so the phase loop skips everything.
-const makeCheckpointMock = (overrides: Record<string, unknown> = {}) => ({
-  getResumePoint: vi.fn().mockReturnValue({ phase: 6, task: null }),
-  isPhaseCompleted: vi.fn().mockReturnValue(true),
-  isTaskCompleted: vi.fn().mockReturnValue(false),
-  startPhase: vi.fn().mockResolvedValue(undefined),
-  completePhase: vi.fn().mockResolvedValue(undefined),
-  startTask: vi.fn().mockResolvedValue(undefined),
-  completeTask: vi.fn().mockResolvedValue(undefined),
-  blockTask: vi.fn().mockResolvedValue(undefined),
-  getState: vi.fn().mockReturnValue({
-    issueNumber: 42,
-    currentPhase: 5,
-    completedPhases: [1, 2, 3, 4, 5],
-    completedTasks: [],
-    blockedTasks: [],
-    resumeCount: 0,
-    currentTask: null,
-    tokenUsage: {},
-  }),
-  recordTokenUsage: vi.fn().mockResolvedValue(undefined),
-  recordGateResult: vi.fn().mockResolvedValue(undefined),
-  setWorktreeInfo: vi.fn().mockResolvedValue(undefined),
-  ...overrides,
-});
+const makeCheckpointMock = (overrides: Record<string, unknown> = {}) =>
+  makeMockCheckpoint([1, 2, 3, 4, 5], {
+    getResumePoint: vi.fn().mockReturnValue({ phase: 6, task: null }),
+    isPhaseCompleted: vi.fn().mockReturnValue(true),
+    ...overrides,
+  });
 
 // Alias used by notifier integration tests
 function makeCheckpoint(overrides: Record<string, unknown> = {}): CheckpointManager {
@@ -211,40 +195,9 @@ function makeConfig(tokenBudget?: number) {
   });
 }
 
-function makeIssue(): IssueDetail {
-  return {
-    number: 42,
-    title: 'Test Issue',
-    body: 'Test body',
-    labels: [],
-    assignees: [],
-    url: 'https://github.com/owner/repo/issues/42',
-  } as unknown as IssueDetail;
-}
-
-function makeWorktree(): WorktreeInfo {
-  return {
-    path: '/tmp/worktree-42',
-    branch: 'cadre/issue-42',
-    baseCommit: 'abc123',
-    issueNumber: 42,
-  } as unknown as WorktreeInfo;
-}
-
-function makeLogger(): Logger {
-  return {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    child: vi.fn().mockReturnValue({
-      debug: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    }),
-  } as unknown as Logger;
-}
+const makeIssue = () => makeMockIssue({ url: 'https://github.com/owner/repo/issues/42' });
+const makeWorktree = () => makeMockWorktree();
+const makeLogger = () => makeMockLogger();
 
 function makePlatform() {
   return {
@@ -259,8 +212,8 @@ function makeLauncher() {
 
 describe('IssueOrchestrator – notification dispatch', () => {
   let config: ReturnType<typeof makeConfig>;
-  let issue: IssueDetail;
-  let worktree: WorktreeInfo;
+  let issue: ReturnType<typeof makeIssue>;
+  let worktree: ReturnType<typeof makeWorktree>;
   let logger: Logger;
   let platform: ReturnType<typeof makePlatform>;
   let launcher: ReturnType<typeof makeLauncher>;
@@ -606,13 +559,8 @@ describe('IssueOrchestrator notifier integration', () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  function makeWorktree(): WorktreeInfo {
-    return {
-      path: worktreePath,
-      branch: 'cadre/issue-42',
-      baseCommit: 'abc123',
-      issueNumber: 42,
-    } as unknown as WorktreeInfo;
+  function makeLocalWorktree() {
+    return makeMockWorktree({ path: worktreePath });
   }
 
   function makeOrchestrator(
@@ -624,7 +572,7 @@ describe('IssueOrchestrator notifier integration', () => {
     return new IssueOrchestrator(
       config,
       makeIssue(),
-      makeWorktree(),
+      makeLocalWorktree(),
       checkpoint,
       launcher,
       makePlatform(),


### PR DESCRIPTION
## Summary

Audit all test files that construct `IssueOrchestrator` directly to ensure they pass a config with `stateDir`, and extract shared test helpers to reduce code duplication.

### Background

The recent move of `progressDir` from `join(worktree.path, '.cadre', 'issues', N)` to `join(config.stateDir, 'issues', N)` means the constructor crashes with `TypeError: The "path" argument must be of type string. Received undefined` if `stateDir` is missing from the config.

### Audit results

All 7 test files that construct `IssueOrchestrator` were checked:
- **Already fixed** (inline `stateDir`): `issue-orchestrator-registry`, `e2e-pipeline`, `issue-orchestrator-budget-delegation`  
- **Already fine** (via `makeRuntimeConfig` which includes `stateDir`): `issue-orchestrator`, `issue-orchestrator-gates`, `issue-orchestrator-ambiguity`, `issue-orchestrator-zod-retry`

### Deduplication

Extracted 4 new shared test helpers under `tests/helpers/`:
- **`make-mock-checkpoint.ts`** — parameterized `CheckpointManager` mock with sub-task tracking  
- **`make-mock-issue.ts`** — full `IssueDetail` with all required fields  
- **`make-mock-worktree.ts`** — full `WorktreeInfo` with `exists`/`syncedAgentFiles`  
- **`make-mock-logger.ts`** — `Logger` mock with `.child()` support

Migrated `issue-orchestrator-registry` and `issue-orchestrator-budget-delegation` from inline `CadreConfig` construction (using stale `copilot:` key) to `makeRuntimeConfig()`, ensuring config shape stays current.

**Net reduction: -306 lines** (249 added, 555 removed) across 10 files.