### PR TITLE
fix(ci): use Node 24 for npm trusted publishing

### DIFF
--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
@@ -31,10 +31,11 @@ jobs:
         run: npx vitest run --exclude 'tests/e2e-*.test.ts'
 
       # Trusted publishing: OIDC auth, no NPM_TOKEN needed.
-      # --provenance triggers OIDC-based auth and generates provenance attestations.
+      # Requires npm 11.5.1+ (ships with Node 24).
+      # Provenance attestations are generated automatically.
       # Configure at: npmjs.com → @cadre-dev/framework → Settings → Trusted Publisher
       #   Organization/user: jafreck
       #   Repository: CADRE
       #   Workflow filename: publish-framework.yml
       - name: Publish @cadre-dev/framework
-        run: npm publish --access public --provenance -w packages/framework
+        run: npm publish --access public -w packages/framework

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
@@ -28,9 +28,10 @@ jobs:
       - run: npm test
 
       # Trusted publishing: OIDC auth, no NPM_TOKEN needed.
-      # --provenance triggers OIDC-based auth and generates provenance attestations.
+      # Requires npm 11.5.1+ (ships with Node 24).
+      # Provenance attestations are generated automatically.
       # Configure at: npmjs.com → @cadre-dev/cadre → Settings → Trusted Publisher
       #   Organization/user: jafreck
       #   Repository: CADRE
       #   Workflow filename: publish.yml
-      - run: npm publish --access public --provenance
+      - run: npm publish --access public


### PR DESCRIPTION
npm trusted publishing requires npm CLI 11.5.1+ (ships with Node 24+). Node 22 ships with an older npm that doesn't support OIDC token exchange for publish auth.

Changes:
- Update `node-version` from 22 to 24 in both publish workflows
- Remove `--provenance` flag (provenance is auto-generated with trusted publishing)
- Update comments

Per https://docs.npmjs.com/trusted-publishers