### PR TITLE
feat(lore): integrate @jafreck/lore MCP for agent knowledge-base lookups (#373)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@cadre-dev/runtime-provider-docker": "*",
         "@cadre-dev/runtime-provider-kata": "*",
         "@inquirer/prompts": "^8",
+        "@jafreck/lore": "^0.2.5",
         "@modelcontextprotocol/sdk": "^1.27",
         "@octokit/rest": "^22",
         "chalk": "^5",
@@ -962,6 +963,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jafreck/lore": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@jafreck/lore/-/lore-0.2.5.tgz",
+      "integrity": "sha512-ysnKjfLzCR9nJz+2JNoEvKNluDgwNXfk29fuaTF5bJ65ziUpAcuA+8uTYS7LwZDWYzdrbfUxAg8C81PJCMraLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "better-sqlite3": "^12.6.2",
+        "fast-glob": "^3.3.3",
+        "simple-git": "^3.32.3",
+        "sqlite-vec": "^0.1.6",
+        "tree-sitter": "0.22.4",
+        "tree-sitter-bash": "^0.25.1",
+        "tree-sitter-c": "^0.23.6",
+        "tree-sitter-c-sharp": "0.23.1",
+        "tree-sitter-cpp": "0.23.4",
+        "tree-sitter-dart": "^1.0.0",
+        "tree-sitter-elixir": "^0.3.5",
+        "tree-sitter-elm": "^4.5.0",
+        "tree-sitter-go": "0.23.4",
+        "tree-sitter-haskell": "^0.23.1",
+        "tree-sitter-java": "0.23.5",
+        "tree-sitter-javascript": "0.23.1",
+        "tree-sitter-julia": "^0.23.1",
+        "tree-sitter-kotlin": "^0.3.8",
+        "tree-sitter-lua": "^2.1.3",
+        "tree-sitter-objc": "^3.0.2",
+        "tree-sitter-ocaml": "^0.24.2",
+        "tree-sitter-php": "^0.24.2",
+        "tree-sitter-python": "0.23.6",
+        "tree-sitter-ruby": "^0.23.1",
+        "tree-sitter-rust": "0.24.0",
+        "tree-sitter-scala": "^0.24.0",
+        "tree-sitter-swift": "^0.7.1",
+        "tree-sitter-typescript": "0.23.2",
+        "tree-sitter-zig": "^0.2.0",
+        "zod": "^4.3"
+      },
+      "bin": {
+        "lore": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@jafreck/lore/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1054,6 +1109,41 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -1806,6 +1896,53 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "license": "ISC"
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/are-we-there-yet/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1826,11 +1963,65 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
+      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -1867,6 +2058,42 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bytes": {
@@ -1962,6 +2189,12 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -1998,6 +2231,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2026,6 +2268,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC"
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -2066,6 +2314,12 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -2125,6 +2379,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2135,6 +2404,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2142,6 +2426,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -2175,7 +2468,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2185,6 +2477,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -2318,6 +2619,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2411,6 +2721,22 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -2449,6 +2775,33 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/finalhandler": {
@@ -2507,6 +2860,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2529,6 +2888,76 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/gauge/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gauge/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+      "license": "MIT",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gauge/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/gauge/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+      "license": "MIT",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gauge/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -2593,6 +3022,12 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -2613,6 +3048,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/glob/node_modules/balanced-match": {
@@ -2682,6 +3129,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC"
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2746,10 +3199,36 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -2770,14 +3249,34 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-interactive": {
@@ -2790,6 +3289,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-promise": {
@@ -2809,6 +3317,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3011,6 +3525,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -3048,6 +3584,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -3064,6 +3612,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -3073,6 +3630,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3088,6 +3651,12 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
+      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3108,6 +3677,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -3115,6 +3690,60 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
+      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-assign": {
@@ -3315,6 +3944,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -3353,6 +3994,39 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3364,6 +4038,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -3380,6 +4064,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -3403,6 +4107,35 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/require-from-string": {
@@ -3438,6 +4171,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -3501,6 +4244,49 @@
         "node": ">= 18"
       }
     },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3511,7 +4297,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3564,6 +4349,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -3683,6 +4474,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-git": {
       "version": "3.32.3",
       "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.32.3.tgz",
@@ -3707,6 +4543,74 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sqlite-vec": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.6.tgz",
+      "integrity": "sha512-hQZU700TU2vWPXZYDULODjKXeMio6rKX7UpPN7Tq9qjPW671IEgURGrcC5LDBMl0q9rBvAuzmcmJmImMqVibYQ==",
+      "license": "MIT OR Apache",
+      "optionalDependencies": {
+        "sqlite-vec-darwin-arm64": "0.1.6",
+        "sqlite-vec-darwin-x64": "0.1.6",
+        "sqlite-vec-linux-arm64": "0.1.6",
+        "sqlite-vec-linux-x64": "0.1.6",
+        "sqlite-vec-windows-x64": "0.1.6"
+      }
+    },
+    "node_modules/sqlite-vec-darwin-arm64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.6.tgz",
+      "integrity": "sha512-5duw/xhM3xE6BCQd//eAkyHgBp9FIwK6veldRhPG96dT6Zpjov3bG02RuE7JAQj0SVJYRW8bJwZ4LxqW0+Q7Dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-darwin-x64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.6.tgz",
+      "integrity": "sha512-MFkKjNfJ5pamFHhyTsrqdxALrjuvpSEZdu6Q/0vMxFa6sr5YlfabeT5xGqEbuH0iobsT1Hca5EZxLhLy0jHYkw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-x64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.6.tgz",
+      "integrity": "sha512-411tWPswywIzdkp+zsAUav4A03f0FjnNfpZFlOw8fBebFR74RSFkwM8Xryf18gLHiYAXUBI4mjY9+/xjwBjKpg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-windows-x64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.6.tgz",
+      "integrity": "sha512-Dy9/KlKJDrjuQ/RRkBqGkMZuSh5bTJDMMOFZft9VJZaXzpYxb5alpgdvD4bbKegpDdfPi2BT4+PBivsNJSlMoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/sqlite-vec/node_modules/sqlite-vec-linux-arm64": {
+      "optional": true
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -3741,6 +4645,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -3837,6 +4750,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3848,6 +4770,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/test-exclude": {
@@ -3909,6 +4859,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3916,6 +4878,562 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tree-sitter": {
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      }
+    },
+    "node_modules/tree-sitter-bash": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-bash/-/tree-sitter-bash-0.25.1.tgz",
+      "integrity": "sha512-7hMytuYIMoXOq24yRulgIxthE9YmggZIOHCyPTTuJcu6EU54tYD+4G39cUb28kxC6jMf/AbPfWGLQtgPTdh3xw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.25.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-c": {
+      "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-c/-/tree-sitter-c-0.23.6.tgz",
+      "integrity": "sha512-0dxXKznVyUA0s6PjNolJNs2yF87O5aL538A/eR6njA5oqX3C3vH4vnx3QdOKwuUdpKEcFdHuiDpRKLLCA/tjvQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-c-sharp": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-c-sharp/-/tree-sitter-c-sharp-0.23.1.tgz",
+      "integrity": "sha512-9zZ4FlcTRWWfRf6f4PgGhG8saPls6qOOt75tDfX7un9vQZJmARjPrAC6yBNCX2T/VKcCjIDbgq0evFaB3iGhQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-cli": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.2.tgz",
+      "integrity": "sha512-kPPXprOqREX+C/FgUp2Qpt9jd0vSwn+hOgjzVv/7hapdoWpa+VeWId53rf4oNNd29ikheF12BYtGD/W90feMbA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "tree-sitter": "cli.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/tree-sitter-cpp": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cpp/-/tree-sitter-cpp-0.23.4.tgz",
+      "integrity": "sha512-qR5qUDyhZ5jJ6V8/umiBxokRbe89bCGmcq/dk94wI4kN86qfdV8k0GHIUEKaqWgcu42wKal5E97LKpLeVW8sKw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2",
+        "tree-sitter-c": "^0.23.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-dart": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-dart/-/tree-sitter-dart-1.0.0.tgz",
+      "integrity": "sha512-Ve5YMPJjjGW9LEsO+MngAOibQsw5obFp+bUT41pvwdcXWRwJImOWs3eaPi6AubEiBmc09qvhdvxeIXvxlhMnug==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "nan": "^2.15.0"
+      }
+    },
+    "node_modules/tree-sitter-elixir": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter-elixir/-/tree-sitter-elixir-0.3.5.tgz",
+      "integrity": "sha512-xozQMvYK0aSolcQZAx2d84Xe/YMWFuRPYFlLVxO01bM2GITh5jyiIp0TqPCQa8754UzRAI7A83hZmfiYub5TZQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      }
+    },
+    "node_modules/tree-sitter-elixir/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/tree-sitter-elm": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-elm/-/tree-sitter-elm-4.5.0.tgz",
+      "integrity": "sha512-GNUKjhOQCiARkQLPEmeYYugbQtuEAdy1uZyoQbQnXXsmKM4apCXpJsd9F9ExwCsq2s40PXD2y+wLUnH17BBkkg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.14.2",
+        "prebuild-install": "^6.0.0"
+      }
+    },
+    "node_modules/tree-sitter-elm/node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tree-sitter-elm/node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/tree-sitter-elm/node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tree-sitter-elm/node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "license": "MIT"
+    },
+    "node_modules/tree-sitter-elm/node_modules/node-abi": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
+      "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.4.1"
+      }
+    },
+    "node_modules/tree-sitter-elm/node_modules/prebuild-install": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
+      "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.21.0",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tree-sitter-elm/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/tree-sitter-elm/node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/tree-sitter-go": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-go/-/tree-sitter-go-0.23.4.tgz",
+      "integrity": "sha512-iQaHEs4yMa/hMo/ZCGqLfG61F0miinULU1fFh+GZreCRtKylFLtvn798ocCZjO2r/ungNZgAY1s1hPFyAwkc7w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-haskell": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-haskell/-/tree-sitter-haskell-0.23.1.tgz",
+      "integrity": "sha512-qG4CYhejveu9DLMLEGBz/n9/TTeGSFLC6wniwOgG6m8/v7Dng8qR0ob0EVG7+XH+9WiOxohpGA23EhceWuxY4w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-java": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter-java/-/tree-sitter-java-0.23.5.tgz",
+      "integrity": "sha512-Yju7oQ0Xx7GcUT01mUglPP+bYfvqjNCGdxqigTnew9nLGoII42PNVP3bHrYeMxswiCRM0yubWmN5qk+zsg0zMA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-javascript": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
+      "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-julia": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-julia/-/tree-sitter-julia-0.23.1.tgz",
+      "integrity": "sha512-3vShY0GIu8ajR6hXzE0pyUk6kkfg4pGx3Bfzm6lGmR9aC3fe+LgoBMlaFJ7JY+t0fNFccc77J8HVP67ukuDMxQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-kotlin": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/tree-sitter-kotlin/-/tree-sitter-kotlin-0.3.8.tgz",
+      "integrity": "sha512-A4obq6bjzmYrA+F0JLLoheFPcofFkctNaZSpnDd+GPn1SfVZLY4/GG4C0cYVBTOShuPBGGAOPLM1JWLZQV4m1g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-kotlin/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/tree-sitter-lua": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tree-sitter-lua/-/tree-sitter-lua-2.1.3.tgz",
+      "integrity": "sha512-BmRSRI0Y4J47cE2cODyXsPiueDSAnIrFLJqOP/gKIJhGa4HoGpvEccmNuhAEVGtCrgaHGhaIkWeqiMGCgQ0cfw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.15.0"
+      }
+    },
+    "node_modules/tree-sitter-objc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-objc/-/tree-sitter-objc-3.0.2.tgz",
+      "integrity": "sha512-Hs0ohmx1u5M+0K7efoW+dv/corhBsfjftfIYLtp7dSGeJ+Zj4c33tDIboBYLs6qijRlz6wtHFxa0YX+FibLulA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4",
+        "tree-sitter-c": "^0.23.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-ocaml": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-ocaml/-/tree-sitter-ocaml-0.24.2.tgz",
+      "integrity": "sha512-H0RAeCepIyXyTPCQra6yMd7Bn5ZBYkIaddzdLNwVZpM9mCe2e8av+3O6Ojl7Z8YHrV/kYsfHvI2y+Hh7qzcYQQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.4"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-php": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-php/-/tree-sitter-php-0.24.2.tgz",
+      "integrity": "sha512-zwgAePc/HozNaWOOfwRAA+3p8yhuehRw8Fb7vn5qd2XjiIc93uJPryDTMYTSjBRjVIUg/KY6pM3rRzs8dSwKfw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.4"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-python": {
+      "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.23.6.tgz",
+      "integrity": "sha512-yIM9z0oxKIxT7bAtPOhgoVl6gTXlmlIhue7liFT4oBPF/lha7Ha4dQBS82Av6hMMRZoVnFJI8M6mL+SwWoLD3A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-ruby": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-ruby/-/tree-sitter-ruby-0.23.1.tgz",
+      "integrity": "sha512-d9/RXgWjR6HanN7wTYhS5bpBQLz1VkH048Vm3CodPGyJVnamXMGb8oEhDypVCBq4QnHui9sTXuJBBP3WtCw5RA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-rust": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-rust/-/tree-sitter-rust-0.24.0.tgz",
+      "integrity": "sha512-NWemUDf629Tfc90Y0Z55zuwPCAHkLxWnMf2RznYu4iBkkrQl2o/CHGB7Cr52TyN5F1DAx8FmUnDtCy9iUkXZEQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-scala": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-scala/-/tree-sitter-scala-0.24.0.tgz",
+      "integrity": "sha512-vkMuAUrBZ1zZz2XcGDQk18Kz73JkpgaeXzbNVobPke0G35sd9jH32aUxG6OLRKM7et0TbsfqkWf4DeJoGk4K1g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-swift": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-swift/-/tree-sitter-swift-0.7.1.tgz",
+      "integrity": "sha512-pneKVTuGamaBsqqqfB9BvNQjktzh/0IVPR54jLB5Fq/JTDQwYHd0Wo6pVyZ5jAYpbztzq+rJ/rpL9ruxTmSoKw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0",
+        "tree-sitter-cli": "^0.23",
+        "which": "2.0.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-typescript": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",
+      "integrity": "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2",
+        "tree-sitter-javascript": "^0.23.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-zig": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-zig/-/tree-sitter-zig-0.2.0.tgz",
+      "integrity": "sha512-tvRaQw16pwlLVUFoBGMmBZFJfXaGB3vrgEcgrmanKL/MPdCBA12NYotrO8iS8C4DRJV5YimGvXt8do7f+d53qg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "nan": "^2.14.0"
       }
     },
     "node_modules/tsx": {
@@ -3936,6 +5454,18 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-is": {
@@ -3987,6 +5517,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -4603,6 +6139,50 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wide-align/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wide-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wide-align/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@cadre-dev/runtime-provider-docker": "*",
     "@cadre-dev/runtime-provider-kata": "*",
     "@inquirer/prompts": "^8",
+    "@jafreck/lore": "^0.2.5",
     "@modelcontextprotocol/sdk": "^1.27",
     "@octokit/rest": "^22",
     "chalk": "^5",

--- a/src/agents/templates/code-reviewer.md
+++ b/src/agents/templates/code-reviewer.md
@@ -11,6 +11,8 @@ The following files may be provided as additional context. They are read-only â€
 - **`scout-report.md`** (conditionally provided): A report of the codebase structure, relevant files, and patterns discovered during scouting. Read this to understand the broader context of the changes under review.
 - **`issueBody`** (conditionally provided in payload): The raw GitHub issue body â€” the original requirements as written by the issue author. When present, use it as the authoritative source of requirements to verify correctness of the changes. If `analysis.md` and `issueBody` disagree on scope, prefer `issueBody`.
 
+{{LORE_GUIDANCE}}
+
 ## Input
 You will receive one or more of the following:
 - A unified diff of the changes (output of `git diff`)

--- a/src/agents/templates/code-writer.md
+++ b/src/agents/templates/code-writer.md
@@ -21,6 +21,8 @@ The following files may be provided as additional context. They are read-only â€
 
 Read all relevant source files before writing any code. Understand existing patterns, types, and conventions before modifying anything.
 
+{{LORE_GUIDANCE}}
+
 ## Output Contract
 
 - **Modified or created source files**: Apply the minimal changes required to satisfy the acceptance criteria. Do not touch files outside the task's file list.

--- a/src/agents/templates/codebase-scout.md
+++ b/src/agents/templates/codebase-scout.md
@@ -21,6 +21,8 @@ You may use the following tools to inspect the repository:
 - **grep** — search file contents for symbols, function names, imports, or patterns
 - **view** — read specific files to understand structure, exports, and logic
 
+{{LORE_GUIDANCE}}
+
 Do **not** modify any files. Do **not** run shell commands or execute code.
 
 ## Output Contract

--- a/src/agents/templates/fix-surgeon.md
+++ b/src/agents/templates/fix-surgeon.md
@@ -18,6 +18,8 @@ The following files may be provided as additional context. They are read-only â€
 - **`scout-report.md`** (conditionally provided): A report of the codebase structure and patterns. Consult this only if you need broader context about how surrounding code works.
 - **Session plan / `implementation-plan.md`** (conditionally provided): The step-by-step implementation plan for the current session (phase-3) or the full plan (`implementation-plan.md` in phase-4). Consult this only if you need to understand how the flagged issue fits into the broader change set.
 
+{{LORE_GUIDANCE}}
+
 Read each flagged issue carefully before making any change. Understand the exact scope of what needs fixing before touching any file.
 
 ## Output Contract

--- a/src/agents/templates/implementation-planner.md
+++ b/src/agents/templates/implementation-planner.md
@@ -112,6 +112,8 @@ When `testable: false`, the test-writer agent is skipped for that session. Leave
 
 - **Read files** (required): Read analysis.md, scout-report.md, and every source file you intend to reference before making any claims about its contents or structure.
 
+{{LORE_GUIDANCE}}
+
 ## Example Output
 
 ```cadre-json

--- a/src/agents/templates/issue-analyst.md
+++ b/src/agents/templates/issue-analyst.md
@@ -88,6 +88,8 @@ The block must match the `AnalysisResult` schema: `requirements` (string array),
 - **File read**: Read context `inputFiles` and any source files needed for accurate analysis
 - **File write**: Write the final markdown report to `outputPath`
 
+{{LORE_GUIDANCE}}
+
 ## Example Output
 
 ```

--- a/src/agents/templates/partials/lore-guidance.md
+++ b/src/agents/templates/partials/lore-guidance.md
@@ -1,0 +1,5 @@
+### Lore Knowledge Base (if available)
+
+If the `mcp__lore` tool is available, use it to query the pre-built knowledge base for function signatures, type definitions, module exports, dependency relationships, and architecture patterns. Prefer Lore queries over reading full source files when you need to locate symbols, understand how modules connect, or survey unfamiliar areas of the codebase. This keeps your context window focused on the information you actually need.
+
+Fall back to direct file reads when Lore does not return a satisfactory answer.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -379,6 +379,39 @@ export const CadreConfigSchema = z.object({
 
   /** Isolation provider configuration for agent invocations. */
   isolation: IsolationConfigSchema,
+
+  /**
+   * Lore knowledge-base configuration.
+   *
+   * When enabled, cadre builds a Lore index for the target repo once per issue
+   * and registers the Lore MCP server in each worktree so agents can query a
+   * pre-built knowledge base instead of reading full files.
+   */
+  lore: z
+    .object({
+      /** Enable the Lore knowledge-base integration. */
+      enabled: z.boolean().default(false),
+      /**
+       * Command used to invoke the Lore CLI.  Defaults to `lore`.
+       * The CLI must support `lore index --root <dir> --db <path>` and
+       * `lore mcp --db <path>`.
+       */
+      command: z.string().default('lore'),
+      /** Extra arguments appended to `lore index --root <worktree> --db <db>`. */
+      indexArgs: z.array(z.string()).default([]),
+      /**
+       * Arguments for the Lore MCP server command written into each
+       * worktree's MCP config.  Defaults to `['mcp']`.
+       */
+      serveArgs: z.array(z.string()).default(['mcp']),
+      /**
+       * Timeout in milliseconds for the index build step.
+       * Defaults to 120 000 (2 min).
+       */
+      indexTimeout: z.number().int().min(1000).default(120_000),
+    })
+    .default({ enabled: false })
+    .optional(),
 });
 
 export type CadreConfig = z.infer<typeof CadreConfigSchema>;

--- a/src/core/fleet/fleet-orchestrator.ts
+++ b/src/core/fleet/fleet-orchestrator.ts
@@ -21,6 +21,7 @@ import { FleetScheduler } from './fleet-scheduler.js';
 import { PullRequestCompletionQueue, type CompletionFailure, type MergeConflictResolverFn } from '../merge/pr-completion-queue.js';
 import { MergeRetryHelper } from '../merge/merge-retry.js';
 import type { PullRequestMergeMethod } from '../../platform/provider.js';
+import { LoreIndexBuilder, LoreMcpConfigWriter, resolveLoreConfig, type LoreConfig } from '../lore/index.js';
 
 export interface FleetResult {
   /** Whether all issues were resolved successfully. */
@@ -55,6 +56,9 @@ export class FleetOrchestrator {
   private readonly tokenTracker: TokenTracker;
   private readonly costEstimator: CostEstimator;
   private readonly contextBuilder: ContextBuilder;
+  private readonly loreConfig: LoreConfig;
+  private readonly loreIndexBuilder: LoreIndexBuilder | undefined;
+  private readonly loreMcpConfigWriter: LoreMcpConfigWriter | undefined;
   private fleetBudgetExceeded = false;
   private eventBus!: FleetEventBus;
   private reporter!: FleetReporter;
@@ -78,6 +82,13 @@ export class FleetOrchestrator {
     this.tokenTracker = new TokenTracker();
     this.costEstimator = new CostEstimator(config.agent.copilot);
     this.contextBuilder = new ContextBuilder(config, logger);
+
+    // Lore knowledge-base integration
+    this.loreConfig = resolveLoreConfig(config);
+    if (this.loreConfig.enabled) {
+      this.loreIndexBuilder = new LoreIndexBuilder(this.loreConfig, logger);
+      this.loreMcpConfigWriter = new LoreMcpConfigWriter(this.loreConfig, config.agent.backend, logger);
+    }
 
     const autoComplete = this.resolveAutoCompleteConfig();
     this.autoCompleteEnabled = autoComplete.enabled;
@@ -874,6 +885,17 @@ export class FleetOrchestrator {
       );
 
       // 5. Create per-issue orchestrator
+      //
+      // Before creating the orchestrator, build the Lore knowledge-base
+      // index for this worktree (once per issue) and write the MCP config
+      // so every agent invocation can query the pre-built index.
+      if (this.loreIndexBuilder) {
+        const indexed = await this.loreIndexBuilder.buildIndex(worktree.path, issue.number);
+        if (indexed && this.loreMcpConfigWriter) {
+          await this.loreMcpConfigWriter.writeMcpConfig(worktree.path, issue.number);
+        }
+      }
+
       const issueOrchestrator = new IssueOrchestrator(
         this.config,
         issue,

--- a/src/core/lore/index.ts
+++ b/src/core/lore/index.ts
@@ -1,0 +1,2 @@
+export { LoreIndexBuilder, resolveLoreConfig, LORE_DB_REL_PATH, type LoreConfig } from './lore-index-builder.js';
+export { LoreMcpConfigWriter } from './lore-mcp-config.js';

--- a/src/core/lore/lore-index-builder.ts
+++ b/src/core/lore/lore-index-builder.ts
@@ -1,0 +1,98 @@
+import { join } from 'node:path';
+import { exec } from '../../util/process.js';
+import type { Logger } from '@cadre-dev/framework/core';
+import type { CadreConfig } from '../../config/schema.js';
+
+/** Relative path within a worktree where the Lore SQLite DB is stored. */
+export const LORE_DB_REL_PATH = join('.cadre', 'lore.db');
+
+export interface LoreConfig {
+  enabled: boolean;
+  command: string;
+  indexArgs: string[];
+  serveArgs: string[];
+  indexTimeout: number;
+}
+
+/**
+ * Resolve the lore config from the cadre config.
+ * Returns a fully resolved config with defaults applied.
+ */
+export function resolveLoreConfig(config: CadreConfig): LoreConfig {
+  const lore = config.lore;
+  return {
+    enabled: lore?.enabled ?? false,
+    command: lore?.command ?? 'lore',
+    indexArgs: lore?.indexArgs ?? [],
+    serveArgs: lore?.serveArgs ?? ['mcp'],
+    indexTimeout: lore?.indexTimeout ?? 120_000,
+  };
+}
+
+/**
+ * Builds a Lore knowledge-base index for a worktree.
+ *
+ * The index is built once per issue by running:
+ *
+ *   lore index --root <worktreePath> --db <worktreePath>/.cadre/lore.db
+ *
+ * before any agents are launched.  This populates the Lore database so
+ * agents can make fast, targeted queries via the Lore MCP server instead
+ * of reading full files.
+ */
+export class LoreIndexBuilder {
+  constructor(
+    private readonly loreConfig: LoreConfig,
+    private readonly logger: Logger,
+  ) {}
+
+  /**
+   * Build (or refresh) the Lore index for the given worktree.
+   *
+   * @param worktreePath  Absolute path to the worktree root.
+   * @param issueNumber   Issue number for structured logging.
+   * @returns `true` if indexing succeeded, `false` otherwise (non-fatal).
+   */
+  async buildIndex(worktreePath: string, issueNumber: number): Promise<boolean> {
+    if (!this.loreConfig.enabled) return false;
+
+    this.logger.info('Building Lore index for worktree', {
+      issueNumber,
+      data: { worktreePath },
+    });
+
+    const dbPath = join(worktreePath, LORE_DB_REL_PATH);
+    const args = ['index', '--root', worktreePath, '--db', dbPath, ...this.loreConfig.indexArgs];
+    const startTime = Date.now();
+
+    try {
+      const result = await exec(this.loreConfig.command, args, {
+        cwd: worktreePath,
+        timeout: this.loreConfig.indexTimeout,
+      });
+
+      const duration = Date.now() - startTime;
+
+      if (result.exitCode !== 0) {
+        this.logger.warn(
+          `Lore index build failed (exit ${result.exitCode}): ${result.stderr}`,
+          { issueNumber, data: { duration, exitCode: result.exitCode } },
+        );
+        return false;
+      }
+
+      this.logger.info(`Lore index built in ${duration}ms`, {
+        issueNumber,
+        data: { duration },
+      });
+      return true;
+    } catch (err) {
+      const duration = Date.now() - startTime;
+      this.logger.warn(
+        `Lore index build error: ${err}`,
+        { issueNumber, data: { duration } },
+      );
+      return false;
+    }
+  }
+}

--- a/src/core/lore/lore-mcp-config.ts
+++ b/src/core/lore/lore-mcp-config.ts
@@ -1,0 +1,126 @@
+import { join } from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
+import type { Logger } from '@cadre-dev/framework/core';
+import { ensureDir, exists } from '../../util/fs.js';
+import { type LoreConfig, LORE_DB_REL_PATH } from './lore-index-builder.js';
+
+/**
+ * Writes MCP server configuration for the Lore knowledge-base tool into
+ * agent worktrees so the Claude / Copilot CLIs will automatically discover
+ * and start the Lore MCP server when an agent is invoked.
+ *
+ * - **Claude backend**: writes to `{worktree}/.claude/settings.local.json`
+ * - **Copilot backend**: writes to `{worktree}/.github/copilot/mcp.json`
+ *
+ * The config files point at the worktree-specific Lore index so each issue
+ * pipeline queries its own snapshot of the codebase.
+ */
+export class LoreMcpConfigWriter {
+  constructor(
+    private readonly loreConfig: LoreConfig,
+    private readonly backend: string,
+    private readonly logger: Logger,
+  ) {}
+
+  /**
+   * Write or merge the Lore MCP server entry into the worktree's CLI-specific
+   * MCP configuration file.
+   *
+   * Non-destructive: if a config file already exists, the lore entry is merged
+   * into the existing `mcpServers` map without overwriting other servers.
+   *
+   * @param worktreePath  Absolute path to the worktree root.
+   * @param issueNumber   Issue number for structured logging.
+   */
+  async writeMcpConfig(worktreePath: string, issueNumber: number): Promise<void> {
+    if (!this.loreConfig.enabled) return;
+
+    if (this.backend === 'claude') {
+      await this.writeClaudeConfig(worktreePath, issueNumber);
+    } else {
+      await this.writeCopilotConfig(worktreePath, issueNumber);
+    }
+  }
+
+  // ── Claude ──
+
+  /**
+   * Write `{worktree}/.claude/settings.local.json` with Lore MCP server.
+   *
+   * Claude CLI reads this file automatically. Using `settings.local.json`
+   * instead of `settings.json` avoids clobbering user settings if they
+   * exist in the worktree already.
+   */
+  private async writeClaudeConfig(worktreePath: string, issueNumber: number): Promise<void> {
+    const configDir = join(worktreePath, '.claude');
+    await ensureDir(configDir);
+    const configPath = join(configDir, 'settings.local.json');
+
+    const dbPath = join(worktreePath, LORE_DB_REL_PATH);
+    const loreMcpEntry = {
+      command: this.loreConfig.command,
+      args: [...this.loreConfig.serveArgs, '--db', dbPath],
+    };
+
+    let config: Record<string, unknown> = {};
+    if (await exists(configPath)) {
+      try {
+        const raw = await readFile(configPath, 'utf-8');
+        config = JSON.parse(raw) as Record<string, unknown>;
+      } catch {
+        // Malformed JSON — start fresh.
+      }
+    }
+
+    const mcpServers = (config['mcpServers'] ?? {}) as Record<string, unknown>;
+    mcpServers['lore'] = loreMcpEntry;
+    config['mcpServers'] = mcpServers;
+
+    await writeFile(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+
+    this.logger.debug('Wrote Lore MCP config for Claude backend', {
+      issueNumber,
+      data: { configPath },
+    });
+  }
+
+  // ── Copilot ──
+
+  /**
+   * Write `{worktree}/.github/copilot/mcp.json` with Lore MCP server.
+   *
+   * Copilot CLI reads this file for MCP server discovery.
+   */
+  private async writeCopilotConfig(worktreePath: string, issueNumber: number): Promise<void> {
+    const configDir = join(worktreePath, '.github', 'copilot');
+    await ensureDir(configDir);
+    const configPath = join(configDir, 'mcp.json');
+
+    const dbPath = join(worktreePath, LORE_DB_REL_PATH);
+    const loreMcpEntry = {
+      command: this.loreConfig.command,
+      args: [...this.loreConfig.serveArgs, '--db', dbPath],
+    };
+
+    let config: Record<string, unknown> = {};
+    if (await exists(configPath)) {
+      try {
+        const raw = await readFile(configPath, 'utf-8');
+        config = JSON.parse(raw) as Record<string, unknown>;
+      } catch {
+        // Malformed JSON — start fresh.
+      }
+    }
+
+    const mcpServers = (config['mcpServers'] ?? {}) as Record<string, unknown>;
+    mcpServers['lore'] = loreMcpEntry;
+    config['mcpServers'] = mcpServers;
+
+    await writeFile(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+
+    this.logger.debug('Wrote Lore MCP config for Copilot backend', {
+      issueNumber,
+      data: { configPath },
+    });
+  }
+}

--- a/src/core/run-coordinator.ts
+++ b/src/core/run-coordinator.ts
@@ -18,6 +18,7 @@ import { gitValidator } from '../validation/git-validator.js';
 import { agentBackendValidator } from '../validation/agent-backend-validator.js';
 import { platformValidator } from '../validation/platform-validator.js';
 import { commandValidator } from '../validation/command-validator.js';
+import { loreValidator } from '../validation/lore-validator.js';
 import { registryCompletenessValidator } from '../validation/registry-completeness-validator.js';
 import { checkStaleState } from '../validation/stale-state-validator.js';
 import type { NotificationManager } from '@cadre-dev/framework/notifications';
@@ -53,6 +54,7 @@ export class RunCoordinator {
       agentBackendValidator,
       platformValidator,
       commandValidator,
+      loreValidator,
       diskValidator,
       registryCompletenessValidator,
     ]);

--- a/src/git/agent-file-sync.ts
+++ b/src/git/agent-file-sync.ts
@@ -103,6 +103,12 @@ export class AgentFileSync {
 
     await ensureDir(this.cacheDir);
 
+    // Load template partials from {agentDir}/partials/.
+    // Each partial is a Markdown file whose content replaces the matching
+    // placeholder in agent templates.  File `lore-guidance.md` is injected
+    // wherever `{{LORE_GUIDANCE}}` appears.
+    const partials = await this.loadPartials(this.agentDir);
+
     const entries = await readdir(this.agentDir);
     const sourceFiles = entries.filter((f) => f.endsWith('.md') && !f.endsWith('.agent.md'));
 
@@ -116,7 +122,10 @@ export class AgentFileSync {
         .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
         .join(' ');
       const description = definition?.description ?? displayName;
-      const body = await readFile(srcPath, 'utf-8');
+      let body = await readFile(srcPath, 'utf-8');
+
+      // Expand {{PARTIAL_NAME}} placeholders with loaded partial content.
+      body = AgentFileSync.expandPartials(body, partials);
 
       let destFileName: string;
       let content: string;
@@ -234,5 +243,50 @@ export class AgentFileSync {
       );
     }
     return syncedRelPaths;
+  }
+
+  // ── Partial Expansion ──
+
+  /**
+   * Load partial Markdown files from `{agentDir}/partials/`.
+   *
+   * Returns a map of placeholder name → content.
+   * File `lore-guidance.md` produces placeholder `LORE_GUIDANCE`.
+   */
+  private async loadPartials(agentDir: string): Promise<Map<string, string>> {
+    const partialsDir = join(agentDir, 'partials');
+    const partials = new Map<string, string>();
+
+    if (!(await exists(partialsDir))) return partials;
+
+    const entries = await readdir(partialsDir);
+    for (const file of entries) {
+      if (!file.endsWith('.md')) continue;
+      const name = file
+        .replace(/\.md$/, '')
+        .replace(/-/g, '_')
+        .toUpperCase();
+      const content = (await readFile(join(partialsDir, file), 'utf-8')).trimEnd();
+      partials.set(name, content);
+    }
+
+    if (partials.size > 0) {
+      this.logger.debug(
+        `Loaded ${partials.size} template partial(s): ${[...partials.keys()].join(', ')}`,
+      );
+    }
+
+    return partials;
+  }
+
+  /**
+   * Replace `{{NAME}}` placeholders in a template body with partial content.
+   * Unresolved placeholders (no matching partial) are removed so raw
+   * `{{…}}` tokens never leak into the final agent file.
+   */
+  static expandPartials(body: string, partials: Map<string, string>): string {
+    return body.replace(/\{\{([A-Z][A-Z0-9_]*)\}\}/g, (match, name: string) => {
+      return partials.get(name) ?? '';
+    });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { gitValidator } from './validation/git-validator.js';
 import { agentBackendValidator } from './validation/agent-backend-validator.js';
 import { platformValidator } from './validation/platform-validator.js';
 import { commandValidator } from './validation/command-validator.js';
+import { loreValidator } from './validation/lore-validator.js';
 import { Logger } from '@cadre-dev/framework/core';
 import { createPlatformProvider } from './platform/factory.js';
 import { withCommandHandler } from './cli/command-error-handler.js';
@@ -196,6 +197,7 @@ program
       agentBackendValidator,
       platformValidator,
       commandValidator,
+      loreValidator,
       diskValidator,
     ]);
     const passed = await suite.run(config);

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -2,6 +2,7 @@ export { gitValidator } from './git-validator.js';
 export { agentBackendValidator } from './agent-backend-validator.js';
 export { platformValidator } from './platform-validator.js';
 export { commandValidator } from './command-validator.js';
+export { loreValidator } from './lore-validator.js';
 export { registryCompletenessValidator } from './registry-completeness-validator.js';
 export { checkStaleState, resolveStaleState } from './stale-state-validator.js';
 export type { StaleConflict, StaleConflictKind, StaleStateResult } from './stale-state-validator.js';

--- a/src/validation/lore-validator.ts
+++ b/src/validation/lore-validator.ts
@@ -1,0 +1,39 @@
+import { exec } from '../util/process.js';
+import type { PreRunValidator, ValidationResult } from '@cadre-dev/framework/core';
+import type { RuntimeConfig } from '../config/loader.js';
+
+/**
+ * Validates that the Lore CLI is available on PATH when `lore.enabled` is
+ * true in the config.  This is a soft warning — the pipeline can still run
+ * without Lore, but agents will not benefit from knowledge-base lookups.
+ */
+export const loreValidator: PreRunValidator = {
+  name: 'lore',
+
+  async validate(config: RuntimeConfig): Promise<ValidationResult> {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    const loreEnabled = config.lore?.enabled ?? false;
+    if (!loreEnabled) {
+      return { passed: true, errors, warnings };
+    }
+
+    const loreCommand = config.lore?.command ?? 'lore';
+
+    const whichResult = await exec('which', [loreCommand]);
+    if (whichResult.exitCode !== 0) {
+      warnings.push(
+        `Lore is enabled but command '${loreCommand}' was not found on PATH. ` +
+        `Install @jafreck/lore or disable config.lore.enabled. ` +
+        `Agents will fall back to direct file reads.`,
+      );
+    }
+
+    return {
+      passed: true, // Lore is optional — warn but don't block the run.
+      errors,
+      warnings,
+    };
+  },
+};

--- a/tests/agent-file-sync.test.ts
+++ b/tests/agent-file-sync.test.ts
@@ -74,7 +74,10 @@ describe('AgentFileSync', () => {
     });
 
     it('generates .agent.md files with frontmatter into cache for copilot', async () => {
-      vi.mocked(fsUtils.exists).mockResolvedValue(true);
+      vi.mocked(fsUtils.exists).mockImplementation(async (p: string) => {
+        if (typeof p === 'string' && p.includes('partials')) return false;
+        return true;
+      });
       vi.mocked(fsp.readdir as ReturnType<typeof vi.fn>).mockResolvedValue(['code-writer.md']);
       vi.mocked(fsp.readFile as ReturnType<typeof vi.fn>).mockResolvedValue('body');
 
@@ -89,7 +92,10 @@ describe('AgentFileSync', () => {
     });
 
     it('generates .md files with frontmatter into cache for claude', async () => {
-      vi.mocked(fsUtils.exists).mockResolvedValue(true);
+      vi.mocked(fsUtils.exists).mockImplementation(async (p: string) => {
+        if (typeof p === 'string' && p.includes('partials')) return false;
+        return true;
+      });
       vi.mocked(fsp.readdir as ReturnType<typeof vi.fn>).mockResolvedValue(['code-writer.md']);
       vi.mocked(fsp.readFile as ReturnType<typeof vi.fn>).mockResolvedValue('body');
 
@@ -101,6 +107,84 @@ describe('AgentFileSync', () => {
       expect(writeCall[0]).toBe('/tmp/state/agents-cache-claude/code-writer.md');
       expect(writeCall[1]).not.toContain('tools:');
       expect(writeCall[1]).toContain('body');
+    });
+
+    it('expands {{PARTIAL}} placeholders from partials/ directory', async () => {
+      // exists: agentDir=true, partialsDir=true, cacheDir check=true
+      vi.mocked(fsUtils.exists).mockResolvedValue(true);
+      // First readdir call is for partials/, second for agentDir entries
+      vi.mocked(fsp.readdir as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(['lore-guidance.md'])        // partials dir
+        .mockResolvedValueOnce(['code-writer.md']);          // agent dir
+      vi.mocked(fsp.readFile as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce('Partial content here')      // partial file read
+        .mockResolvedValueOnce('before\n{{LORE_GUIDANCE}}\nafter'); // agent template read
+
+      const sync = new AgentFileSync('/tmp/agents', 'claude', mockLogger, '/tmp/state');
+      await sync.buildAgentCache();
+
+      const writeCall = vi.mocked(fsp.writeFile as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(writeCall[1]).toContain('Partial content here');
+      expect(writeCall[1]).not.toContain('{{LORE_GUIDANCE}}');
+      expect(writeCall[1]).toContain('before\nPartial content here\nafter');
+    });
+
+    it('removes unresolved {{PLACEHOLDER}} tokens when no matching partial exists', async () => {
+      vi.mocked(fsUtils.exists).mockImplementation(async (p: string) => {
+        if (typeof p === 'string' && p.includes('partials')) return false;
+        return true;
+      });
+      vi.mocked(fsp.readdir as ReturnType<typeof vi.fn>).mockResolvedValue(['code-writer.md']);
+      vi.mocked(fsp.readFile as ReturnType<typeof vi.fn>)
+        .mockResolvedValue('before\n{{UNKNOWN_PARTIAL}}\nafter');
+
+      const sync = new AgentFileSync('/tmp/agents', 'copilot', mockLogger, '/tmp/state');
+      await sync.buildAgentCache();
+
+      const writeCall = vi.mocked(fsp.writeFile as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(writeCall[1]).not.toContain('{{UNKNOWN_PARTIAL}}');
+      expect(writeCall[1]).toContain('before\n\nafter');
+    });
+  });
+
+  describe('expandPartials (static)', () => {
+    it('replaces a single placeholder', () => {
+      const partials = new Map([['FOO', 'replaced content']]);
+      const result = AgentFileSync.expandPartials('before {{FOO}} after', partials);
+      expect(result).toBe('before replaced content after');
+    });
+
+    it('replaces multiple different placeholders', () => {
+      const partials = new Map([
+        ['A', 'alpha'],
+        ['B', 'beta'],
+      ]);
+      const result = AgentFileSync.expandPartials('{{A}} and {{B}}', partials);
+      expect(result).toBe('alpha and beta');
+    });
+
+    it('replaces repeated occurrences of the same placeholder', () => {
+      const partials = new Map([['X', 'val']]);
+      const result = AgentFileSync.expandPartials('{{X}} then {{X}}', partials);
+      expect(result).toBe('val then val');
+    });
+
+    it('removes unresolved placeholders', () => {
+      const partials = new Map<string, string>();
+      const result = AgentFileSync.expandPartials('keep {{MISSING}} keep', partials);
+      expect(result).toBe('keep  keep');
+    });
+
+    it('returns body unchanged when no placeholders exist', () => {
+      const partials = new Map([['FOO', 'bar']]);
+      const result = AgentFileSync.expandPartials('no placeholders here', partials);
+      expect(result).toBe('no placeholders here');
+    });
+
+    it('does not match lowercase or mixed-case placeholders', () => {
+      const partials = new Map([['foo', 'bar']]);
+      const result = AgentFileSync.expandPartials('{{foo}} {{Foo}}', partials);
+      expect(result).toBe('{{foo}} {{Foo}}');
     });
   });
 

--- a/tests/agent-templates.test.ts
+++ b/tests/agent-templates.test.ts
@@ -57,8 +57,8 @@ describe('Agent Template Files', () => {
       expect(files).toHaveLength(14);
     });
 
-    it('should not contain any non-.md files', () => {
-      const files = readdirSync(TEMPLATES_DIR).filter((f) => !f.endsWith('.md'));
+    it('should not contain unexpected non-.md entries', () => {
+      const files = readdirSync(TEMPLATES_DIR).filter((f) => !f.endsWith('.md') && f !== 'partials');
       expect(files).toHaveLength(0);
     });
 

--- a/tests/config-schema.test.ts
+++ b/tests/config-schema.test.ts
@@ -1081,3 +1081,66 @@ describe('AgentConfigSchema', () => {
     expect(result.success).toBe(true);
   });
 });
+
+// ── Lore Config ──
+
+describe('CadreConfigSchema — lore', () => {
+  const validConfig = {
+    projectName: 'test-project',
+    platform: 'github',
+    repository: 'owner/repo',
+    repoPath: '/tmp/repo',
+    issues: { ids: [1] },
+  };
+
+  it('should default lore to undefined (opt-in)', () => {
+    const result = CadreConfigSchema.parse(validConfig);
+    // lore is optional — undefined when omitted
+    expect(result.lore).toBeUndefined();
+  });
+
+  it('should accept lore.enabled = true with all defaults', () => {
+    const result = CadreConfigSchema.parse({
+      ...validConfig,
+      lore: { enabled: true },
+    });
+    expect(result.lore?.enabled).toBe(true);
+    expect(result.lore?.command).toBe('lore');
+    expect(result.lore?.indexArgs).toEqual([]);
+    expect(result.lore?.serveArgs).toEqual(['mcp']);
+    expect(result.lore?.indexTimeout).toBe(120_000);
+  });
+
+  it('should accept custom lore command and args', () => {
+    const result = CadreConfigSchema.parse({
+      ...validConfig,
+      lore: {
+        enabled: true,
+        command: '/usr/local/bin/lore',
+        indexArgs: ['--deep', '--lang', 'typescript'],
+        serveArgs: ['serve'],
+        indexTimeout: 60_000,
+      },
+    });
+    expect(result.lore?.command).toBe('/usr/local/bin/lore');
+    expect(result.lore?.indexArgs).toEqual(['--deep', '--lang', 'typescript']);
+    expect(result.lore?.serveArgs).toEqual(['serve']);
+    expect(result.lore?.indexTimeout).toBe(60_000);
+  });
+
+  it('should reject indexTimeout below 1000', () => {
+    const result = CadreConfigSchema.safeParse({
+      ...validConfig,
+      lore: { enabled: true, indexTimeout: 500 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should default enabled to false when lore object provided without enabled', () => {
+    const result = CadreConfigSchema.parse({
+      ...validConfig,
+      lore: {},
+    });
+    expect(result.lore?.enabled).toBe(false);
+  });
+});

--- a/tests/lore-integration.test.ts
+++ b/tests/lore-integration.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LoreIndexBuilder, resolveLoreConfig, type LoreConfig } from '../src/core/lore/lore-index-builder.js';
+import { LoreMcpConfigWriter } from '../src/core/lore/lore-mcp-config.js';
+import type { CadreConfig } from '../src/config/schema.js';
+
+// ── Mocks ──
+
+vi.mock('../src/util/process.js', () => ({
+  exec: vi.fn(),
+}));
+
+vi.mock('../src/util/fs.js', () => ({
+  ensureDir: vi.fn().mockResolvedValue(undefined),
+  exists: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn().mockResolvedValue('{}'),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { exec } from '../src/util/process.js';
+import { exists } from '../src/util/fs.js';
+import { readFile, writeFile } from 'node:fs/promises';
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+};
+
+const defaultLoreConfig: LoreConfig = {
+  enabled: true,
+  command: 'lore',
+  indexArgs: [],
+  serveArgs: ['mcp'],
+  indexTimeout: 120_000,
+};
+
+// ── resolveLoreConfig ──
+
+describe('resolveLoreConfig', () => {
+  it('should return disabled config when lore is undefined', () => {
+    const config = { lore: undefined } as unknown as CadreConfig;
+    const result = resolveLoreConfig(config);
+    expect(result.enabled).toBe(false);
+    expect(result.command).toBe('lore');
+  });
+
+  it('should resolve explicit config values', () => {
+    const config = {
+      lore: {
+        enabled: true,
+        command: 'my-lore',
+        indexArgs: ['--deep'],
+        serveArgs: ['serve', '--port', '9999'],
+        indexTimeout: 60_000,
+      },
+    } as unknown as CadreConfig;
+    const result = resolveLoreConfig(config);
+    expect(result).toEqual({
+      enabled: true,
+      command: 'my-lore',
+      indexArgs: ['--deep'],
+      serveArgs: ['serve', '--port', '9999'],
+      indexTimeout: 60_000,
+    });
+  });
+
+  it('should apply defaults for missing fields', () => {
+    const config = {
+      lore: { enabled: true },
+    } as unknown as CadreConfig;
+    const result = resolveLoreConfig(config);
+    expect(result.command).toBe('lore');
+    expect(result.indexArgs).toEqual([]);
+    expect(result.serveArgs).toEqual(['mcp']);
+    expect(result.indexTimeout).toBe(120_000);
+  });
+});
+
+// ── LoreIndexBuilder ──
+
+describe('LoreIndexBuilder', () => {
+  let builder: LoreIndexBuilder;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    builder = new LoreIndexBuilder(defaultLoreConfig, mockLogger as any);
+  });
+
+  it('should return false when lore is disabled', async () => {
+    const disabledBuilder = new LoreIndexBuilder(
+      { ...defaultLoreConfig, enabled: false },
+      mockLogger as any,
+    );
+    const result = await disabledBuilder.buildIndex('/tmp/worktree', 42);
+    expect(result).toBe(false);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('should run lore index command and return true on success', async () => {
+    vi.mocked(exec).mockResolvedValue({
+      exitCode: 0,
+      stdout: 'Indexed 150 files',
+      stderr: '',
+      signal: null,
+      timedOut: false,
+    });
+
+    const result = await builder.buildIndex('/tmp/worktree', 42);
+
+    expect(result).toBe(true);
+    expect(exec).toHaveBeenCalledWith(
+      'lore',
+      ['index', '--root', '/tmp/worktree', '--db', '/tmp/worktree/.cadre/lore.db'],
+      { cwd: '/tmp/worktree', timeout: 120_000 },
+    );
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'Building Lore index for worktree',
+      expect.objectContaining({ issueNumber: 42 }),
+    );
+  });
+
+  it('should pass extra indexArgs to the command', async () => {
+    const customBuilder = new LoreIndexBuilder(
+      { ...defaultLoreConfig, indexArgs: ['--deep', '--lang', 'typescript'] },
+      mockLogger as any,
+    );
+    vi.mocked(exec).mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      signal: null,
+      timedOut: false,
+    });
+
+    await customBuilder.buildIndex('/tmp/worktree', 7);
+
+    expect(exec).toHaveBeenCalledWith(
+      'lore',
+      ['index', '--root', '/tmp/worktree', '--db', '/tmp/worktree/.cadre/lore.db', '--deep', '--lang', 'typescript'],
+      expect.any(Object),
+    );
+  });
+
+  it('should return false and warn on non-zero exit code', async () => {
+    vi.mocked(exec).mockResolvedValue({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'index failed: no files found',
+      signal: null,
+      timedOut: false,
+    });
+
+    const result = await builder.buildIndex('/tmp/worktree', 42);
+
+    expect(result).toBe(false);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Lore index build failed'),
+      expect.objectContaining({ issueNumber: 42 }),
+    );
+  });
+
+  it('should return false and warn on exception', async () => {
+    vi.mocked(exec).mockRejectedValue(new Error('command not found'));
+
+    const result = await builder.buildIndex('/tmp/worktree', 42);
+
+    expect(result).toBe(false);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Lore index build error'),
+      expect.objectContaining({ issueNumber: 42 }),
+    );
+  });
+
+  it('should use custom command from config', async () => {
+    const customBuilder = new LoreIndexBuilder(
+      { ...defaultLoreConfig, command: '/usr/local/bin/my-lore' },
+      mockLogger as any,
+    );
+    vi.mocked(exec).mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      signal: null,
+      timedOut: false,
+    });
+
+    await customBuilder.buildIndex('/tmp/worktree', 1);
+
+    expect(exec).toHaveBeenCalledWith(
+      '/usr/local/bin/my-lore',
+      expect.any(Array),
+      expect.any(Object),
+    );
+  });
+});
+
+// ── LoreMcpConfigWriter ──
+
+describe('LoreMcpConfigWriter', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(exists).mockResolvedValue(false);
+  });
+
+  describe('Claude backend', () => {
+    let writer: LoreMcpConfigWriter;
+
+    beforeEach(() => {
+      writer = new LoreMcpConfigWriter(defaultLoreConfig, 'claude', mockLogger as any);
+    });
+
+    it('should be a no-op when lore is disabled', async () => {
+      const disabledWriter = new LoreMcpConfigWriter(
+        { ...defaultLoreConfig, enabled: false },
+        'claude',
+        mockLogger as any,
+      );
+      await disabledWriter.writeMcpConfig('/tmp/worktree', 42);
+      expect(writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should write .claude/settings.local.json with lore MCP entry', async () => {
+      await writer.writeMcpConfig('/tmp/worktree', 42);
+
+      expect(writeFile).toHaveBeenCalledWith(
+        '/tmp/worktree/.claude/settings.local.json',
+        expect.any(String),
+        'utf-8',
+      );
+
+      const written = JSON.parse(vi.mocked(writeFile).mock.calls[0][1] as string);
+      expect(written.mcpServers.lore).toEqual({
+        command: 'lore',
+        args: ['mcp', '--db', '/tmp/worktree/.cadre/lore.db'],
+      });
+    });
+
+    it('should merge into existing settings file', async () => {
+      vi.mocked(exists).mockResolvedValue(true);
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify({
+        mcpServers: { github: { command: 'github-mcp-server', args: ['stdio'] } },
+        otherSetting: true,
+      }));
+
+      await writer.writeMcpConfig('/tmp/worktree', 42);
+
+      const written = JSON.parse(vi.mocked(writeFile).mock.calls[0][1] as string);
+      expect(written.mcpServers.github).toEqual({
+        command: 'github-mcp-server',
+        args: ['stdio'],
+      });
+      expect(written.mcpServers.lore).toEqual({
+        command: 'lore',
+        args: ['mcp', '--db', '/tmp/worktree/.cadre/lore.db'],
+      });
+      expect(written.otherSetting).toBe(true);
+    });
+  });
+
+  describe('Copilot backend', () => {
+    let writer: LoreMcpConfigWriter;
+
+    beforeEach(() => {
+      writer = new LoreMcpConfigWriter(defaultLoreConfig, 'copilot', mockLogger as any);
+    });
+
+    it('should write .github/copilot/mcp.json with lore MCP entry', async () => {
+      await writer.writeMcpConfig('/tmp/worktree', 42);
+
+      expect(writeFile).toHaveBeenCalledWith(
+        '/tmp/worktree/.github/copilot/mcp.json',
+        expect.any(String),
+        'utf-8',
+      );
+
+      const written = JSON.parse(vi.mocked(writeFile).mock.calls[0][1] as string);
+      expect(written.mcpServers.lore).toEqual({
+        command: 'lore',
+        args: ['mcp', '--db', '/tmp/worktree/.cadre/lore.db'],
+      });
+    });
+
+    it('should merge into existing copilot mcp.json', async () => {
+      vi.mocked(exists).mockResolvedValue(true);
+      vi.mocked(readFile).mockResolvedValue(JSON.stringify({
+        mcpServers: { other: { command: 'other-server', args: [] } },
+      }));
+
+      await writer.writeMcpConfig('/tmp/worktree', 7);
+
+      const written = JSON.parse(vi.mocked(writeFile).mock.calls[0][1] as string);
+      expect(written.mcpServers.other).toEqual({
+        command: 'other-server',
+        args: [],
+      });
+      expect(written.mcpServers.lore).toBeDefined();
+    });
+  });
+
+  it('should include custom serveArgs in the MCP entry', async () => {
+    const customConfig: LoreConfig = {
+      ...defaultLoreConfig,
+      serveArgs: ['serve', '--port', '8080'],
+    };
+    const writer = new LoreMcpConfigWriter(customConfig, 'claude', mockLogger as any);
+
+    await writer.writeMcpConfig('/tmp/worktree', 1);
+
+    const written = JSON.parse(vi.mocked(writeFile).mock.calls[0][1] as string);
+    expect(written.mcpServers.lore.args).toEqual([
+      'serve', '--port', '8080', '--db', '/tmp/worktree/.cadre/lore.db',
+    ]);
+  });
+});

--- a/tests/lore-validator.test.ts
+++ b/tests/lore-validator.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeRuntimeConfig } from './helpers/make-runtime-config.js';
+
+vi.mock('../src/util/process.js', () => ({
+  exec: vi.fn(),
+}));
+
+import { exec } from '../src/util/process.js';
+import { loreValidator } from '../src/validation/lore-validator.js';
+
+describe('loreValidator', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should pass when lore is not enabled', async () => {
+    const config = makeRuntimeConfig();
+    const result = await loreValidator.validate(config);
+    expect(result.passed).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('should pass when lore is enabled and command exists on PATH', async () => {
+    vi.mocked(exec).mockResolvedValue({
+      exitCode: 0,
+      stdout: '/usr/local/bin/lore\n',
+      stderr: '',
+      signal: null,
+      timedOut: false,
+    });
+
+    const config = makeRuntimeConfig({
+      lore: {
+        enabled: true,
+        command: 'lore',
+        indexArgs: [],
+        serveArgs: ['mcp'],
+        indexTimeout: 120_000,
+      },
+    } as any);
+
+    const result = await loreValidator.validate(config);
+    expect(result.passed).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('should warn (not error) when lore is enabled but command not found', async () => {
+    vi.mocked(exec).mockResolvedValue({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'lore not found',
+      signal: null,
+      timedOut: false,
+    });
+
+    const config = makeRuntimeConfig({
+      lore: {
+        enabled: true,
+        command: 'lore',
+        indexArgs: [],
+        serveArgs: ['mcp'],
+        indexTimeout: 120_000,
+      },
+    } as any);
+
+    const result = await loreValidator.validate(config);
+    // Lore is optional — warn but always pass
+    expect(result.passed).toBe(true);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('lore');
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should check the custom command when configured', async () => {
+    vi.mocked(exec).mockResolvedValue({
+      exitCode: 0,
+      stdout: '/usr/local/bin/my-lore\n',
+      stderr: '',
+      signal: null,
+      timedOut: false,
+    });
+
+    const config = makeRuntimeConfig({
+      lore: {
+        enabled: true,
+        command: 'my-lore',
+        indexArgs: [],
+        serveArgs: ['mcp'],
+        indexTimeout: 120_000,
+      },
+    } as any);
+
+    await loreValidator.validate(config);
+    expect(exec).toHaveBeenCalledWith('which', ['my-lore']);
+  });
+});

--- a/tests/postbuild-script.test.ts
+++ b/tests/postbuild-script.test.ts
@@ -69,8 +69,8 @@ describe('dist/agents/templates/ after build', () => {
     }
   });
 
-  it.skipIf(!existsSync(DIST_TEMPLATES_DIR))('should not contain any non-.md files', () => {
-    const nonMd = readdirSync(DIST_TEMPLATES_DIR).filter((f) => !f.endsWith('.md'));
+  it.skipIf(!existsSync(DIST_TEMPLATES_DIR))('should not contain unexpected non-.md files', () => {
+    const nonMd = readdirSync(DIST_TEMPLATES_DIR).filter((f) => !f.endsWith('.md') && f !== 'partials');
     expect(nonMd).toHaveLength(0);
   });
 });

--- a/tests/runtime-validation.test.ts
+++ b/tests/runtime-validation.test.ts
@@ -96,14 +96,14 @@ describe('CadreRuntime.validate()', () => {
     expect(result).toBe(false);
   });
 
-  it('should construct PreRunValidationSuite with all five validators', async () => {
+  it('should construct PreRunValidationSuite with all validators', async () => {
     mockRunSuite.mockResolvedValue(true);
     const runtime = new CadreRuntime(makeConfig());
     await runtime.validate();
     expect(PreRunValidationSuite).toHaveBeenCalledOnce();
     const [validators] = (PreRunValidationSuite as unknown as ReturnType<typeof vi.fn>).mock.calls[0] as [unknown[]];
     expect(Array.isArray(validators)).toBe(true);
-    expect((validators as unknown[]).length).toBe(6);
+    expect((validators as unknown[]).length).toBe(7);
   });
 
   it('should pass config to the suite run method', async () => {


### PR DESCRIPTION
## Summary

Integrates **@jafreck/lore** (v0.2.5) as an MCP server so agents can query a pre-built knowledge base instead of reading full files. The Lore index is built **once per issue** after worktree provisioning and before the 5-phase pipeline runs.

Closes #373

## Changes

### Config (`src/config/schema.ts`)
- New optional `lore` section with `enabled`, `command`, `indexArgs`, `serveArgs`, and `indexTimeout` fields. Opt-in via `lore.enabled: true`.

### Runtime
- **`LoreIndexBuilder`** (`src/core/lore/lore-index-builder.ts`) — runs `lore index --root <worktree> --db <worktree>/.cadre/lore.db` once per issue in `FleetOrchestrator.processIssue()`. The DB is stored at `.cadre/lore.db` inside each worktree.
- **`LoreMcpConfigWriter`** (`src/core/lore/lore-mcp-config.ts`) — writes MCP server config into worktrees (`.claude/settings.local.json` for Claude, `.github/copilot/mcp.json` for Copilot) pointing at the worktree-local DB via `lore mcp --db <path>`.
- **`loreValidator`** (`src/validation/lore-validator.ts`) — warns (non-blocking) when Lore is enabled but the CLI is not on PATH.

### Template Partial System (`src/git/agent-file-sync.ts`)
- `buildAgentCache()` now loads Markdown fragments from `{agentDir}/partials/` and expands `{{PLACEHOLDER}}` flags in agent templates before writing cached files.
- `expandPartials()` is a static method for easy unit testing.
- `lore-guidance.md` partial provides a single source of truth for Lore instructions, injected into 6 agent templates via `{{LORE_GUIDANCE}}`.
- Unresolved placeholders are stripped so raw `{{…}}` tokens never leak into agent files.

### Agent Templates
Templates updated with `{{LORE_GUIDANCE}}` placeholder: `issue-analyst`, `codebase-scout`, `implementation-planner`, `code-writer`, `code-reviewer`, `fix-surgeon`.

### Dependency
- Added `@jafreck/lore: ^0.2.5` to `package.json` + lockfile.

## Testing

- 23 new tests across 2 new test files (`lore-integration.test.ts`, `lore-validator.test.ts`) and 4 updated test files.
- Full suite: **195 files, 3752 tests pass**, 0 failures.
- TypeScript: clean `tsc --noEmit`.

## Fallback Behaviour

All Lore integration is opt-in and non-blocking:
- When `lore.enabled` is `false` (default), nothing changes.
- When indexing fails, the MCP config is not written and agents fall back to direct file reads.
- Template text says "if available" so agents degrade gracefully when the Lore MCP server is absent.