### PR TITLE
chore(deps): bump @jafreck/lore to ^0.3.7 and remove deleted tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@cadre-dev/runtime-provider-docker": "*",
         "@cadre-dev/runtime-provider-kata": "*",
         "@inquirer/prompts": "^8",
-        "@jafreck/lore": "^0.3.6",
+        "@jafreck/lore": "^0.3.7",
         "@modelcontextprotocol/sdk": "^1.27",
         "@octokit/rest": "^22",
         "chalk": "^5",
@@ -1478,9 +1478,9 @@
       }
     },
     "node_modules/@jafreck/lore": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jafreck/lore/-/lore-0.3.6.tgz",
-      "integrity": "sha512-D+WwUwHLKIgR4aYIM7V/GKa+Iq2s6iO14DX0m97PYkwnTqpBbBGYdFdgmXIPaDjc5D+Kn17xHyxOH2nAONGmVQ==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@jafreck/lore/-/lore-0.3.7.tgz",
+      "integrity": "sha512-ZbkYUbPnEK/ZbeFfBmZzAaoPhr/8Z3N5ruW3QKFJVBWC/yJ3Zr+1PqZ0W2qi1okx1HfayakQ9eJFTLp9p9yVrA==",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@cadre-dev/runtime-provider-docker": "*",
     "@cadre-dev/runtime-provider-kata": "*",
     "@inquirer/prompts": "^8",
-    "@jafreck/lore": "^0.3.6",
+    "@jafreck/lore": "^0.3.7",
     "@modelcontextprotocol/sdk": "^1.27",
     "@octokit/rest": "^22",
     "chalk": "^5",

--- a/src/agents/templates/partials/lore-guidance.md
+++ b/src/agents/templates/partials/lore-guidance.md
@@ -7,20 +7,15 @@ source files. This keeps your context window focused on the information you actu
 Key Lore tools:
 - **`lore_lookup`** — find symbols by name or files by path (supports `exact`, `prefix`, `contains` matching)
 - **`lore_search`** — structural BM25, semantic, or fused search across symbols and documentation
-- **`lore_graph`** — query call, import, module, inheritance, and type-dependency edges; supports `source_id` for outbound and `target_id` for inbound/reverse queries
-- **`lore_architecture`** — build a component-level architecture view with edges, entry/leaf nodes, and external dependency usage
+- **`lore_graph`** — query call, import, inheritance, and type-dependency edges; supports `source_id` for outbound and `target_id` for inbound/reverse queries
 - **`lore_snippet`** — return source snippets by file path + line range or by symbol name; includes containing-symbol context metadata
 - **`lore_docs`** — list, fetch, or search indexed documentation with branch, kind, and path filters
-- **`lore_annotations`** — return indexed TODO/FIXME/HACK/NOTE annotations with optional path and limit filters
 - **`lore_routes`** — query extracted API routes/endpoints with optional method, path prefix, and framework filters
 - **`lore_notes_read`** / **`lore_notes_write`** — read and write agent-authored notes by key and scope, with staleness tracking
 - **`lore_test_map`** — return mapped test files (with confidence) for a given source file path
 - **`lore_blame`** — query blame, line-range history, or ownership aggregates with risk signals
 - **`lore_history`** — query commit history by file, author, ref, recency, or semantic commit-message similarity
-- **`lore_coverage`** — symbol-level coverage, uncovered lines, and staleness metadata
 - **`lore_metrics`** — aggregate index metrics plus coverage/staleness fields
-- **`lore_analyze`** — graph analysis: cycle detection, connected components, clustering, and codebase summary
-- **`lore_writeback`** — persist agent-authored symbol summaries
 
 Prefer Lore queries over reading full source files when you need to locate symbols,
 understand how modules connect, or survey unfamiliar areas of the codebase.


### PR DESCRIPTION
Bump `@jafreck/lore` from `^0.3.6` to `^0.3.7` (resolves to 0.3.7, [npm](https://www.npmjs.com/package/@jafreck/lore)).

### Breaking changes handled

v0.3.7 removed 6 low-value MCP tools and the `module` edge kind from `lore_graph`. The `lore-guidance.md` partial has been updated accordingly:

| Removed tool | Action |
|---|---|
| `lore_annotations` | Removed from guidance |
| `lore_coverage` | Removed from guidance |
| `lore_writeback` | Removed from guidance |
| `lore_analyze` | Removed from guidance |
| `lore_architecture` | Removed from guidance |
| `module` edge kind in `lore_graph` | Removed from description |

### Changes

- **`package.json`** + **`package-lock.json`** — version bump to `^0.3.7`
- **`lore-guidance.md` partial** — removed 6 deleted tools and `module` edge kind reference

### API verification

| Integration point | v0.3.7 API | Our code | Status |
|---|---|---|---|
| Index CLI | `lore index --root <path> --db <path>` | Same | ✅ |
| MCP serve CLI | `lore mcp --db <path>` | Same | ✅ |
| MCP config shape | `{ command, args: ["mcp", "--db", dbPath] }` | Same | ✅ |
| Remaining MCP tools | 11 tools (lookup, search, graph, snippet, docs, routes, notes, test_map, blame, history, metrics) | Updated in partial | ✅ |