### PR TITLE
feat(docker-provider): add healthCheck, exec timeout, and E2E tests

### DIFF
--- a/packages/runtime-provider-docker/src/docker-provider.ts
+++ b/packages/runtime-provider-docker/src/docker-provider.ts
@@ -4,6 +4,7 @@ import type {
   IsolationCapabilities,
   IsolationPolicy,
   IsolationProvider,
+  IsolationProviderHealthCheckResult,
   IsolationSession,
 } from '@cadre-dev/framework/runtime';
 import { DockerSession, type DockerRunner } from './docker-session.js';
@@ -47,6 +48,19 @@ export class DockerProvider implements IsolationProvider {
       secrets: false,
       resources: true,
     };
+  }
+
+  async healthCheck(): Promise<IsolationProviderHealthCheckResult> {
+    const runner = this.opts.runner ?? createDefaultRunner();
+    try {
+      const result = await runner(['info', '--format', '{{.ServerVersion}}']);
+      if (result.exitCode === 0) {
+        return { healthy: true, message: 'Docker daemon reachable', details: { version: result.stdout.trim() } };
+      }
+      return { healthy: false, message: result.stderr || 'docker info returned non-zero exit code' };
+    } catch (err) {
+      return { healthy: false, message: err instanceof Error ? err.message : String(err) };
+    }
   }
 
   async createSession(policy: IsolationPolicy): Promise<IsolationSession> {

--- a/packages/runtime-provider-docker/src/docker-session.ts
+++ b/packages/runtime-provider-docker/src/docker-session.ts
@@ -27,6 +27,17 @@ export class DockerSession implements IsolationSession {
       }
     }
     execArgs.push(this.opts.containerId, command, ...args);
+
+    if (options?.timeoutMs != null) {
+      const runnerPromise = this.opts.runner(execArgs);
+      const timeoutPromise = new Promise<ExecResult>((resolve) => {
+        setTimeout(() => {
+          resolve({ exitCode: 124, stdout: '', stderr: 'Command timed out', timedOut: true });
+        }, options.timeoutMs!);
+      });
+      return Promise.race([runnerPromise, timeoutPromise]);
+    }
+
     return this.opts.runner(execArgs);
   }
 

--- a/packages/runtime-provider-docker/src/tests/docker-e2e.test.ts
+++ b/packages/runtime-provider-docker/src/tests/docker-e2e.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { execFile } from 'node:child_process';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { DockerProvider } from '../docker-provider.js';
+
+const SKIP = process.env.CADRE_E2E_DOCKER !== '1';
+
+// Use a minimal image for speed
+const IMAGE = 'alpine:3';
+
+function dockerExec(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    execFile('docker', args, (error, stdout, stderr) => {
+      resolve({ stdout, stderr, exitCode: error ? 1 : 0 });
+    });
+  });
+}
+
+(SKIP ? describe.skip : describe)('DockerProvider E2E (requires Docker)', () => {
+  const sessionIds: string[] = [];
+
+  afterAll(async () => {
+    // Force-remove any containers that might still be running
+    if (sessionIds.length > 0) {
+      await dockerExec(['rm', '--force', ...sessionIds]).catch(() => {});
+    }
+  });
+
+  it('healthCheck() against real Docker daemon', async () => {
+    const provider = new DockerProvider({ image: IMAGE });
+    const result = await provider.healthCheck();
+    expect(result.healthy).toBe(true);
+    expect(result.details?.version).toBeTruthy();
+    expect(typeof result.details?.version).toBe('string');
+  });
+
+  it('full lifecycle: create → exec → destroy', async () => {
+    const provider = new DockerProvider({ image: IMAGE });
+    const session = await provider.createSession({});
+    sessionIds.push(session.sessionId);
+
+    const result = await session.exec('echo', ['hello']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('hello');
+
+    await session.destroy();
+
+    // Verify the container is gone
+    const check = await dockerExec(['ps', '-a', '--filter', `id=${session.sessionId}`, '--format', '{{.ID}}']);
+    expect(check.stdout.trim()).toBe('');
+  });
+
+  it('network isolation mode none', async () => {
+    const provider = new DockerProvider({ image: IMAGE });
+    const session = await provider.createSession({ networkMode: 'none' });
+    sessionIds.push(session.sessionId);
+
+    const result = await session.exec('ping', ['-c', '1', '-W', '2', '8.8.8.8']);
+    expect(result.exitCode).not.toBe(0);
+
+    await session.destroy();
+  });
+
+  it('resource limits (memory)', async () => {
+    const provider = new DockerProvider({ image: IMAGE });
+    const session = await provider.createSession({ resources: { memoryMb: 32 } });
+    sessionIds.push(session.sessionId);
+
+    // Try cgroup v2 first, fall back to cgroup v1
+    let result = await session.exec('cat', ['/sys/fs/cgroup/memory.max']);
+    if (result.exitCode !== 0) {
+      result = await session.exec('cat', ['/sys/fs/cgroup/memory/memory.limit_in_bytes']);
+    }
+    expect(result.exitCode).toBe(0);
+    const memoryLimit = parseInt(result.stdout.trim(), 10);
+    expect(memoryLimit).toBe(32 * 1024 * 1024);
+
+    await session.destroy();
+  });
+
+  it('working directory via worktreePath mount', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'cadre-e2e-'));
+    const testContent = 'cadre-e2e-test-content';
+    const testFilename = 'test-file.txt';
+    await writeFile(join(tempDir, testFilename), testContent);
+
+    try {
+      const provider = new DockerProvider({ image: IMAGE, worktreePath: tempDir });
+      const session = await provider.createSession({});
+      sessionIds.push(session.sessionId);
+
+      const result = await session.exec('cat', [`/workspace/${testFilename}`]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe(testContent);
+
+      await session.destroy();
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+
+  it('env allowlist forwarding', async () => {
+    process.env.CADRE_E2E_TEST_VAR = 'hello_e2e';
+    try {
+      const provider = new DockerProvider({ image: IMAGE });
+      const session = await provider.createSession({ envAllowlist: ['CADRE_E2E_TEST_VAR'] });
+      sessionIds.push(session.sessionId);
+
+      const result = await session.exec('sh', ['-c', 'echo $CADRE_E2E_TEST_VAR']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('hello_e2e');
+
+      await session.destroy();
+    } finally {
+      delete process.env.CADRE_E2E_TEST_VAR;
+    }
+  });
+
+  it('exec with cwd option', async () => {
+    const provider = new DockerProvider({ image: IMAGE });
+    const session = await provider.createSession({});
+    sessionIds.push(session.sessionId);
+
+    const result = await session.exec('pwd', [], { cwd: '/tmp' });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('/tmp');
+
+    await session.destroy();
+  });
+
+  it('exec with env option', async () => {
+    const provider = new DockerProvider({ image: IMAGE });
+    const session = await provider.createSession({});
+    sessionIds.push(session.sessionId);
+
+    const result = await session.exec('sh', ['-c', 'echo $MY_VAR'], { env: { MY_VAR: 'injected' } });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('injected');
+
+    await session.destroy();
+  });
+
+  it('destroy is idempotent (real container)', async () => {
+    const provider = new DockerProvider({ image: IMAGE });
+    const session = await provider.createSession({});
+    sessionIds.push(session.sessionId);
+
+    await session.destroy();
+    await session.destroy(); // Should also succeed, no throw
+  });
+
+  it('exec after destroy throws', async () => {
+    const provider = new DockerProvider({ image: IMAGE });
+    const session = await provider.createSession({});
+    sessionIds.push(session.sessionId);
+
+    await session.destroy();
+    await expect(session.exec('echo', ['nope'])).rejects.toThrow(/destroyed/);
+  });
+});

--- a/packages/runtime-provider-docker/src/tests/docker-provider.test.ts
+++ b/packages/runtime-provider-docker/src/tests/docker-provider.test.ts
@@ -241,4 +241,52 @@ describe('DockerProvider', () => {
       expect(session.sessionId).toBe('container-xyz');
     });
   });
+
+  describe('healthCheck()', () => {
+    it('returns healthy result when runner succeeds', async () => {
+      const runner = vi.fn(async (_args: string[]) => ({
+        exitCode: 0,
+        stdout: '24.0.7\n',
+        stderr: '',
+      }));
+      const provider = new DockerProvider({ image: 'ubuntu:22.04', runner });
+      const result = await provider.healthCheck();
+      expect(result.healthy).toBe(true);
+      expect(result.message).toBe('Docker daemon reachable');
+      expect(result.details).toEqual({ version: '24.0.7' });
+    });
+
+    it('returns unhealthy result when runner returns non-zero exit code', async () => {
+      const runner = vi.fn(async (_args: string[]) => ({
+        exitCode: 1,
+        stdout: '',
+        stderr: 'Cannot connect to the Docker daemon',
+      }));
+      const provider = new DockerProvider({ image: 'ubuntu:22.04', runner });
+      const result = await provider.healthCheck();
+      expect(result.healthy).toBe(false);
+      expect(result.message).toBe('Cannot connect to the Docker daemon');
+    });
+
+    it('returns unhealthy result when runner throws', async () => {
+      const runner = vi.fn(async (_args: string[]) => {
+        throw new Error('ENOENT: docker not found');
+      });
+      const provider = new DockerProvider({ image: 'ubuntu:22.04', runner });
+      const result = await provider.healthCheck();
+      expect(result.healthy).toBe(false);
+      expect(result.message).toBe('ENOENT: docker not found');
+    });
+
+    it('uses the injected runner (not always the default)', async () => {
+      const runner = vi.fn(async (_args: string[]) => ({
+        exitCode: 0,
+        stdout: '25.0.0\n',
+        stderr: '',
+      }));
+      const provider = new DockerProvider({ image: 'ubuntu:22.04', runner });
+      await provider.healthCheck();
+      expect(runner).toHaveBeenCalledWith(['info', '--format', '{{.ServerVersion}}']);
+    });
+  });
 });

--- a/packages/runtime-provider-docker/src/tests/docker-session.test.ts
+++ b/packages/runtime-provider-docker/src/tests/docker-session.test.ts
@@ -7,6 +7,13 @@ function makeRunner(result: ExecResult = { exitCode: 0, stdout: 'ok', stderr: ''
   return vi.fn(async (_args: string[]) => result);
 }
 
+function makeDelayedRunner(delayMs: number, result: ExecResult = { exitCode: 0, stdout: 'ok', stderr: '' }): DockerRunner {
+  return vi.fn(async (_args: string[]) => {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return result;
+  });
+}
+
 const CONTAINER_ID = 'test-container-abc';
 
 describe('DockerSession', () => {
@@ -116,6 +123,35 @@ describe('DockerSession', () => {
       });
       const session = new DockerSession({ containerId: CONTAINER_ID, runner });
       await expect(session.destroy()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('exec() with timeoutMs', () => {
+    it('returns result with timedOut: false when command completes within timeout', async () => {
+      const runner = makeDelayedRunner(10, { exitCode: 0, stdout: 'done\n', stderr: '' });
+      const session = new DockerSession({ containerId: CONTAINER_ID, runner });
+      const result = await session.exec('echo', ['done'], { timeoutMs: 5000 });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('done\n');
+      expect(result.timedOut).toBeUndefined();
+    });
+
+    it('returns timedOut: true with exitCode 124 when command exceeds timeout', async () => {
+      const runner = makeDelayedRunner(5000, { exitCode: 0, stdout: 'done\n', stderr: '' });
+      const session = new DockerSession({ containerId: CONTAINER_ID, runner });
+      const result = await session.exec('sleep', ['10'], { timeoutMs: 50 });
+      expect(result.exitCode).toBe(124);
+      expect(result.timedOut).toBe(true);
+      expect(result.stderr).toBe('Command timed out');
+    });
+
+    it('works identically when timeoutMs is not specified (no regression)', async () => {
+      const runner = makeRunner({ exitCode: 0, stdout: 'hello\n', stderr: '' });
+      const session = new DockerSession({ containerId: CONTAINER_ID, runner });
+      const result = await session.exec('echo', ['hello']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('hello\n');
+      expect(result.timedOut).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Closes #413

## Summary

Completes the `@cadre-dev/runtime-provider-docker` package with missing features and a gated E2E test suite.

## Changes

### `DockerProvider.healthCheck()`
- Runs `docker info --format '{{.ServerVersion}}'` via the injected (or default) runner
- Returns `{ healthy: true, message, details: { version } }` on success
- Returns `{ healthy: false, message }` on failure — never throws

### `DockerSession.exec()` timeout support
- When `ExecOptions.timeoutMs` is provided, wraps the runner call with `Promise.race`
- On timeout: returns `{ exitCode: 124, stdout: '', stderr: 'Command timed out', timedOut: true }`
- No behavior change when `timeoutMs` is omitted

### Unit tests (7 new)
- 4 tests for `healthCheck()` (healthy, unhealthy exit code, unhealthy throw, uses injected runner)
- 3 tests for `timeoutMs` (within timeout, exceeds timeout, no regression)

### E2E test suite (`docker-e2e.test.ts`)
Gated behind `CADRE_E2E_DOCKER=1` — fully skipped otherwise.

10 tests covering:
- `healthCheck()` against real Docker daemon
- Full lifecycle (create → exec → destroy + container removal verification)
- Network isolation (`--network none`)
- Memory resource limits (cgroup verification)
- Worktree path mount at `/workspace`
- Env allowlist forwarding
- Exec with `cwd` and `env` options
- Destroy idempotency
- Exec-after-destroy error
- `afterAll` cleanup guard for leaked containers

## Validation

```
npx vitest run packages/runtime-provider-docker
# 48 passed | 10 skipped (E2E gated)
```

All 41 original tests continue to pass.