### PR TITLE
feat: make permission flags explicit opt-in for framework backends

### DIFF
--- a/packages/framework/src/runtime/backend/backend.ts
+++ b/packages/framework/src/runtime/backend/backend.ts
@@ -16,10 +16,13 @@ export type { AgentBackend, BackendLoggerLike, BackendRuntimeConfig } from './co
 interface CopilotBackendOptions {
   cliCommand?: string;
   agentDir?: string;
+  allowAllTools?: boolean;
+  allowAllPaths?: boolean;
 }
 
 interface ClaudeBackendOptions {
   cliCommand?: string;
+  allowedTools?: string;
 }
 
 async function fsExists(path: string): Promise<boolean> {
@@ -240,6 +243,8 @@ export class CopilotBackend implements AgentBackend {
   private readonly agentDir: string;
   private readonly defaultTimeout: number;
   private readonly defaultModel: string | undefined;
+  private readonly allowAllTools: boolean;
+  private readonly allowAllPaths: boolean;
 
   constructor(
     private readonly config: BackendRuntimeConfig,
@@ -250,6 +255,8 @@ export class CopilotBackend implements AgentBackend {
     this.agentDir = options?.agentDir?.trim() || '.github/agents';
     this.defaultTimeout = config.agent.timeout ?? 120_000;
     this.defaultModel = config.agent.model;
+    this.allowAllTools = options?.allowAllTools ?? false;
+    this.allowAllPaths = options?.allowAllPaths ?? false;
   }
 
   async init(): Promise<void> {
@@ -261,11 +268,11 @@ export class CopilotBackend implements AgentBackend {
     const args = [
       '--agent', invocation.agent,
       '-p', prompt,
-      '--allow-all-tools',
-      '--allow-all-paths',
       '--no-ask-user',
       '-s',
     ];
+    if (this.allowAllTools) args.push('--allow-all-tools');
+    if (this.allowAllPaths) args.push('--allow-all-paths');
     if (this.defaultModel) {
       args.push('--model', this.defaultModel);
     }
@@ -309,6 +316,7 @@ export class ClaudeBackend implements AgentBackend {
   private readonly cliCommand: string;
   private readonly defaultTimeout: number;
   private readonly defaultModel: string | undefined;
+  private readonly allowedTools: string | undefined;
 
   constructor(
     private readonly config: BackendRuntimeConfig,
@@ -318,6 +326,7 @@ export class ClaudeBackend implements AgentBackend {
     this.cliCommand = options?.cliCommand?.trim() || 'claude';
     this.defaultTimeout = config.agent.timeout ?? 120_000;
     this.defaultModel = config.agent.model;
+    this.allowedTools = options?.allowedTools;
   }
 
   async init(): Promise<void> {
@@ -328,9 +337,11 @@ export class ClaudeBackend implements AgentBackend {
     const prompt = `Read your context file at: ${invocation.contextPath}`;
     const args = [
       '-p', prompt,
-      '--allowedTools', 'Bash,Read,Write,Edit,MultiEdit,Glob,Grep,TodoRead,TodoWrite,mcp__*',
-      '--output-format', 'json',
     ];
+    if (this.allowedTools) {
+      args.push('--allowedTools', this.allowedTools);
+    }
+    args.push('--output-format', 'json');
     if (this.defaultModel) {
       args.push('--model', this.defaultModel);
     }

--- a/packages/framework/src/runtime/backend/contract.ts
+++ b/packages/framework/src/runtime/backend/contract.ts
@@ -16,10 +16,16 @@ export interface BackendAgentConfig {
     cliCommand?: string;
     agentDir?: string;
     costOverrides?: Record<string, unknown>;
+    /** Pass --allow-all-tools to the Copilot CLI. Must be explicitly enabled. */
+    allowAllTools?: boolean;
+    /** Pass --allow-all-paths to the Copilot CLI. Must be explicitly enabled. */
+    allowAllPaths?: boolean;
   };
   claude?: BackendOptions & {
     cliCommand?: string;
     agentDir?: string;
+    /** Comma-separated tool names for --allowedTools. When omitted, --allowedTools is not passed. */
+    allowedTools?: string;
   };
 }
 

--- a/src/cli/status-renderer.ts
+++ b/src/cli/status-renderer.ts
@@ -42,7 +42,7 @@ export function renderFleetStatus(
   copilotConfig?: NonNullable<CadreConfig['agent']>['copilot'],
 ): string {
   const estimator = new CostEstimator(
-    copilotConfig ?? { cliCommand: 'copilot', agentDir: '.github/agents' },
+    copilotConfig ? { costOverrides: copilotConfig.costOverrides } : {},
   );
 
   const totalTokens = state.tokenUsage.total;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -67,6 +67,8 @@ export const AgentConfigSchema = z.object({
     .object({
       cliCommand: z.string().default('copilot'),
       agentDir: z.string().default('agents'),
+      allowAllTools: z.boolean().default(true),
+      allowAllPaths: z.boolean().default(true),
       costOverrides: z
         .record(
           z.string(),
@@ -84,6 +86,7 @@ export const AgentConfigSchema = z.object({
       cliCommand: z.string().default('claude'),
       /** Directory where Claude subagent files live. */
       agentDir: z.string().default('agents'),
+      allowedTools: z.string().default('Bash,Read,Write,Edit,MultiEdit,Glob,Grep,TodoRead,TodoWrite,mcp__*'),
     })
     .default({}),
 });

--- a/tests/agent-backend.test.ts
+++ b/tests/agent-backend.test.ts
@@ -103,7 +103,7 @@ describe('CopilotBackend', () => {
     );
   });
 
-  it('should include --agent, -p, --allow-all-tools, --allow-all-paths, --no-ask-user, -s args', async () => {
+  it('should include --agent and -p args', async () => {
     const backend = new CopilotBackend(config, logger as never);
     setupSpawn(makeProcessResult());
     const invocation = makeInvocation({ agent: 'test-writer' });
@@ -113,8 +113,38 @@ describe('CopilotBackend', () => {
     expect(args).toContain('--agent');
     expect(args).toContain('test-writer');
     expect(args).toContain('-p');
+  });
+
+  it('should always include --no-ask-user and -s for headless execution', async () => {
+    const backend = new CopilotBackend(config, logger as never);
+    setupSpawn(makeProcessResult());
+    await backend.invoke(makeInvocation(), '/tmp/worktree');
+
+    const [, args] = mockSpawnProcess.mock.calls[0];
+    expect(args).toContain('--no-ask-user');
+    expect(args).toContain('-s');
+  });
+
+  it('should include --allow-all-tools and --allow-all-paths when enabled in config', async () => {
+    const backend = new CopilotBackend(config, logger as never);
+    setupSpawn(makeProcessResult());
+    await backend.invoke(makeInvocation(), '/tmp/worktree');
+
+    const [, args] = mockSpawnProcess.mock.calls[0];
     expect(args).toContain('--allow-all-tools');
     expect(args).toContain('--allow-all-paths');
+  });
+
+  it('should not include --allow-all-tools or --allow-all-paths when disabled in config', async () => {
+    const restrictedConfig = makeConfig({ allowAllTools: false, allowAllPaths: false });
+    const backend = new CopilotBackend(restrictedConfig, logger as never);
+    setupSpawn(makeProcessResult());
+    await backend.invoke(makeInvocation(), '/tmp/worktree');
+
+    const [, args] = mockSpawnProcess.mock.calls[0];
+    expect(args).not.toContain('--allow-all-tools');
+    expect(args).not.toContain('--allow-all-paths');
+    // headless flags are still present
     expect(args).toContain('--no-ask-user');
     expect(args).toContain('-s');
   });
@@ -368,7 +398,7 @@ describe('ClaudeBackend', () => {
     );
   });
 
-  it('should include -p, --allowedTools, and --output-format json args', async () => {
+  it('should include -p, --allowedTools, and --output-format json args when allowedTools is configured', async () => {
     const backend = new ClaudeBackend(config, logger as never);
     setupSpawn(makeProcessResult());
     await backend.invoke(makeInvocation(), '/tmp/worktree');
@@ -376,6 +406,21 @@ describe('ClaudeBackend', () => {
     const [, args] = mockSpawnProcess.mock.calls[0];
     expect(args).toContain('-p');
     expect(args).toContain('--allowedTools');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('json');
+  });
+
+  it('should not include --allowedTools when allowedTools is not configured', async () => {
+    const noToolsConfig = makeConfig({ allowedTools: undefined as unknown as string });
+    // Remove the allowedTools key entirely
+    delete (noToolsConfig as Record<string, unknown>).agent?.['claude']?.['allowedTools'];
+    (noToolsConfig.agent.claude as Record<string, unknown>).allowedTools = undefined;
+    const backend = new ClaudeBackend(noToolsConfig, logger as never);
+    setupSpawn(makeProcessResult());
+    await backend.invoke(makeInvocation(), '/tmp/worktree');
+
+    const [, args] = mockSpawnProcess.mock.calls[0];
+    expect(args).not.toContain('--allowedTools');
     expect(args).toContain('--output-format');
     expect(args).toContain('json');
   });

--- a/tests/agent-backends.test.ts
+++ b/tests/agent-backends.test.ts
@@ -103,7 +103,7 @@ describe('CopilotBackend', () => {
     );
   });
 
-  it('should include --agent, -p, --allow-all-tools, --allow-all-paths, --no-ask-user, -s args', async () => {
+  it('should include --agent and -p args', async () => {
     const backend = new CopilotBackend(config, logger as never);
     setupSpawn(makeProcessResult());
     const invocation = makeInvocation({ agent: 'test-writer' });
@@ -113,8 +113,38 @@ describe('CopilotBackend', () => {
     expect(args).toContain('--agent');
     expect(args).toContain('test-writer');
     expect(args).toContain('-p');
+  });
+
+  it('should always include --no-ask-user and -s for headless execution', async () => {
+    const backend = new CopilotBackend(config, logger as never);
+    setupSpawn(makeProcessResult());
+    await backend.invoke(makeInvocation(), '/tmp/worktree');
+
+    const [, args] = mockSpawnProcess.mock.calls[0];
+    expect(args).toContain('--no-ask-user');
+    expect(args).toContain('-s');
+  });
+
+  it('should include --allow-all-tools and --allow-all-paths when enabled in config', async () => {
+    const backend = new CopilotBackend(config, logger as never);
+    setupSpawn(makeProcessResult());
+    await backend.invoke(makeInvocation(), '/tmp/worktree');
+
+    const [, args] = mockSpawnProcess.mock.calls[0];
     expect(args).toContain('--allow-all-tools');
     expect(args).toContain('--allow-all-paths');
+  });
+
+  it('should not include --allow-all-tools or --allow-all-paths when disabled in config', async () => {
+    const restrictedConfig = makeConfig({ allowAllTools: false, allowAllPaths: false });
+    const backend = new CopilotBackend(restrictedConfig, logger as never);
+    setupSpawn(makeProcessResult());
+    await backend.invoke(makeInvocation(), '/tmp/worktree');
+
+    const [, args] = mockSpawnProcess.mock.calls[0];
+    expect(args).not.toContain('--allow-all-tools');
+    expect(args).not.toContain('--allow-all-paths');
+    // headless flags are still present
     expect(args).toContain('--no-ask-user');
     expect(args).toContain('-s');
   });
@@ -347,7 +377,7 @@ describe('ClaudeBackend', () => {
     );
   });
 
-  it('should include -p, --allowedTools, and --output-format json args', async () => {
+  it('should include -p, --allowedTools, and --output-format json args when allowedTools is configured', async () => {
     const backend = new ClaudeBackend(config, logger as never);
     setupSpawn(makeProcessResult());
     await backend.invoke(makeInvocation(), '/tmp/worktree');
@@ -355,6 +385,19 @@ describe('ClaudeBackend', () => {
     const [, args] = mockSpawnProcess.mock.calls[0];
     expect(args).toContain('-p');
     expect(args).toContain('--allowedTools');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('json');
+  });
+
+  it('should not include --allowedTools when allowedTools is not configured', async () => {
+    const noToolsConfig = makeConfig({ allowedTools: undefined as unknown as string });
+    (noToolsConfig.agent.claude as Record<string, unknown>).allowedTools = undefined;
+    const backend = new ClaudeBackend(noToolsConfig, logger as never);
+    setupSpawn(makeProcessResult());
+    await backend.invoke(makeInvocation(), '/tmp/worktree');
+
+    const [, args] = mockSpawnProcess.mock.calls[0];
+    expect(args).not.toContain('--allowedTools');
     expect(args).toContain('--output-format');
     expect(args).toContain('json');
   });

--- a/tests/helpers/backend-fixtures.ts
+++ b/tests/helpers/backend-fixtures.ts
@@ -23,6 +23,9 @@ export function makeConfig(overrides: Partial<{
   timeout: number;
   extraPath: string[];
   claudeCli: string;
+  allowAllTools: boolean;
+  allowAllPaths: boolean;
+  allowedTools: string;
 }> = {}) {
   return makeRuntimeConfig({
     copilot: {
@@ -38,10 +41,13 @@ export function makeConfig(overrides: Partial<{
       copilot: {
         cliCommand: overrides.cliCommand ?? 'copilot',
         agentDir: overrides.agentDir ?? '.github/agents',
+        allowAllTools: overrides.allowAllTools ?? true,
+        allowAllPaths: overrides.allowAllPaths ?? true,
       },
       claude: {
         cliCommand: overrides.claudeCli ?? 'claude',
         agentDir: overrides.agentDir ?? '.github/agents',
+        allowedTools: overrides.allowedTools ?? 'Bash,Read,Write,Edit,MultiEdit,Glob,Grep,TodoRead,TodoWrite,mcp__*',
       },
     },
     environment: {


### PR DESCRIPTION
## Summary

The framework no longer hardcodes dangerous permission flags. Consumers must explicitly enable them via config.

### What changed

**Framework**
- CopilotBackend: --allow-all-tools and --allow-all-paths are now only passed when allowAllTools / allowAllPaths are set to true in config (default: false)
- ClaudeBackend: --allowedTools is only passed when an allowedTools string is provided in config (default: omitted)
- Headless execution flags (--no-ask-user, -s) remain hardcoded as they are required for programmatic operation

**Cadre consumer**
- Config schema explicitly defaults allowAllTools and allowAllPaths to true, and provides the existing allowedTools string, preserving current behavior

### Why

The framework is a library consumed by multiple projects. Hardcoding broad permissions means any consumer gets full tool and path access by default. Permission escalation should be a conscious consumer decision, not a framework default.

### Files changed
- packages/framework/src/runtime/backend/contract.ts - Added config fields
- packages/framework/src/runtime/backend/backend.ts - Conditional flag passing
- src/config/schema.ts - Cadre defaults (preserves existing behavior)
- src/cli/status-renderer.ts - Fixed pre-existing type mismatch
- tests/ - Updated and expanded backend tests
