### PR TITLE
fix(framework): prevent false regression detection when commands pass with benign stderr

### DIFF
--- a/packages/framework/src/runtime/commands/parse-failures.ts
+++ b/packages/framework/src/runtime/commands/parse-failures.ts
@@ -25,8 +25,10 @@ export function extractFailures(
     else if (includeTS && /error TS\d+:/.test(trimmed)) {
       failures.add(trimmed);
     }
-    // Generic error lines
+    // Generic error lines — but exclude common CLI/usage noise
     else if (/^\s*(error|Error)\s*:/i.test(trimmed) && trimmed.length < 200) {
+      // Skip benign CLI help/usage messages that are not real failures
+      if (/unknown option|Did you mean|Usage:/i.test(trimmed)) continue;
       failures.add(trimmed);
     }
   }

--- a/packages/framework/src/runtime/commands/verify.ts
+++ b/packages/framework/src/runtime/commands/verify.ts
@@ -36,6 +36,13 @@ export async function verifyCommand(config: VerifyCommandConfig): Promise<Verify
   let output = result.stderr + result.stdout;
   let failures = extractFailures(output);
 
+  // When the command passes (exit code 0), discard any "failures" extracted
+  // from benign stderr noise (e.g. CLI help text, deprecation warnings).
+  // A passing command has no actionable failures by definition.
+  if (result.exitCode === 0) {
+    failures = [];
+  }
+
   if (result.exitCode !== 0 && failures.length === 0 && sentinelValue) {
     failures = [sentinelValue];
   }
@@ -53,6 +60,10 @@ export async function verifyCommand(config: VerifyCommandConfig): Promise<Verify
     result = await execShell(command, { cwd, timeout });
     output = result.stderr + result.stdout;
     failures = extractFailures(output);
+
+    if (result.exitCode === 0) {
+      failures = [];
+    }
 
     if (result.exitCode !== 0 && failures.length === 0 && sentinelValue) {
       failures = [sentinelValue];


### PR DESCRIPTION
## Problem

The integration phase (Phase 4) was producing **false positive regression failures** when all commands actually passed. Specifically, `verifyCommand()` called `extractFailures()` on combined stdout+stderr output even when the command exited with code 0. Benign stderr content like `error: unknown option '--help'` (from tests that intentionally invoke CLI help) matched the generic error pattern and was flagged as a regression.

This caused the Phase 4 gate to fail with:
```
integration-report.md contains new regression failures
```
...even though build, test, and lint all passed.

## Root Cause

Two issues in `@cadre-dev/framework/runtime`:

1. **`verifyCommand()`** in `packages/framework/src/runtime/commands/verify.ts` scanned output for failures regardless of exit code. A passing command (exit code 0) should have no actionable failures.

2. **`extractFailures()`** in `packages/framework/src/runtime/commands/parse-failures.ts` matched CLI usage/help messages like `error: unknown option '--help'` via the generic `/^\s*(error|Error)\s*:/i` pattern.

## Fix

1. **`verify.ts`**: When exit code is 0, discard extracted failures immediately. Still calls `extractFailures()` for observability, but clears the result since a passing command has no real failures.

2. **`parse-failures.ts`**: Skip lines matching common CLI noise patterns (`unknown option`, `Did you mean`, `Usage:`) in the generic error matcher, as defense-in-depth.

## Testing

All 188 test files pass (3667 tests) on this branch, including the existing verify/regression test suites.