### PR TITLE
fix(ci): fix trusted publishing

### DIFF
--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -19,10 +19,14 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.22.1"
+          node-version: "22"
+          cache: "npm"
           registry-url: "https://registry.npmjs.org"
 
-      - run: npm ci
+      - name: Install latest npm
+        run: npm install -g npm@latest
+
+      - run: npm install --legacy-peer-deps
 
       - name: Build framework
         run: npm run build -w packages/framework
@@ -30,16 +34,10 @@ jobs:
       - name: Run framework tests
         run: npx vitest run --exclude 'tests/e2e-*.test.ts'
 
-      # Remove the _authToken line that actions/setup-node adds to .npmrc
-      # so npm falls back to OIDC for trusted publishing.
-      - run: sed -i '/_authToken/d' ~/.npmrc
-
-      # Trusted publishing: OIDC auth, no NPM_TOKEN needed.
-      # Requires npm 11.5.1+ (ships with Node 22.14.0+).
-      # Provenance attestations are generated automatically.
+      # Trusted publishing: OIDC auth via --provenance, no NPM_TOKEN needed.
       # Configure at: npmjs.com → @cadre-dev/framework → Settings → Trusted Publisher
       #   Organization/user: jafreck
       #   Repository: CADRE
       #   Workflow filename: publish-framework.yml
       - name: Publish @cadre-dev/framework
-        run: npm publish --access public -w packages/framework
+        run: npm publish --provenance --access public -w packages/framework

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,22 +20,20 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.22.1"
+          node-version: "22"
+          cache: "npm"
           registry-url: "https://registry.npmjs.org"
 
-      - run: npm ci
+      - name: Install latest npm
+        run: npm install -g npm@latest
+
+      - run: npm install --legacy-peer-deps
       - run: npm run build
       - run: npm test
 
-      # Remove the _authToken line that actions/setup-node adds to .npmrc
-      # so npm falls back to OIDC for trusted publishing.
-      - run: sed -i '/_authToken/d' ~/.npmrc
-
-      # Trusted publishing: OIDC auth, no NPM_TOKEN needed.
-      # Requires npm 11.5.1+ (ships with Node 22.14.0+).
-      # Provenance attestations are generated automatically.
+      # Trusted publishing: OIDC auth via --provenance, no NPM_TOKEN needed.
       # Configure at: npmjs.com → @cadre-dev/cadre → Settings → Trusted Publisher
       #   Organization/user: jafreck
       #   Repository: CADRE
       #   Workflow filename: publish.yml
-      - run: npm publish --access public
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
Aligns cadre publish workflows with the working Lore pattern:

- `node-version: 22` with `registry-url` and `cache: npm`
- `npm install -g npm@latest` to ensure latest npm with trusted publishing support
- `npm install --legacy-peer-deps` instead of `npm ci` (avoids lock file strictness issues)
- `npm publish --provenance --access public` (`--provenance` triggers OIDC auth)

Reference: https://github.com/jafreck/Lore/blob/main/.github/workflows/publish.yml