### PR TITLE
fix(ci): add --provenance to npm publish for OIDC auth

### DIFF
--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -30,9 +30,10 @@ jobs:
         run: npx vitest run --exclude 'tests/e2e-*.test.ts'
 
       # Trusted publishing: OIDC auth, no NPM_TOKEN needed.
+      # --provenance triggers OIDC-based auth and generates provenance attestations.
       # Configure at: npmjs.com → @cadre-dev/framework → Settings → Trusted Publisher
       #   Organization/user: jafreck
       #   Repository: CADRE
       #   Workflow filename: publish-framework.yml
       - name: Publish @cadre-dev/framework
-        run: npm publish --access public -w packages/framework
+        run: npm publish --access public --provenance -w packages/framework

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,9 +27,9 @@ jobs:
       - run: npm test
 
       # Trusted publishing: OIDC auth, no NPM_TOKEN needed.
-      # Provenance attestations are generated automatically.
+      # --provenance triggers OIDC-based auth and generates provenance attestations.
       # Configure at: npmjs.com → @cadre-dev/cadre → Settings → Trusted Publisher
       #   Organization/user: jafreck
       #   Repository: CADRE
       #   Workflow filename: publish.yml
-      - run: npm publish --access public
+      - run: npm publish --access public --provenance


### PR DESCRIPTION
Without `--provenance`, npm doesn't use the OIDC token for authentication, causing 404 errors on publish.

Adds `--provenance` to both `publish.yml` and `publish-framework.yml`.