### PR TITLE
fix(ci): remove registry-url to unblock OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22.22.1"
-          registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22.22.1"
-          registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
The `registry-url` input on `actions/setup-node` writes `_authToken=${NODE_AUTH_TOKEN}` to `.npmrc`. Since no `NODE_AUTH_TOKEN` secret is set, this results in an invalid auth token that takes precedence over the OIDC token exchange, causing 404 errors on publish.

Removing `registry-url` lets npm fall back to its native OIDC flow for trusted publishing.