### PR TITLE
feat(framework): add first-class mcpServers field to AgentInvocation

### DIFF
--- a/packages/framework/src/runtime/backend/backend.ts
+++ b/packages/framework/src/runtime/backend/backend.ts
@@ -269,6 +269,12 @@ export class CopilotBackend implements AgentBackend {
     if (this.defaultModel) {
       args.push('--model', this.defaultModel);
     }
+    // Forward MCP server configs to agent subprocess
+    if (invocation.mcpServers) {
+      for (const [name, cfg] of Object.entries(invocation.mcpServers)) {
+        args.push('--additional-mcp-config', JSON.stringify({ [name]: { url: cfg.url } }));
+      }
+    }
     const timeout = invocation.timeout ?? this.defaultTimeout;
     return runInvokePipeline(
       this.cliCommand,
@@ -327,6 +333,12 @@ export class ClaudeBackend implements AgentBackend {
     ];
     if (this.defaultModel) {
       args.push('--model', this.defaultModel);
+    }
+    // Forward MCP server configs to agent subprocess
+    if (invocation.mcpServers) {
+      for (const [name, cfg] of Object.entries(invocation.mcpServers)) {
+        args.push('--mcp-config', JSON.stringify({ [name]: { type: 'url', url: cfg.url } }));
+      }
     }
     const timeout = invocation.timeout ?? this.defaultTimeout;
     return runInvokePipeline(

--- a/packages/framework/src/runtime/context/types.ts
+++ b/packages/framework/src/runtime/context/types.ts
@@ -23,8 +23,8 @@ export interface AgentInvocation {
   timeout?: number;
   /** Override the model for this invocation (for per-invocation routing, A/B testing, or fallback). */
   modelOverride?: string;
-  /** Consumer-specific metadata. Avoids perpetual type widening for domain-specific fields. */
-  extensions?: Record<string, unknown>;
+  /** MCP servers to forward to the agent CLI subprocess. Key = server name, value = server config. */
+  mcpServers?: Record<string, { url: string }>;
 }
 
 /** Detailed token usage split by input/output tokens and model. */
@@ -60,8 +60,6 @@ export interface AgentResult {
   outputExists: boolean;
   /** Error message if the agent failed. */
   error?: string;
-  /** Consumer-specific result metadata. Avoids perpetual type widening for domain-specific fields. */
-  extensions?: Record<string, unknown>;
 }
 
 /** A discrete unit of work within an agent session. */

--- a/packages/framework/src/runtime/launch-with-events.ts
+++ b/packages/framework/src/runtime/launch-with-events.ts
@@ -59,8 +59,6 @@ export interface InvocationMetric {
   maxAttempts?: number;
   /** Whether this invocation was a retry of a previously failed attempt. */
   wasRetry?: boolean;
-  /** Consumer-specific metric metadata. */
-  extensions?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Replace the untyped `extensions` bag with a typed `mcpServers` field on `AgentInvocation`. Both `CopilotBackend` and `ClaudeBackend` now iterate `mcpServers` and emit the appropriate CLI flags (`--additional-mcp-config` / `--mcp-config`).

## Changes

### `packages/framework/src/runtime/context/types.ts`
- **`AgentInvocation`**: replaced `extensions?: Record<string, unknown>` with `mcpServers?: Record<string, { url: string }>` — typed, explicit, self-documenting
- **`AgentResult`**: removed unused `extensions` field
  
### `packages/framework/src/runtime/launch-with-events.ts`
- **`InvocationMetric`**: removed unused `extensions` field

### `packages/framework/src/runtime/backend/backend.ts`
- **`CopilotBackend.invoke()`**: iterates `invocation.mcpServers` and pushes `--additional-mcp-config` per server
- **`ClaudeBackend.invoke()`**: iterates `invocation.mcpServers` and pushes `--mcp-config` per server (with `type: 'url'` wrapper)

## Motivation

The `extensions` field was a speculative untyped escape hatch (`Record<string, unknown>`) that was never set or read by any code — not by cadre itself, not by any consumer. Making MCP server forwarding a first-class typed field:
- Provides autocomplete and compile-time checking for consumers
- Eliminates blind `as` casts in the backends
- Keeps the framework free of consumer-specific concepts (no AAMF references)