### PR TITLE
chore: release framework v0.2.0

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cadre-dev/framework",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Consolidated framework for CADRE agent orchestration",
   "license": "MIT",
   "author": "Jacob Freck",


### PR DESCRIPTION
Bump `@cadre-dev/framework` from 0.1.0 to 0.2.0 for npm publish.

The previous `framework-v0.2.0` tag pointed to a commit where the version was still 0.1.0 (reverted by a concurrent squash merge). This fixes the version so the publish workflow will produce the correct 0.2.0 tarball.