### PR TITLE
fix(fleet): migrate legacy byIssue→byWorkItem in fleet checkpoint

### DIFF
--- a/packages/framework/__tests__/engine/checkpoint/checkpoint.test.ts
+++ b/packages/framework/__tests__/engine/checkpoint/checkpoint.test.ts
@@ -838,4 +838,64 @@ describe('FleetCheckpointManager', () => {
     // Clean up
     await rm(legacyPath, { force: true });
   });
+
+  it('should migrate byIssue to byWorkItem when loading legacy checkpoint', async () => {
+    const legacyState = {
+      projectName: 'my-project',
+      version: 1,
+      issues: {},
+      tokenUsage: { total: 100, byIssue: { '42': 50, '99': 50 } },
+      startedAt: '2026-01-01T00:00:00.000Z',
+      lastCheckpoint: '2026-01-01T00:00:00.000Z',
+      resumeCount: 0,
+    };
+    await writeFile(join(tempDir, 'fleet-checkpoint.json'), JSON.stringify(legacyState));
+
+    const manager = new FleetCheckpointManager(tempDir, 'my-project', mockLogger);
+    const state = await manager.load();
+
+    expect(state.tokenUsage.byWorkItem).toEqual({ '42': 50, '99': 50 });
+    expect((state.tokenUsage as Record<string, unknown>).byIssue).toBeUndefined();
+
+    // recordTokenUsage should work without crashing
+    await manager.recordTokenUsage('42', 10);
+    expect(state.tokenUsage.byWorkItem['42']).toBe(60);
+  });
+
+  it('should initialize byWorkItem when tokenUsage has neither byWorkItem nor byIssue', async () => {
+    const legacyState = {
+      projectName: 'my-project',
+      version: 1,
+      issues: {},
+      tokenUsage: { total: 0 },
+      startedAt: '2026-01-01T00:00:00.000Z',
+      lastCheckpoint: '2026-01-01T00:00:00.000Z',
+      resumeCount: 0,
+    };
+    await writeFile(join(tempDir, 'fleet-checkpoint.json'), JSON.stringify(legacyState));
+
+    const manager = new FleetCheckpointManager(tempDir, 'my-project', mockLogger);
+    const state = await manager.load();
+
+    expect(state.tokenUsage.byWorkItem).toEqual({});
+    await manager.recordTokenUsage('192', 100);
+    expect(state.tokenUsage.byWorkItem['192']).toBe(100);
+  });
+
+  it('should initialize tokenUsage when missing from legacy checkpoint', async () => {
+    const legacyState = {
+      projectName: 'my-project',
+      version: 1,
+      issues: {},
+      startedAt: '2026-01-01T00:00:00.000Z',
+      lastCheckpoint: '2026-01-01T00:00:00.000Z',
+      resumeCount: 0,
+    };
+    await writeFile(join(tempDir, 'fleet-checkpoint.json'), JSON.stringify(legacyState));
+
+    const manager = new FleetCheckpointManager(tempDir, 'my-project', mockLogger);
+    const state = await manager.load();
+
+    expect(state.tokenUsage).toEqual({ total: 0, byWorkItem: {} });
+  });
 });

--- a/packages/framework/src/engine/checkpoint/checkpoint.ts
+++ b/packages/framework/src/engine/checkpoint/checkpoint.ts
@@ -480,6 +480,7 @@ export class FleetCheckpointManager {
     if (await this.store.exists(this.checkpointPath)) {
       try {
         this.state = await this.store.readJSON<FleetCheckpointState>(this.checkpointPath);
+        this.migrateState();
         this.state.resumeCount += 1;
         this.logger.info('Loaded fleet checkpoint', {
           data: {
@@ -506,6 +507,7 @@ export class FleetCheckpointManager {
             `Migrating legacy fleet checkpoint from ${legacyPath} to ${this.checkpointPath}`,
           );
           this.state = legacy;
+          this.migrateState();
           this.state.resumeCount += 1;
           await this.save();
           return this.state;
@@ -531,6 +533,30 @@ export class FleetCheckpointManager {
   getState(): FleetCheckpointState {
     if (!this.state) throw new Error('Fleet checkpoint not loaded');
     return this.state;
+  }
+
+  /**
+   * Migrate legacy checkpoint state fields to the current schema.
+   * - Renames `byIssue` → `byWorkItem` in tokenUsage.
+   * - Ensures `tokenUsage` and `tokenUsage.byWorkItem` exist.
+   */
+  private migrateState(): void {
+    if (!this.state) return;
+    if (!this.state.tokenUsage) {
+      this.state.tokenUsage = { total: 0, byWorkItem: {} };
+    } else {
+      const tu = this.state.tokenUsage as Record<string, unknown>;
+      if (!this.state.tokenUsage.byWorkItem && tu.byIssue) {
+        this.state.tokenUsage.byWorkItem = tu.byIssue as Record<string, number>;
+        delete tu.byIssue;
+      }
+      if (!this.state.tokenUsage.byWorkItem) {
+        this.state.tokenUsage.byWorkItem = {};
+      }
+    }
+    if (!this.state.issues) {
+      this.state.issues = {};
+    }
   }
 
   async setWorkItemStatus(

--- a/src/core/fleet/fleet-orchestrator.ts
+++ b/src/core/fleet/fleet-orchestrator.ts
@@ -995,6 +995,7 @@ export class FleetOrchestrator {
           '',
           '',
           0,
+          issue.title,
           error,
         );
         return {


### PR DESCRIPTION
## Problem

`FleetCheckpointManager.load()` crashed with:
```
TypeError: Cannot read properties of undefined (reading '192')
```
when loading a fleet checkpoint written by an older cadre version that stored token usage under `tokenUsage.byIssue` instead of the current `tokenUsage.byWorkItem` field. The first call to `recordTokenUsage()` after load then accessed `undefined['192']`.

This was observed during a Lore run where issue #192 failed during the PR composition phase (rebase conflict), and the subsequent error-handling path tried to record token usage against the stale checkpoint state.

## Root Cause

The fleet checkpoint schema was renamed from `byIssue` to `byWorkItem` at some point, but no migration was added to `load()`. Legacy checkpoint files on disk still had the old field name.

## Fix

1. **Add `migrateState()`** to `FleetCheckpointMan1. **Add `migrateState()`** to `FleetCheckpointMan1. **Add `migrateState()`** to `FleetCheckpointMan1. **Add `migrateState()`** to `Fleet`,1. **Add `migrateState()`** to `FleetChecf mi1. **


. **Add `migrateState()`** to `FleetCheckpointMan1. **AdgEr. **A c. **Add `migrateState()`** to `FleetCheckpointMan1. **AdgEr. **A c. **Add `migrateState()`** to `FleetCheckpointMan1. **AdgEr. **A c. **Add `migrateState()`** to `FleetCheckpointMan1. **AdgEr. **A c. **Add `migrateState()`** to `FleetCheckpointMan1.ed 3 new tests for checkpoint migration scenarios:
  - Legacy `byIssue` → `byWorkItem` rename
  - Missing `byWorkItem` (neither old nor new field present)
  - Missing `tokenUsage` entirely