### PR TITLE
fix(ci): add environment: npm for trusted publishing

### DIFF
--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -10,6 +10,7 @@ jobs:
   publish-framework:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: npm
     permissions:
       contents: read
       id-token: write # Required for OIDC trusted publishing

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: npm
     # Skip framework-only releases — those are handled by publish-framework.yml
     if: ${{ !startsWith(github.event.release.tag_name, 'framework-v') }}
     permissions:


### PR DESCRIPTION
npm trusted publishing requires the OIDC token to include the environment claim. Since the trusted publisher config on npmjs.com specifies environment `npm`, the workflow jobs need `environment: npm` to match.